### PR TITLE
rma: set Read Request Message ID field in responses

### DIFF
--- a/uet_api.c
+++ b/uet_api.c
@@ -1788,6 +1788,7 @@ static uet_ses_rc_t uet_get_rd_tx_desc(
 	tx_desc->remote_msg_off = msg_off;
 	tx_desc->mr_desc = mr_desc;
 
+	tx_desc->rd_rsp.req_msg_id = pp->ses_msg_id;
 	tx_desc->rd_rsp.mod_len = req_len;
 	tx_desc->rd_rsp.pds_info = *pds_info;
 
@@ -2687,8 +2688,8 @@ static int uet_build_rd_rsp_ses_hdr(struct uet_tx_desc *tx_desc,
 	ses->cmn.msg_id = htons(tx_desc->msg_id);
 	ses->cmn.index_gen_job_id = htonl(tx_desc->job_id <<
 					  UET_SES_RSP_JOB_ID_SHIFT);
-	ses->rd_msg_id_payload_len = htonl(payload_len <<
-					   UET_SES_RSP_D_PAYLOAD_LEN_SHIFT);
+	ses->rd_msg_id = htons(tx_desc->rd_rsp.req_msg_id);
+	ses->payload_len = htons(payload_len << UET_SES_RSP_D_PAYLOAD_LEN_SHIFT);
 	ses->mod_len = htonl(tx_desc->rd_rsp.mod_len);
 	ses->msg_off = htonl(tx_desc->remote_msg_off);
 

--- a/uet_api_private.h
+++ b/uet_api_private.h
@@ -278,6 +278,7 @@ struct uet_ephemeral_av {
 struct uet_rd_rsp_info {
 	struct uet_pds_info pds_info;     /* pds info echoed in read response */
 	uint32_t mod_len;                          /* modified message length */
+	uint16_t req_msg_id;                    /* message ID of Read request */
 };
 
 /* tx msg descriptor states */


### PR DESCRIPTION
Commit de52b43a ("Update SES packet headers to align with v0.75 spec") introduced the new `rd_msg_id` header field and set it in the `build_response_w_data` branch of `uet_pds_to_ses_rx_req()`.

However, that doesn't seem to execute (at least in a `UET_PDS=pds uet rma` test).  Instead `uet_get_rd_tx_desc()` is called;  populate `rd_msg_id` there too.  We don't seem to have the request message ID handy, so add a field to `struct uet_rd_rsp_info` to store it.

Fixes #37