### PR TITLE
fix: Add return statement at post_err_exit label to prevent test hangs

### DIFF
--- a/uet_api.c
+++ b/uet_api.c
@@ -2359,6 +2359,7 @@ static uet_ses_rc_t uet_rx_cancel_pkt(
 
 post_err_exit:
 	uet_rx_cq_post_err(rx_desc, FI_EIO);
+	return ses_rc;
 
 err_exit:
 	*gtd_del = true;


### PR DESCRIPTION
Hello

This is (another) one-line fix.
Without it the 'Unexpected Untagged Message Test' fails and cause client application to hang up.