### PR TITLE
Implement 'uet_mr_regv'

### DIFF
--- a/uet_api.c
+++ b/uet_api.c
@@ -4527,6 +4527,83 @@ int uet_mr_reg(uet_domain_handle_t domain_handle, void *buf, size_t len,
 	return FI_SUCCESS;
 }
 
+int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
+	       size_t iov_count,uint64_t access, uint64_t requested_key,
+		   uint64_t flags,void *context, uet_mr_handle_t *mr_handle)
+{
+	int rc;
+	uint64_t key, rkey;
+	bool desc_allocated;
+	size_t mr_index;
+	struct uet_domain *uet_dom;
+	struct uet_mr_desc *mr_desc;
+
+	uet_dom = (struct uet_domain *) domain_handle;
+
+	/* allocate descriptor for memory region */
+	key = requested_key & UET_MR_KEY_IDEMPOTENT_SAFE;
+	if (uet_dom->info->domain_attr->mr_mode & FI_MR_PROV_KEY) {
+		desc_allocated = false;
+		if (requested_key & UET_MR_KEY_OPTIMIZED) {
+			if (uet_alloc_opt_mr_desc(uet_dom, &mr_index) ==
+			    FI_SUCCESS) {
+				desc_allocated = true;
+				key |= (UET_MR_KEY_OPTIMIZED |
+					(mr_index <<
+					 UET_MR_KEY_OPTIMIZED_RKEY_SHIFT));
+			}
+		}
+		if (!desc_allocated) {
+			rc = uet_alloc_mr_desc(uet_dom, &mr_index);
+			if (rc != FI_SUCCESS)
+				return rc;
+			key |= (mr_index << UET_MR_KEY_RKEY_SHIFT);
+		}
+		rkey = mr_index;
+	} else {
+		if (requested_key & UET_MR_KEY_OPTIMIZED) {
+			rkey = (requested_key & UET_MR_KEY_OPTIMIZED_RKEY_MASK) >>
+				UET_MR_KEY_OPTIMIZED_RKEY_SHIFT;
+			if (rkey > UET_MR_KEY_OPTIMIZED_MAX_RKEY) {
+				UET_API_ERR(
+				"Requested key too large for optimized format");
+				return -FI_EINVAL;
+			}
+			key |= (UET_MR_KEY_OPTIMIZED |
+				(rkey << UET_MR_KEY_OPTIMIZED_RKEY_SHIFT));
+		} else {
+			rkey = (requested_key & UET_MR_KEY_RKEY_MASK) >>
+				UET_MR_KEY_RKEY_SHIFT;
+			if (rkey > UET_MR_KEY_MAX_RKEY) {
+				UET_API_ERR("Requested key too large");
+				return -FI_EINVAL;
+			}
+			key |= rkey << UET_MR_KEY_RKEY_SHIFT;
+		}
+		rc = uet_alloc_mr_desc(uet_dom, &mr_index);
+		if (rc != FI_SUCCESS)
+			return rc;
+	}
+
+	/* init memory region descriptor */
+	mr_desc = &uet_dom->mr_desc[mr_index];
+	memset(mr_desc, 0, sizeof(struct uet_mr_desc));
+	mr_desc->state = UET_MR_DESC_STATE_DISABLED_REG;
+	mr_desc->uet_dom = uet_dom;
+	mr_desc->buf_desc.type = UET_MR_BUF_TYPE_IOV;
+	mr_desc->buf_desc.iov.iov = iov;
+	mr_desc->buf_desc.iov.iov_count = iov_count;
+	mr_desc->access = access;
+	mr_desc->flags = flags;
+	mr_desc->context = context;
+	mr_desc->full_key = key;
+	mr_desc->hash_key.rkey = rkey;
+
+	*mr_handle = mr_desc;
+
+	return FI_SUCCESS;
+}
+
 uint64_t uet_mr_key(uet_mr_handle_t mr_handle)
 {
 	struct uet_mr_desc *mr_desc;

--- a/uet_api.c
+++ b/uet_api.c
@@ -4454,6 +4454,18 @@ int uet_mr_reg(uet_domain_handle_t domain_handle, void *buf, size_t len,
 	       uint64_t access, uint64_t requested_key, uint64_t flags,
 	       void *context, uet_mr_handle_t *mr_handle)
 {
+	struct iovec iov;
+
+	iov.iov_base = (void *)buf;
+	iov.iov_len = len;
+	return uet_mr_regv(domain_handle, &iov, 1, access, requested_key,
+			   flags, context, mr_handle);
+}
+
+int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
+	       size_t iov_count,uint64_t access, uint64_t requested_key,
+		   uint64_t flags,void *context, uet_mr_handle_t *mr_handle)
+{
 	int rc;
 	uint64_t key, rkey;
 	bool desc_allocated;
@@ -4514,85 +4526,15 @@ int uet_mr_reg(uet_domain_handle_t domain_handle, void *buf, size_t len,
 	memset(mr_desc, 0, sizeof(struct uet_mr_desc));
 	mr_desc->state = UET_MR_DESC_STATE_DISABLED_REG;
 	mr_desc->uet_dom = uet_dom;
-	mr_desc->buf_desc.type = UET_MR_BUF_TYPE_CONTIG;
-	mr_desc->buf_desc.buf = buf;
-	mr_desc->buf_desc.len = len;
-	mr_desc->access = access;
-	mr_desc->flags = flags;
-	mr_desc->context = context;
-	mr_desc->full_key = key;
-	mr_desc->hash_key.rkey = rkey;
-
-	*mr_handle = mr_desc;
-	return FI_SUCCESS;
-}
-
-int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
-	       size_t iov_count,uint64_t access, uint64_t requested_key,
-		   uint64_t flags,void *context, uet_mr_handle_t *mr_handle)
-{
-	int rc;
-	uint64_t key, rkey;
-	bool desc_allocated;
-	size_t mr_index;
-	struct uet_domain *uet_dom;
-	struct uet_mr_desc *mr_desc;
-
-	uet_dom = (struct uet_domain *) domain_handle;
-
-	/* allocate descriptor for memory region */
-	key = requested_key & UET_MR_KEY_IDEMPOTENT_SAFE;
-	if (uet_dom->info->domain_attr->mr_mode & FI_MR_PROV_KEY) {
-		desc_allocated = false;
-		if (requested_key & UET_MR_KEY_OPTIMIZED) {
-			if (uet_alloc_opt_mr_desc(uet_dom, &mr_index) ==
-			    FI_SUCCESS) {
-				desc_allocated = true;
-				key |= (UET_MR_KEY_OPTIMIZED |
-					(mr_index <<
-					 UET_MR_KEY_OPTIMIZED_RKEY_SHIFT));
-			}
-		}
-		if (!desc_allocated) {
-			rc = uet_alloc_mr_desc(uet_dom, &mr_index);
-			if (rc != FI_SUCCESS)
-				return rc;
-			key |= (mr_index << UET_MR_KEY_RKEY_SHIFT);
-		}
-		rkey = mr_index;
+	if (iov_count == 1) {
+		mr_desc->buf_desc.type = UET_MR_BUF_TYPE_CONTIG;
+		mr_desc->buf_desc.buf = iov->iov_base;
+		mr_desc->buf_desc.len = iov->iov_len;
 	} else {
-		if (requested_key & UET_MR_KEY_OPTIMIZED) {
-			rkey = (requested_key & UET_MR_KEY_OPTIMIZED_RKEY_MASK) >>
-				UET_MR_KEY_OPTIMIZED_RKEY_SHIFT;
-			if (rkey > UET_MR_KEY_OPTIMIZED_MAX_RKEY) {
-				UET_API_ERR(
-				"Requested key too large for optimized format");
-				return -FI_EINVAL;
-			}
-			key |= (UET_MR_KEY_OPTIMIZED |
-				(rkey << UET_MR_KEY_OPTIMIZED_RKEY_SHIFT));
-		} else {
-			rkey = (requested_key & UET_MR_KEY_RKEY_MASK) >>
-				UET_MR_KEY_RKEY_SHIFT;
-			if (rkey > UET_MR_KEY_MAX_RKEY) {
-				UET_API_ERR("Requested key too large");
-				return -FI_EINVAL;
-			}
-			key |= rkey << UET_MR_KEY_RKEY_SHIFT;
-		}
-		rc = uet_alloc_mr_desc(uet_dom, &mr_index);
-		if (rc != FI_SUCCESS)
-			return rc;
+		mr_desc->buf_desc.type = UET_MR_BUF_TYPE_IOV;
+		mr_desc->buf_desc.iov.iov = iov;
+		mr_desc->buf_desc.iov.iov_count = iov_count;
 	}
-
-	/* init memory region descriptor */
-	mr_desc = &uet_dom->mr_desc[mr_index];
-	memset(mr_desc, 0, sizeof(struct uet_mr_desc));
-	mr_desc->state = UET_MR_DESC_STATE_DISABLED_REG;
-	mr_desc->uet_dom = uet_dom;
-	mr_desc->buf_desc.type = UET_MR_BUF_TYPE_IOV;
-	mr_desc->buf_desc.iov.iov = iov;
-	mr_desc->buf_desc.iov.iov_count = iov_count;
 	mr_desc->access = access;
 	mr_desc->flags = flags;
 	mr_desc->context = context;

--- a/uet_api.c
+++ b/uet_api.c
@@ -1456,13 +1456,19 @@ static bool uet_domain_has_ep(struct uet_domain *uet_dom)
 static void uet_domain_free(struct uet_domain *uet_dom)
 {
 	struct dlist_entry *item;
+	struct iovec *iov;
 
 	item = &uet_dom->domain_list_entry;
+	iov = (struct iovec *)uet_dom->mr_desc->buf_desc.iov.iov;
 	dlist_remove(item);
 	if (uet_dom->mr_desc_alloc_cb.state)
 		free(uet_dom->mr_desc_alloc_cb.state);
-	if (uet_dom->mr_desc)
+	if (uet_dom->mr_desc) {
+		if (iov)
+			free(iov);
+
 		free(uet_dom->mr_desc);
+	}
 	free(uet_dom);
 }
 
@@ -3908,6 +3914,7 @@ int uet_domain(uet_handle_t handle, struct fid_fabric *fabric,
 		uet_dom->num_mr = info->domain_attr->mr_cnt;
 	else
 		uet_dom->num_mr = UET_DEF_MR_CNT;
+
 	uet_dom->mr_desc = calloc(uet_dom->num_mr,
 				 sizeof(struct uet_mr_desc));
 	if (uet_dom->mr_desc == NULL) {
@@ -4472,6 +4479,7 @@ int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
 	size_t mr_index;
 	struct uet_domain *uet_dom;
 	struct uet_mr_desc *mr_desc;
+	struct iovec *iov_handle;
 
 	uet_dom = (struct uet_domain *) domain_handle;
 
@@ -4521,6 +4529,10 @@ int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
 			return rc;
 	}
 
+	iov_handle = calloc(iov_count, sizeof(struct iovec));
+	for (int i = 0; i < iov_count; i++)
+		iov_handle[i] = iov[i];
+
 	/* init memory region descriptor */
 	mr_desc = &uet_dom->mr_desc[mr_index];
 	memset(mr_desc, 0, sizeof(struct uet_mr_desc));
@@ -4532,7 +4544,7 @@ int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
 		mr_desc->buf_desc.len = iov->iov_len;
 	} else {
 		mr_desc->buf_desc.type = UET_MR_BUF_TYPE_IOV;
-		mr_desc->buf_desc.iov.iov = iov;
+		mr_desc->buf_desc.iov.iov = iov_handle;
 		mr_desc->buf_desc.iov.iov_count = iov_count;
 	}
 	mr_desc->access = access;

--- a/uet_api.c
+++ b/uet_api.c
@@ -4463,8 +4463,8 @@ int uet_mr_reg(uet_domain_handle_t domain_handle, void *buf, size_t len,
 }
 
 int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
-	       size_t iov_count,uint64_t access, uint64_t requested_key,
-		   uint64_t flags,void *context, uet_mr_handle_t *mr_handle)
+	       size_t iov_count, uint64_t access, uint64_t requested_key,
+		   uint64_t flags, void *context, uet_mr_handle_t *mr_handle)
 {
 	int rc;
 	uint64_t key, rkey;

--- a/uet_api.h
+++ b/uet_api.h
@@ -209,6 +209,35 @@ int uet_mr_reg(uet_domain_handle_t domain_handle, void *buf, size_t len,
 	       void *context, uet_mr_handle_t *mr_handle);
 
 /*
+ * simple API to register a memory region supporting scatter-gather with a
+ * domain
+ *
+ * parms:
+ *   domain_handle - handle identifying uet domain instance
+ *   iov           - address of scatter-gather list
+ *   iov_count     - number of elements in scatter-gather list
+ *   access        - memory access permissions, see fi_mr
+ *   requested_key - requested remote key, ignored if the
+ *                   FI_MR_PROV_KEY flag is set in the
+ *                   domain mr_mode bits
+ *   flags         - operational flags, see fi_mr
+ *   context       - user specified context associated with mr
+ *   mr_handle     - ptr to location where uet endpoint handle is
+ *                   returned, the uet provider can use the mr_handle
+ *                   as the memory region descriptor
+ * returns:
+ *   0 on success,
+ *   negative value corresponding to fabric errno on error
+ *
+ * notes:
+ *   - can be used to implement the following libfabric fi_mr api's:
+ *     - fi_mr_reg
+ */
+int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
+	       size_t iov_count, uint64_t access, uint64_t requested_key,
+		   uint64_t flags, void *context, uet_mr_handle_t *mr_handle);
+
+/*
  * flexible api to register a memory region with a domain
  *
  * parms:


### PR DESCRIPTION
Function needed for `fi_mr_regv`.

Tested with `fi_mr_test` fabtest, no tests are available so far at uet-ref-prov level

Feature tested internally with all fixes from other PRs included. Since this branch is based off main, PDS tests are expected to fail until https://github.com/ultraethernet/uet-ref-prov/pull/52 is merged. Once merged with https://github.com/ultraethernet/uet-ref-prov/pull/52 into main, it should work as expected.