### PR TITLE
pds: fix stack overflow of pkt_len

### DIFF
--- a/uet_pds.c
+++ b/uet_pds.c
@@ -310,7 +310,7 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
  */
 static int uet_pds_sec_rx_pkt(struct uet_instance *uet,
 			      uint8_t **pkt,
-			      int *pkt_len)
+			      size_t *pkt_len)
 {
 	int tag_len;
 	int rc;
@@ -335,7 +335,7 @@ static int uet_pds_sec_rx_pkt(struct uet_instance *uet,
 	rc = uet_nic_rx_pkt(UET_NIC(uet),
 			    *pkt,
 			    uet->nic.max_pkt_size,
-			    (size_t *)pkt_len);
+			    pkt_len);
 	if (rc != 1)
 		goto err_exit;
 
@@ -1906,7 +1906,7 @@ exit_err:
 int uet_pds_progress_rx(struct uet_instance *uet)
 {
 	uint8_t *pkt;
-	int pkt_len;
+	size_t pkt_len;
 	struct uet_parsed_pkt pp;
 	bool pkt_is_ack, pkt_is_rd_rsp;
 	struct uet_pdc_pkt *pdc_pkt = NULL;


### PR DESCRIPTION
int is 32-bit, size_t is 64-bit on 64-bit targets.  The rawsock NIC shim stores a size_t value.  A caller using an int worth of storage causes it to corrupt the neighboring variable.

Found with ASAN:

	+CFLAGS += -g -fsanitize=address
	+LDFLAGS += -g -fsanitize=address -static-libasan

	==24==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffe2a94d7b0 at pc 0x56076b9122ce bp 0x7ffe2a94d660 sp 0x7ffe2a94d658
	WRITE of size 8 at 0x7ffe2a94d7b0 thread T0
	    #0 0x56076b9122cd in nic_rawsock_rx_pkt nic_shim/nic_rawsock.c:243
	    #1 0x56076b8edbb1 in uet_nic_rx_pkt nic_shim/uet_nic.h:205
	    #2 0x56076b8ee3d4 in uet_pds_nic_rx_pkt /src/uet/uet_pds.c:236
	    #3 0x56076b9016eb in uet_pds_progress_rx /src/uet/uet_pds.c:1760
	    #4 0x56076b8eb856 in uet_cq_read /src/uet/uet_api.c:4243
	    #5 0x56076b8bf8dd in uet_compl_wait /src/uet/uet.c:567
	    #6 0x56076b8c3512 in uet_msg_server /src/uet/uet.c:1043
	    #7 0x56076b8c3ddf in uet_run /src/uet/uet.c:1135
	    #8 0x56076b8c4225 in main /src/uet/uet.c:1178
	    #9 0x7fd62fa46249 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
	    #10 0x7fd62fa46304 in __libc_start_main_impl ../csu/libc-start.c:360
	    #11 0x56076b7e0490 in _start (/usr/bin/uet+0x12490)

	Address 0x7ffe2a94d7b0 is located in stack of thread T0 at offset 80 in frame
	    #0 0x56076b9015fa in uet_pds_progress_rx /src/uet/uet_pds.c:1746

	  This frame has 5 object(s):
	    [48, 49) 'pkt_is_ack' (line 1750)
	    [64, 65) 'pkt_is_rd_rsp' (line 1750)
	    [80, 84) 'pkt_len' (line 1748) <== Memory access at offset 80 partially overflows this variable
	    [96, 104) 'pds_info' (line 1753)
	    [128, 280) 'pp' (line 1749)
	HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
	      (longjmp and C++ exceptions *are* supported)
	SUMMARY: AddressSanitizer: stack-buffer-overflow nic_shim/nic_rawsock.c:243 in nic_rawsock_rx_pkt
	Shadow bytes around the buggy address:
	  0x100045521aa0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
	  0x100045521ab0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
	  0x100045521ac0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
	  0x100045521ad0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
	  0x100045521ae0: 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1
	=>0x100045521af0: f1 f1 01 f2 01 f2[04]f2 00 f2 f2 f2 00 00 00 00
	  0x100045521b00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 f3
	  0x100045521b10: f3 f3 f3 f3 f3 f3 f3 f3 00 00 00 00 00 00 00 00
	  0x100045521b20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1
	  0x100045521b30: f1 f1 00 f3 f3 f3 00 00 00 00 00 00 00 00 00 00
	  0x100045521b40: f1 f1 f1 f1 00 00 00 00 00 00 00 00 00 00 00 f3
	Shadow byte legend (one shadow byte represents 8 application bytes):
	  Addressable:           00
	  Partially addressable: 01 02 03 04 05 06 07
	  Heap left redzone:       fa
	  Freed heap region:       fd
	  Stack left redzone:      f1
	  Stack mid redzone:       f2
	  Stack right redzone:     f3
	  Stack after return:      f5
	  Stack use after scope:   f8
	  Global redzone:          f9
	  Global init order:       f6
	  Poisoned by user:        f7
	  Container overflow:      fc
	  Array cookie:            ac
	  Intra object redzone:    bb
	  ASan internal:           fe
	  Left alloca redzone:     ca
	  Right alloca redzone:    cb
	==24==ABORTING

Fix it by making the caller pkt_len a size_t and removing the cast.