### PR TITLE
turn on full testsuite

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Start server client
         run: |
           arp -a
-          sudo LD_LIBRARY_PATH=../libfabric/src/.libs UET_IFNAME=brm ./uet server 10.1.0.2 &
+          sudo LD_LIBRARY_PATH=../libfabric/src/.libs UET_IFNAME=brm ./uet server test 10.1.0.2 &
           echo "Server started in background."
           sleep 2
-          sudo LD_LIBRARY_PATH=../libfabric/src/.libs UET_IFNAME=vm2 ./uet client 10.1.0.1
+          sudo LD_LIBRARY_PATH=../libfabric/src/.libs UET_IFNAME=vm2 ./uet client test 10.1.0.1
           echo "Client started."


### PR DESCRIPTION
We added 'test' argument to run full testsuite on push

Eric, we also noticed that GitHub actions doesn't get triggered on pull request from a fork. If it is possible with UltraEthernet credits, it could be enabled here:
`
Settings-> Actions-> General-> Fork pull request workflows-> Run workflows from fork pull requests`