### PR TITLE
fix: Hang on unexpected message receiption in PDS mode

### DIFF
--- a/uet.c
+++ b/uet.c
@@ -827,7 +827,7 @@ static uet_rc_t uet_msg_client_unexpected(struct uet_context *ctx)
 	uet_addr_handle_t addr_handle;
 	int prev_descr_count, attempt_count;
 	struct dlist_entry *active_list;
-	struct dlist_entry * dummy_item;
+	struct dlist_entry *dummy_item;
 	int descr_count;
 
 	if (ctx->cfg.tag) {
@@ -888,7 +888,7 @@ static uet_rc_t uet_msg_client_unexpected(struct uet_context *ctx)
 
 	if (first) {
 
-		/* 
+		/*
 		 * NOTE: Previous behavior and error (bug) description:
 		 *
 		 * After the client completes TX, the server echoes the message
@@ -896,30 +896,30 @@ static uet_rc_t uet_msg_client_unexpected(struct uet_context *ctx)
 		 * call uet_recv.
 		 * Now, we call uet_cq_read periodically to mimic the client
 		 * waiting for the TX packet completion.
-		 * 
+		 *
 		 * After the first packet of the echoed message arrives, the
 		 * client parses it, checks that since there is no matching read
 		 * descriptor in the ring buffer, client sends a NO_MATCH
 		 * notification to the server, but creates an active RX
 		 * descriptor for the first packet.
-		 * 
+		 *
 		 * The server receives the client's notification and sends a
 		 * MSG_ERROR back to ask the client to terminate the message.
-		 * 
+		 *
 		 * Then, the client removes the active descriptor and notifies
 		 * the server.
 		 * The server tries to retransmit the message, and the whole
 		 * cycle repeats.
-		 * 
+		 *
 		 * The client side waits for up to 3ms in this cycle and then
 		 * calls uet_recv, putting the appropriate read descriptor in
 		 * the ring buffer, so the message is not unexpected anymore
 		 * and gets properly received.
-		 * 
+		 *
 		 * The server tries to retransmit up to 10 times, then gives up.
 		 * This breaks the test logic on fast computers if the cycle
 		 * happens more than 10 times within 3ms.
-		 * 
+		 *
 		 * NOTE: FIX description
 		 * To avoid test failure, we now count MSG_ERROR arrivals by
 		 * counting the number of active RX descriptors and detecting
@@ -936,7 +936,7 @@ static uet_rc_t uet_msg_client_unexpected(struct uet_context *ctx)
 		     delta < UNEXPECTED_MSG_TEST_DELAY;
 		     delta = now - start) {
 			uet_cq_read(ctx->tx_cq_handle, &cq_entry, 1);
-			
+
 			active_list = &(((struct uet_ep *)(ctx->ep_handle))->
 						rx_desc_active_list_head);
 
@@ -944,14 +944,15 @@ static uet_rc_t uet_msg_client_unexpected(struct uet_context *ctx)
 			descr_count = 0;
 			dlist_foreach(active_list, dummy_item)
 				descr_count++;
-			
+
 			/* is descriptor removed from the active list? */
 			if (descr_count < prev_descr_count)
 				attempt_count++; /* a MSG_ERROR arrived */
 
 			prev_descr_count = descr_count;
 
-			if (attempt_count >= 5) break;
+			if (attempt_count >= 5)
+				break;
 
 			uet_gettime(&now);
 		}

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -1931,6 +1931,31 @@ static int uet_pds_process_request(struct uet_instance *uet,
 		    pdc->pdc_id, pdc->rx_bm_base_psn, pdc_pkt->pkt_pp.pds_psn,
 		    (pdc_pkt->pkt_pp.pds_psn - pdc->rx_bm_base_psn));
 
+	/*
+	 * Previous Behavior and Bug Description:
+	 * - When handling unexpected messages, if the Receiver has not yet
+	 *   posted a buffer, the SES sets the `gtd_del` flag to 1.
+	 * - In such cases, the Client-side RX bitmap's `base_psn` does not update
+	 *   and remains set to its default value. This leads to test failures
+	 *   and inconsistency in packet handling.
+	 *
+	 * Fix Description:
+	 * - To resolve this, we now check if a `clear_psn` value exists that is
+	 *   greater than the RX bitmap's current `base_psn`.
+	 * - If such a `clear_psn` is found, the `base_psn` is updated to match
+	 *   the `clear_psn`, ensuring proper synchronization and preventing
+	 *   test failures.
+	 *
+	 * Note for Review:
+	 * - Refer to the Packet Delivery Sublayer documentation, Section 1.1.9.4.2,
+	 *   for additional context. (The last comment can be removed after the review.)
+	 */
+	while (pdc->rx_bm_base_psn < pdc_pkt->pkt_pp.pds_clear_psn) {
+		bm_unset(pdc->rx_bm,
+		   pdc_pkt->pkt_pp.pds_clear_psn - pdc->rx_bm_base_psn);
+		pdc->rx_bm_base_psn++;
+	}
+
 	bm_set(pdc->rx_bm, (pdc_pkt->pkt_pp.pds_psn - pdc->rx_bm_base_psn),
 	       pdc_pkt);
 

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -1034,12 +1034,12 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	pdc_pkt->psn = pdc->next_psn++;
 	pds_hdr->psn = htonl(pdc_pkt->psn);
 
-        /*
-         * Set the clear_psn to the left edge (-1) of the tx_bm which moves
+	/*
+	 * Set the clear_psn to the left edge (-1) of the tx_bm which moves
 	 * forward as ACKs are received. Note that this is considered a
 	 * cumulative clear value.
-         */
-        pds_hdr->clear_psn_offset =
+	 */
+	pds_hdr->clear_psn_offset =
 		htons(psn_2c_offset(pdc_pkt->psn,
 				    (pdc->tx_bm_base_psn - 1)));
 
@@ -1588,8 +1588,57 @@ static int uet_pds_shift_rx_window(struct uet_instance *uet,
 	struct uet_pdc_pkt *pdc_pkt;
 	bool shifted = false;
 	int rc;
+	int max_rx_psn_offset;
+	int clear_to_base_diff;
 
 	while (true) {
+
+		/*
+		 * Previous Behavior and Bug Description:
+		 * - When handling unexpected messages, if the Receiver has not
+		 *   yet posted a buffer, the SES sets the `gtd_del` flag to 1.
+		 * - In such cases, the Client-side RX bitmap's `base_psn` does
+		 *   not update and remains set to its default value. This leads
+		 *   to test failures and inconsistency in packet handling.
+		 *
+		 * Fix Description:
+		 * - To resolve this, we now check if a `clear_psn` value exists
+		 *   that is greater than the RX bitmap's current `base_psn`.
+		 * - If such a `clear_psn` is found, the `base_psn` is updated
+		 *   to match the `clear_psn`, ensuring proper synchronization
+		 *   and preventing test failures.
+		 *
+		 * Note for Review:
+		 * - Refer to the Packet Delivery Sublayer documentation,
+		 *   Section 1.1.9.4.2, for additional context.
+		 */
+
+		/*
+		 * Extracting the last settled PDC packet PSN from the RX bitmap
+		 */
+		max_rx_psn_offset = bm_max(pdc->rx_bm);
+		if (!bm_get(pdc->rx_bm, max_rx_psn_offset, (void **)&pdc_pkt))
+			break;
+
+		clear_to_base_diff =
+			pdc_pkt->pkt_pp.pds_clear_psn - pdc->rx_bm_base_psn;
+
+		if (clear_to_base_diff > UET_DEFAULT_MPR ||
+				clear_to_base_diff < -UET_DEFAULT_MPR) {
+			UET_PDS_WARN("invalid CLEAR PSN %u on PDC %u "
+					"(outside MPR %u[+-%u])",
+					pdc_pkt->pkt_pp.pds_clear_psn,
+					pdc_pkt->pkt_pp.pds_dpdcid,
+					pdc->rx_bm_base_psn, UET_DEFAULT_MPR);
+			return -FI_EINVAL;
+
+		}
+
+		if (clear_to_base_diff > 0) {
+			bm_shift_right(pdc->rx_bm, clear_to_base_diff);
+			pdc->rx_bm_base_psn += clear_to_base_diff;
+		}
+
 		if (!bm_get(pdc->rx_bm, 0, (void **)&pdc_pkt))
 			break;
 
@@ -1930,31 +1979,6 @@ static int uet_pds_process_request(struct uet_instance *uet,
 	UET_PDS_DBG("PDC %u rx_bm: base=%u psn=%u SET bit=%u",
 		    pdc->pdc_id, pdc->rx_bm_base_psn, pdc_pkt->pkt_pp.pds_psn,
 		    (pdc_pkt->pkt_pp.pds_psn - pdc->rx_bm_base_psn));
-
-	/*
-	 * Previous Behavior and Bug Description:
-	 * - When handling unexpected messages, if the Receiver has not yet
-	 *   posted a buffer, the SES sets the `gtd_del` flag to 1.
-	 * - In such cases, the Client-side RX bitmap's `base_psn` does not update
-	 *   and remains set to its default value. This leads to test failures
-	 *   and inconsistency in packet handling.
-	 *
-	 * Fix Description:
-	 * - To resolve this, we now check if a `clear_psn` value exists that is
-	 *   greater than the RX bitmap's current `base_psn`.
-	 * - If such a `clear_psn` is found, the `base_psn` is updated to match
-	 *   the `clear_psn`, ensuring proper synchronization and preventing
-	 *   test failures.
-	 *
-	 * Note for Review:
-	 * - Refer to the Packet Delivery Sublayer documentation, Section 1.1.9.4.2,
-	 *   for additional context. (The last comment can be removed after the review.)
-	 */
-	while (pdc->rx_bm_base_psn < pdc_pkt->pkt_pp.pds_clear_psn) {
-		bm_unset(pdc->rx_bm,
-		   pdc_pkt->pkt_pp.pds_clear_psn - pdc->rx_bm_base_psn);
-		pdc->rx_bm_base_psn++;
-	}
 
 	bm_set(pdc->rx_bm, (pdc_pkt->pkt_pp.pds_psn - pdc->rx_bm_base_psn),
 	       pdc_pkt);

--- a/util/bitmap.c
+++ b/util/bitmap.c
@@ -103,7 +103,7 @@ bool bm_get(const struct bitmap *bm, int i, void **data)
 		return false; /* could assert() here */
 
 	if ((i < 0) || (i >= bm->size))
-		return NULL; /* could assert() here */
+		return false; /* could assert() here */
 
 	if (data)
 		*data = bm->data_arr[i];


### PR DESCRIPTION
Ensure proper synchronization by processing clear PSN and base PSN according to PDS specification (1.1.9.4.2 in 0.74rc4)

Previous Behavior and Bug Description:
- When handling unexpected messages, if the Receiver has not yet posted a buffer, the SES sets the `gtd_del` flag to 1.
- In such cases, the Client-side RX bitmap's `base_psn` does not update and remains set to its default value. This leads to test failures and inconsistency in packet handling.

Fix Description:
- To resolve this, we now check if a `clear_psn` value exists that is greater than the RX bitmap's current `base_psn`.
- If such a `clear_psn` is found, the `base_psn` is updated to match the `clear_psn`, ensuring proper synchronization and preventing test failures.

For more info please Refer to the Packet Delivery Sublayer documentation v0.75rc4, Section 1.1.9.4.2
