### PR TITLE
tools: add containerized build & test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,4 @@
 Dockerfile
+/scripts
+/dissector
+*.pcap

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+FROM debian:bookworm-20240211-slim AS base
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get -y update && \
+	apt-get -y dist-upgrade
+
+FROM base AS build-env
+RUN apt-get -y install \
+	build-essential \
+	gcc-multilib \
+	autoconf \
+	automake \
+	libtool \
+	libnl-3-dev \
+	libnl-route-3-dev \
+	libnuma-dev \
+	libudev-dev \
+	libxdp-dev \
+	clang \
+	uuid-dev \
+	pkg-config \
+	python-is-python3
+
+FROM build-env AS build-libfabric
+WORKDIR /src
+ADD https://github.com/ofiwg/libfabric/releases/download/v1.20.1/libfabric-1.20.1.tar.bz2 .
+RUN tar --no-same-owner -jxvf libfabric-1.20.1.tar.bz2 \
+	&& ln -s libfabric-1.20.1 libfabric
+WORKDIR /src/libfabric
+RUN autoreconf
+RUN ./configure
+RUN make -j $(nproc)
+# test
+RUN make -j $(nproc) check
+RUN util/fi_info
+# install
+RUN make install DESTDIR=/stage
+
+FROM build-libfabric AS build-uet
+WORKDIR /src/uet
+ADD . .
+RUN make
+RUN make xdp
+
+FROM base AS runtime
+RUN apt-get -y install \
+	libnuma1 \
+	libuuid1 \
+	libxdp1 \
+	libnl-3-200 \
+	libnl-route-3-200
+COPY --from=build-libfabric /stage /
+RUN ldconfig
+RUN fi_info
+COPY --from=build-uet /src/uet/uet /usr/bin/
+COPY --from=build-uet /src/uet/uet_xdp /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,12 +42,16 @@ RUN make
 RUN make xdp
 
 FROM base AS runtime
-RUN apt-get -y install \
+RUN apt-get -y install --no-install-recommends \
 	libnuma1 \
 	libuuid1 \
 	libxdp1 \
 	libnl-3-200 \
-	libnl-route-3-200
+	libnl-route-3-200 \
+	`# for lame tools exec()'d by ref code` \
+	iputils-ping `# ping` \
+	net-tools `# arp` \
+	iproute2 `# ip`
 COPY --from=build-libfabric /stage /
 RUN ldconfig
 RUN fi_info

--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ libfabric v1.20.1 and uses a symlink for the common name.
 % sudo LD_LIBRARY_PATH=../libfabric/src/.libs UET_IFNAME=ens4f0np0 ./uet client 192.168.1.1
 ```
 
+#### Containerized
+
+Run `scripts/build` to build `uet` et al into an OCI (docker) image.  Run
+`scripts/run [<flavor>]` to run said image in a container pair, writing
+out a .pcap of the packets into the current directory.  The `<flavor>` is
+passed to `uet` (and is used to name the .pcap file), and could be e.g.
+`tag`, `rma`, or none.
+
+The tools currently require [`buildah`](https://buildah.io/) to build and
+[`podman`](https://podman.io/) (and `tcpdump` on host) to run.
+
 ### xdp
 
 > The `uet_xdp` program has both `rawsock` and `xdp` build into it and the

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -ex
+cd "$(dirname "$0")/.."
+buildah bud --layers --tag "${UETREF_OCI_IMAGE:-uet-ref}" .

--- a/scripts/run
+++ b/scripts/run
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+: ${UETREF_OCI_IMAGE:=uet-ref}
+: ${UETREF_PREFIX:=uet}
+
+
+
+mode="$1"
+
+set -ex
+for idx in 1 2 ; do
+	podman stop --time 0 --ignore "${UETREF_PREFIX}${idx}"
+	podman rm --ignore "${UETREF_PREFIX}${idx}"
+	podman run \
+		"--name=${UETREF_PREFIX}${idx}" \
+		--rm \
+		-d \
+		--cap-add=NET_RAW \
+		--network=bridge \
+		-e UET_IFNAME=eth0 \
+		"$UETREF_OCI_IMAGE" \
+		sleep inf
+done
+
+
+get_ip() {
+	podman inspect --format='{{ .NetworkSettings.IPAddress }}' "${UETREF_PREFIX}${1}"
+}
+
+nsenter --target=$(podman inspect --format='{{ .State.Pid }}' "${UETREF_PREFIX}1") \
+	--user \
+	--net \
+	tcpdump -s0 -n -e -i eth0 -U -w "uet${mode:+-}${mode}".pcap &
+TCPDUMP_PID=$!
+# stopping the container also kills tcpdump (by removing the net_device)
+##trap "kill $TCPDUMP_PID" EXIT
+
+podman exec -d \
+	"${UETREF_PREFIX}1" \
+	uet server $mode $(get_ip 2)
+podman exec \
+	"${UETREF_PREFIX}2" \
+	uet client $mode $(get_ip 1)
+
+for idx in 1 2 ; do
+	podman stop --time 0 "${UETREF_PREFIX}${idx}"
+done


### PR DESCRIPTION
Had these kicking about for a while, maybe others find them useful.  The [README](README.md) includes a short description:


Run `scripts/build` to build `uet` et al into an OCI (docker) image.  Run
`scripts/run [<flavor>]` to run said image in a container pair, writing
out a .pcap of the packets into the current directory.  The `<flavor>` is
passed to `uet` (and is used to name the .pcap file), and could be e.g.
`tag`, `rma`, or none.

The tools currently require [`buildah`](https://buildah.io/) to build and
[`podman`](https://podman.io/) (and `tcpdump` on host) to run.
