### PR TITLE
UET-Libfabric Changes

### DIFF
--- a/uet_addr.h
+++ b/uet_addr.h
@@ -15,9 +15,6 @@
 #define UET_ADDR_DEF_INDEX		15
 #define UET_ADDR_DEF_INITIATOR_ID	16
 
-	/* addr format, should be added to enum in <rdma/fabric.h> */
-#define FI_ADDR_UET (FI_ADDR_EFA + 1)
-
 #define UET_ADDR_VERSION	0
 
 #define UET_ADDR_VER_MASK	0xf0

--- a/uet_api.c
+++ b/uet_api.c
@@ -3157,7 +3157,6 @@ int uet_getinfo(uet_handle_t handle, struct uet_addr *node,
 	}
 	uet_init_uet_addr_ipv4(src_addr, uet->nic.ipv4_addr);
 
-	new_info->addr_format = FI_ADDR_UET;
 	new_info->dest_addrlen = 0;
 	new_info->src_addrlen = sizeof(struct uet_addr);
 	new_info->src_addr = src_addr;

--- a/util/uet_util.h
+++ b/util/uet_util.h
@@ -17,7 +17,7 @@
 #define UET_MSEC_PER_SEC  1000
 #define UET_NSEC_PER_MSEC 1000000
 
-#if __BIG_ENDIAN__
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 # define htonll(x) (x)
 # define ntohll(x) (x)
 #else


### PR DESCRIPTION
Two small changes to make this repo play nicely w/ the uet-libfabric code: removing FI_ADDR_UET (it is now defined and set in the fi_info struct by the uet provider) and changed the endianess compiler macro to make it compatible across more compilers.