### PR TITLE
dissector: add request/response tracking and frame links

### DIFF
--- a/dissector/uet.lua
+++ b/dissector/uet.lua
@@ -8,6 +8,8 @@
 
 p_uet = Proto("uet", "UltraEthernet Transport")
 p_uet.prefs["ip_proto"] = Pref.uint("IP protocol#", 253, "IP protocol number for UET")
+p_uet.prefs["track"] = Pref.bool("Track requests and responses", true,
+	"Enable to track request/response/ACK packet relationships (at the expense of memory and/or CPU usage)")
 
 -- LIST
 local UET_EXPECTED = 0
@@ -357,7 +359,8 @@ function p_uet.dissector(buf, pinfo, root)
 		summary = type_str
 	end
 
-	if not pinfo.visited then
+	local do_track = p_uet.prefs.track and not pinfo.visited and not pinfo.in_error_pkt
+	if do_track then
 		pds_frame_info[pinfo.number] = {}
 	end
 
@@ -384,7 +387,8 @@ function p_uet.dissector(buf, pinfo, root)
 		offset = 16
 		subtree:set_len(offset)
 		-- TODO: cc_state
-		if not pinfo.visited and not pinfo.in_error_pkt then
+
+		if do_track then
 			local key = track_key(pinfo.net_src, b_spdcid, b_psn)
 			pds_req_map[key] = pinfo.number
 
@@ -411,7 +415,10 @@ function p_uet.dissector(buf, pinfo, root)
 		subtree:add(fld.psn, b_psn) -- TODO: ack_psn?
 		subtree:add(fld.spdcid, b_spdcid)
 		subtree:add(fld.dpdcid, b_dpdcid)
-		if not pinfo.visited and not pinfo.in_error_pkt then
+		offset = 12
+		subtree:set_len(offset)
+
+		if do_track then
 			local key = track_key(pinfo.net_dst, b_dpdcid, b_psn)
 			local req = pds_req_map[key]
 			if req ~= nil then
@@ -419,9 +426,6 @@ function p_uet.dissector(buf, pinfo, root)
 				pds_frame_info[req].ack_in = pinfo.number
 			end
 		end
-
-		offset = 12
-		subtree:set_len(offset)
 	end
 
 	local fi = pds_frame_info[pinfo.number]

--- a/dissector/uet.lua
+++ b/dissector/uet.lua
@@ -337,6 +337,11 @@ local dissect_data	= Dissector.get("data")
 local pds_req_map = {} -- <IP, PDCID, PSN> -> framenum
 local pds_frame_info = {} -- framenum -> table
 
+function track_key(net_addr, pdcid_tvb, psn_tvb)
+	-- TODO: anything more efficient than strings?
+	return tostring(net_addr) .. "--" .. tostring(pdcid_tvb:uint()) .. "--" .. tostring(psn_tvb:uint())
+end
+
 function p_uet.dissector(buf, pinfo, root)
 	pinfo.cols.protocol = p_uet.name
 
@@ -380,11 +385,11 @@ function p_uet.dissector(buf, pinfo, root)
 		subtree:set_len(offset)
 		-- TODO: cc_state
 		if not pinfo.visited and not pinfo.in_error_pkt then
-			local key = tostring(pinfo.net_src) .. "--" .. tostring(b_spdcid:uint()) .. "--" .. tostring(b_psn:uint())
+			local key = track_key(pinfo.net_src, b_spdcid, b_psn)
 			pds_req_map[key] = pinfo.number
 
 			-- TODO: only if "response"? how? what about Clear?
-			local fkey = tostring(pinfo.net_dst) .. "--" .. tostring(b_dpdcid:uint()) .. "--" .. tostring(b_fwd_psn:uint())
+			local fkey = track_key(pinfo.net_dst, b_dpdcid, b_fwd_psn)
 			local fw = pds_req_map[fkey]
 			if fw ~= nil then
 				pds_frame_info[pinfo.number].req_in = fw
@@ -407,7 +412,7 @@ function p_uet.dissector(buf, pinfo, root)
 		subtree:add(fld.spdcid, b_spdcid)
 		subtree:add(fld.dpdcid, b_dpdcid)
 		if not pinfo.visited and not pinfo.in_error_pkt then
-			local key = tostring(pinfo.net_dst) .. "--" .. tostring(b_dpdcid:uint()) .. "--" .. tostring(b_psn:uint())
+			local key = track_key(pinfo.net_dst, b_dpdcid, b_psn)
 			local req = pds_req_map[key]
 			if req ~= nil then
 				pds_frame_info[pinfo.number].req_in = req

--- a/dissector/uet.lua
+++ b/dissector/uet.lua
@@ -271,6 +271,9 @@ fld.psn		= ProtoField.uint32("uet.psn",		"Packet Sequence Number",		base.DEC)
 fld.spdcid	= ProtoField.uint16("uet.spdcid",	"Source PDC ID",			base.DEC)
 fld.dpdcid	= ProtoField.uint16("uet.dpdcid",	"Destination PDC ID",			base.DEC)
 fld.forward_psn	= ProtoField.uint32("uet.forward_psn",	"Forward Packet Sequence Number",	base.DEC)
+fld.req_in	= ProtoField.framenum("uet.request_in",	"Request in",				base.NONE, frametype.REQUEST)
+fld.ack_in	= ProtoField.framenum("uet.ack_in",	"ACK in",				base.NONE, frametype.ACK)
+fld.resp_in	= ProtoField.framenum("uet.response_in", "Response in",				base.NONE, frametype.RESPONSE)
 
 -- ROD/RUD request flags
 fld.flag_rreq_syn	= ProtoField.bool("uet.flags.rreq.syn",		"SYN",			16, yes_no, 0x40)
@@ -331,6 +334,9 @@ fld.ses_resp_payload_len	= ProtoField.uint32("uet.ses.resp.payload_len",		"Paylo
 
 local dissect_data	= Dissector.get("data")
 
+local pds_req_map = {} -- <IP, PDCID, PSN> -> framenum
+local pds_frame_info = {} -- framenum -> table
+
 function p_uet.dissector(buf, pinfo, root)
 	pinfo.cols.protocol = p_uet.name
 
@@ -344,6 +350,10 @@ function p_uet.dissector(buf, pinfo, root)
 	local offset = 4
 	if type_str ~= nil then
 		summary = type_str
+	end
+
+	if not pinfo.visited then
+		pds_frame_info[pinfo.number] = {}
 	end
 
 	if h_type == TYPE_RUD_REQ or h_type == TYPE_ROD_REQ then
@@ -365,6 +375,18 @@ function p_uet.dissector(buf, pinfo, root)
 		offset = 16
 		subtree:set_len(offset)
 		-- TODO: cc_state
+		if not pinfo.visited then
+			local key = tostring(pinfo.net_src) .. "--" .. tostring(buf(8, 2):uint()) .. "--" .. tostring(buf(4, 4):uint())
+			pds_req_map[key] = pinfo.number
+
+			-- TODO: only if "response"? how? what about Clear?
+			local fkey = tostring(pinfo.net_dst) .. "--" .. tostring(buf(10, 2):uint()) .. "--" .. tostring(buf(12, 4):uint())
+			local fw = pds_req_map[fkey]
+			if fw ~= nil then
+				pds_frame_info[pinfo.number].req_in = fw
+				pds_frame_info[fw].resp_in = pinfo.number
+			end
+		end
 	end if h_type == TYPE_PDS_ACK then
 		subtree:add(fld.next_hdr, buf(2, 2))
 		local flags_tree = subtree:add(fld.flags, buf(2, 2))
@@ -377,8 +399,30 @@ function p_uet.dissector(buf, pinfo, root)
 		subtree:add(fld.psn, buf(4, 4)) -- TODO: ack_psn?
 		subtree:add(fld.spdcid, buf(8, 2))
 		subtree:add(fld.dpdcid, buf(10, 2))
+		if not pinfo.visited then
+			local key = tostring(pinfo.net_dst) .. "--" .. tostring(buf(10, 2):uint()) .. "--" .. tostring(buf(4, 4):uint())
+			local req = pds_req_map[key]
+			if req ~= nil then
+				pds_frame_info[pinfo.number].req_in = req
+				pds_frame_info[req].ack_in = pinfo.number
+			end
+		end
+
 		offset = 12
 		subtree:set_len(offset)
+	end
+
+	local fi = pds_frame_info[pinfo.number]
+	if fi ~= nil then
+		if fi.req_in ~= nil then
+			subtree:add(fld.req_in, fi.req_in):set_generated()
+		end
+		if fi.ack_in ~= nil then
+			subtree:add(fld.ack_in, fi.ack_in):set_generated()
+		end
+		if fi.resp_in ~= nil then
+			subtree:add(fld.resp_in, fi.resp_in):set_generated()
+		end
 	end
 
 	-- TODO: TYPE_CTRL
@@ -475,4 +519,6 @@ function p_uet:init()
 	local udp_table = DissectorTable.get("udp.port")
 	ip_table:add(p_uet.prefs["ip_proto"], p_uet)
 	udp_table:add_for_decode_as(p_uet)
+	pds_req_map = {}
+	pds_frame_info = {}
 end

--- a/dissector/uet.lua
+++ b/dissector/uet.lua
@@ -366,21 +366,25 @@ function p_uet.dissector(buf, pinfo, root)
 		flags_tree:add(fld.flag_rreq_retx, buf(2, 2))
 		flags_tree:add(fld.flag_rreq_rsv, buf(2, 2))
 
-		subtree:add(fld.psn, buf(4, 4))
-		subtree:add(fld.spdcid, buf(8, 2))
+		local b_psn = buf(4, 4)
+		local b_spdcid = buf(8, 2)
+		local b_dpdcid = buf(10, 2)
+		local b_fwd_psn = buf(12, 4)
+		subtree:add(fld.psn, b_psn)
+		subtree:add(fld.spdcid, b_spdcid)
 		-- TODO: mode&offset for SYN
-		subtree:add(fld.dpdcid, buf(10, 2))
+		subtree:add(fld.dpdcid, b_dpdcid)
 		-- TODO: clear
-		subtree:add(fld.forward_psn, buf(12, 4))
+		subtree:add(fld.forward_psn, b_fwd_psn)
 		offset = 16
 		subtree:set_len(offset)
 		-- TODO: cc_state
 		if not pinfo.visited and not pinfo.in_error_pkt then
-			local key = tostring(pinfo.net_src) .. "--" .. tostring(buf(8, 2):uint()) .. "--" .. tostring(buf(4, 4):uint())
+			local key = tostring(pinfo.net_src) .. "--" .. tostring(b_spdcid:uint()) .. "--" .. tostring(b_psn:uint())
 			pds_req_map[key] = pinfo.number
 
 			-- TODO: only if "response"? how? what about Clear?
-			local fkey = tostring(pinfo.net_dst) .. "--" .. tostring(buf(10, 2):uint()) .. "--" .. tostring(buf(12, 4):uint())
+			local fkey = tostring(pinfo.net_dst) .. "--" .. tostring(b_dpdcid:uint()) .. "--" .. tostring(b_fwd_psn:uint())
 			local fw = pds_req_map[fkey]
 			if fw ~= nil then
 				pds_frame_info[pinfo.number].req_in = fw
@@ -396,11 +400,14 @@ function p_uet.dissector(buf, pinfo, root)
 		flags_tree:add(fld.flag_ack_probe, buf(2, 2))
 		flags_tree:add(fld.flag_ack_rsv, buf(2, 2))
 
-		subtree:add(fld.psn, buf(4, 4)) -- TODO: ack_psn?
-		subtree:add(fld.spdcid, buf(8, 2))
-		subtree:add(fld.dpdcid, buf(10, 2))
+		local b_psn = buf(4, 4)
+		local b_spdcid = buf(8, 2)
+		local b_dpdcid = buf(10, 2)
+		subtree:add(fld.psn, b_psn) -- TODO: ack_psn?
+		subtree:add(fld.spdcid, b_spdcid)
+		subtree:add(fld.dpdcid, b_dpdcid)
 		if not pinfo.visited and not pinfo.in_error_pkt then
-			local key = tostring(pinfo.net_dst) .. "--" .. tostring(buf(10, 2):uint()) .. "--" .. tostring(buf(4, 4):uint())
+			local key = tostring(pinfo.net_dst) .. "--" .. tostring(b_dpdcid:uint()) .. "--" .. tostring(b_psn:uint())
 			local req = pds_req_map[key]
 			if req ~= nil then
 				pds_frame_info[pinfo.number].req_in = req

--- a/dissector/uet.lua
+++ b/dissector/uet.lua
@@ -375,7 +375,7 @@ function p_uet.dissector(buf, pinfo, root)
 		offset = 16
 		subtree:set_len(offset)
 		-- TODO: cc_state
-		if not pinfo.visited then
+		if not pinfo.visited and not pinfo.in_error_pkt then
 			local key = tostring(pinfo.net_src) .. "--" .. tostring(buf(8, 2):uint()) .. "--" .. tostring(buf(4, 4):uint())
 			pds_req_map[key] = pinfo.number
 
@@ -399,7 +399,7 @@ function p_uet.dissector(buf, pinfo, root)
 		subtree:add(fld.psn, buf(4, 4)) -- TODO: ack_psn?
 		subtree:add(fld.spdcid, buf(8, 2))
 		subtree:add(fld.dpdcid, buf(10, 2))
-		if not pinfo.visited then
+		if not pinfo.visited and not pinfo.in_error_pkt then
 			local key = tostring(pinfo.net_dst) .. "--" .. tostring(buf(10, 2):uint()) .. "--" .. tostring(buf(4, 4):uint())
 			local req = pds_req_map[key]
 			if req ~= nil then


### PR DESCRIPTION
This PR adds tracking of requests vs. ACK packets based on PSNs, as well as "response" tracking based on forward-PSN. (the latter may need some work wrt Clear; feedback welcome).

Results are added to the tree as frame# links, and the UI also renders these as per-frame symbols in the leftmost column.

![image](https://github.com/ultraethernet/uet-ref-prov/assets/60935716/a06e7a83-08c1-4ab1-a9e7-cce6f0c8a583)
