### PR TITLE
Fix fabtests

### DIFF
--- a/nic_shim/nic_rawsock.c
+++ b/nic_shim/nic_rawsock.c
@@ -269,27 +269,6 @@ int nic_rawsock_rx_poll(struct uet_nic *nic)
 	return -FI_EIO;
 }
 
-/* register memory region with nic */
-int nic_rawsock_mr_reg(struct uet_nic *nic,
-		       struct uet_mr_buf_desc *desc,
-		       uet_nic_mr_handle_t *handle)
-{
-	if (desc->type != UET_MR_BUF_TYPE_CONTIG) {
-		UET_API_ERR("MR reg only supported for contiguous buf type");
-		return -FI_EINVAL;
-	}
-
-	desc->contig.dma_addr = desc->buf;
-	return FI_SUCCESS;
-}
-
-/* deregister memory region that was registered with nic */
-int nic_rawsock_mr_dereg(struct uet_nic *nic,
-			 uet_nic_mr_handle_t handle)
-{
-	return FI_SUCCESS;
-}
-
 /* free nic resources */
 void nic_rawsock_finalize(struct uet_nic *nic)
 {

--- a/nic_shim/nic_xdp.c
+++ b/nic_shim/nic_xdp.c
@@ -462,27 +462,6 @@ int nic_xdp_rx_poll(struct uet_nic *nic)
 	return 0;
 }
 
-/* register memory region with nic */
-int nic_xdp_mr_reg(struct uet_nic *nic,
-		   struct uet_mr_buf_desc *desc,
-		   uet_nic_mr_handle_t *handle)
-{
-	if (desc->type != UET_MR_BUF_TYPE_CONTIG) {
-		UET_API_ERR("MR reg only supported for contiguous buf type");
-		return -FI_EINVAL;
-	}
-
-	desc->contig.dma_addr = desc->buf;
-	return FI_SUCCESS;
-}
-
-/* deregister memory region that was registered with nic */
-int nic_xdp_mr_dereg(struct uet_nic *nic,
-		     uet_nic_mr_handle_t handle)
-{
-	return FI_SUCCESS;
-}
-
 static struct xsk_umem_info *nic_xdp_xsk_configure_umem(void *mem,
 							uint64_t mem_size)
 {

--- a/nic_shim/uet_nic.c
+++ b/nic_shim/uet_nic.c
@@ -50,11 +50,6 @@ extern int nic_rawsock_rx_pkt(struct uet_nic *nic,
 			      size_t pkt_buf_size,
 			      size_t *rx_pkt_size);
 extern int nic_rawsock_rx_poll(struct uet_nic *nic);
-extern int nic_rawsock_mr_reg(struct uet_nic *nic,
-			      struct uet_mr_buf_desc *desc,
-			      uet_nic_mr_handle_t *handle);
-extern int nic_rawsock_mr_dereg(struct uet_nic *nic,
-				uet_nic_mr_handle_t handle);
 extern void nic_rawsock_finalize(struct uet_nic *nic);
 extern int nic_rawsock_initialize(struct uet_nic *nic);
 
@@ -103,8 +98,6 @@ int uet_nic_initialize(struct uet_nic *nic)
 		nic->nic_tx_pkt      = nic_rawsock_tx_pkt;
 		nic->nic_rx_pkt      = nic_rawsock_rx_pkt;
 		nic->nic_rx_poll     = nic_rawsock_rx_poll;
-		nic->nic_mr_reg      = nic_rawsock_mr_reg;
-		nic->nic_mr_dereg    = nic_rawsock_mr_dereg;
 		nic->nic_finalize    = nic_rawsock_finalize;
 		nic->nic_initialize  = nic_rawsock_initialize;
 #if ENABLE_XDP

--- a/nic_shim/uet_nic.c
+++ b/nic_shim/uet_nic.c
@@ -69,11 +69,6 @@ extern int nic_xdp_rx_pkt(struct uet_nic *nic,
 			  size_t pkt_buf_size,
 			  size_t *rx_pkt_size);
 extern int nic_xdp_rx_poll(struct uet_nic *nic);
-extern int nic_xdp_mr_reg(struct uet_nic *nic,
-			  struct uet_mr_buf_desc *desc,
-			  uet_nic_mr_handle_t *handle);
-extern int nic_xdp_mr_dereg(struct uet_nic *nic,
-			    uet_nic_mr_handle_t handle);
 extern void nic_xdp_finalize(struct uet_nic *nic);
 extern int nic_xdp_initialize(struct uet_nic *nic);
 #endif
@@ -107,8 +102,6 @@ int uet_nic_initialize(struct uet_nic *nic)
 		nic->nic_tx_pkt      = nic_xdp_tx_pkt;
 		nic->nic_rx_pkt      = nic_xdp_rx_pkt;
 		nic->nic_rx_poll     = nic_xdp_rx_poll;
-		nic->nic_mr_reg      = nic_xdp_mr_reg;
-		nic->nic_mr_dereg    = nic_xdp_mr_dereg;
 		nic->nic_finalize    = nic_xdp_finalize;
 		nic->nic_initialize  = nic_xdp_initialize;
 #endif

--- a/nic_shim/uet_nic.h
+++ b/nic_shim/uet_nic.h
@@ -71,11 +71,6 @@ struct uet_nic {
 			  void *pkt,
 			  size_t pkt_buf_size,
 			  size_t *rx_pkt_size);
-	int (*nic_mr_reg)(struct uet_nic *nic,
-			  struct uet_mr_buf_desc *desc,
-			  uet_nic_mr_handle_t *handle);
-	int (*nic_mr_dereg)(struct uet_nic *nic,
-			    uet_nic_mr_handle_t handle);
 	int (*nic_rx_poll)(struct uet_nic *nic);
 	void (*nic_finalize)(struct uet_nic *nic);
 	int (*nic_initialize)(struct uet_nic *nic);
@@ -220,49 +215,6 @@ static inline int uet_nic_rx_poll(struct uet_nic *nic)
 		assert(0);
 
 	return nic->nic_rx_poll(nic);
-}
-
-/*
- * register a memory region with nic
- *
- * parms:
- *      uet    - ptr to uet nic struct
- *      desc   - ptr to buffer info struct for memory region
- *      handle - ptr to location where nic handle for registered
- *               memory region is to be returned
- *
- * returns:
- *      FI_SUCCESS on success,
- *      negative value corresponding to fabric errno on error
- */
-static inline int uet_nic_mr_reg(struct uet_nic *nic,
-				 struct uet_mr_buf_desc *desc,
-				 uet_nic_mr_handle_t *handle)
-{
-	if (!nic || !desc || !handle)
-		assert(0);
-
-	return nic->nic_mr_reg(nic, desc, handle);
-}
-
-/*
- * deregister memory region that was registered with nic
- *
- * parms:
- *      uet    - ptr to uet nic struct
- *      handle - nic handle for registered memory region
- *
- * returns:
- *      FI_SUCCESS on success,
- *      negative value corresponding to fabric errno on error
- */
-static inline int uet_nic_mr_dereg(struct uet_nic *nic,
-				   uet_nic_mr_handle_t handle)
-{
-	if (!nic || !handle)
-		assert(0);
-
-	return nic->nic_mr_dereg(nic, handle);
 }
 
 #endif /* _UET_NIC_H_ */

--- a/nic_shim/uet_nic.h
+++ b/nic_shim/uet_nic.h
@@ -27,8 +27,6 @@
 
 #define UET_NIC(uet) (&(uet)->nic)
 
-typedef void *uet_nic_mr_handle_t;      /* nic handle for memory region */
-
 struct uet_mr_buf_desc;
 struct uet_instance;
 

--- a/uet.c
+++ b/uet.c
@@ -192,6 +192,14 @@ static void uet_free_res(struct uet_context *ctx)
 		ctx->peer_addr_handle = UET_NULL_HANDLE;
 	}
 
+
+	if (ctx->ep_handle != UET_NULL_HANDLE) {
+		rc = uet_ep_close(ctx->ep_handle);
+		if (rc)
+			UET_ERR("uet_endpoint_close: %s", fi_strerror(-rc));
+		ctx->ep_handle = UET_NULL_HANDLE;
+	}
+
 	if (ctx->tx_cq_handle != UET_NULL_HANDLE) {
 		rc = uet_cq_close(ctx->tx_cq_handle);
 		if (rc)
@@ -204,13 +212,6 @@ static void uet_free_res(struct uet_context *ctx)
 		if (rc)
 			UET_ERR("uet_cq_close: %s", fi_strerror(-rc));
 		ctx->rx_cq_handle = UET_NULL_HANDLE;
-	}
-
-	if (ctx->ep_handle != UET_NULL_HANDLE) {
-		rc = uet_ep_close(ctx->ep_handle);
-		if (rc)
-			UET_ERR("uet_endpoint_close: %s", fi_strerror(-rc));
-		ctx->ep_handle = UET_NULL_HANDLE;
 	}
 
 	if (ctx->mr_handle != UET_NULL_HANDLE) {

--- a/uet_api.c
+++ b/uet_api.c
@@ -30,7 +30,6 @@
  *   - not designed for high performance
  */
 
-#include <bits/types/struct_iovec.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -187,13 +186,13 @@ static int uet_alloc_opt_mr_desc(struct uet_domain *uet_dom, size_t *mr_index)
 static void uet_dealloc_mr_desc(struct uet_domain *uet_dom,
 				struct uet_mr_desc *mr_desc)
 {
-	uint8_t *offset;
+	size_t offset;
 	size_t mr_index;
 
 	mr_desc->state = UET_MR_DESC_STATE_INACTIVE;
 
 	offset = ((uint8_t *) mr_desc) - ((uint8_t *) uet_dom->mr_desc);
-	mr_index = ((size_t) offset) / sizeof(struct uet_mr_desc);
+	mr_index = offset / sizeof(struct uet_mr_desc);
 	uet_dom->mr_desc_alloc_cb.state[mr_index] = UET_MR_DESC_AVAILABLE;
 }
 
@@ -673,8 +672,6 @@ static void uet_mr_hash_finalize(struct uet_ep *uet_ep)
 
 	HASH_ITER(mr_hh, uet_ep->mr_hash_table, current, tmp) {
 		HASH_DELETE(mr_hh, uet_ep->mr_hash_table, current);
-		uet_nic_mr_dereg(UET_NIC(uet_ep->uet_domain->uet),
-				 current->nic_mr_handle);
 		current->state = UET_MR_DESC_STATE_DISABLED_REG;
 		current->uet_ep = NULL;
 	}
@@ -1388,6 +1385,7 @@ static void uet_ep_free(struct uet_ep *uet_ep)
 	uet_rw_unlock(&uet_ep->uet_domain->ep_lock, UET_RW_LOCK_WR_ACCESS);
 
 	free(uet_ep);
+	uet_ep = NULL; /* To prevent use after free */
 }
 
 /* free resources associated with all endpoints of a domain */
@@ -2640,7 +2638,7 @@ static int uet_pds_to_ses_rx_req(uet_pkt_handle_t rx_pkt_handle,
 		ses_rc = uet_rx_req_pkt(uet_ep, pp, &list,
 					false, true, gtd_del);
 		if (ses_rc == UET_RC_UNCOR_TRNSNT)
-			ses_nack = true;
+			*ses_nack = true;
 		ep_gen = (uint32_t) uet_ep->untagged_gen;
 		break;
 	case UET_READ:
@@ -2649,7 +2647,7 @@ static int uet_pds_to_ses_rx_req(uet_pkt_handle_t rx_pkt_handle,
 		if (ses_rc != UET_RC_OK) {
 			*gtd_del = true;
 			if (ses_rc == UET_RC_UNCOR_TRNSNT)
-				ses_nack = true;
+				*ses_nack = true;
 		} else if (ack_d_info.valid)
 			goto build_response_w_data;
 		ep_gen = (uint32_t) uet_ep->untagged_gen;
@@ -3740,6 +3738,7 @@ static ssize_t uet_send_req_api_common(
 	uint64_t remote_mem_addr, uint64_t remote_key, void *context)
 {
 	int rc;
+	size_t i;
 	uint16_t msg_id;
 	uint32_t msg_len = 0;
 	struct uet_instance *uet;
@@ -4368,7 +4367,7 @@ int uet_mr_disable(uet_mr_handle_t mr_handle)
 	}
 
 	if (mr_desc->uet_ep->uet_domain->info->domain_attr->mr_mode &
-			FI_MR_PROV_KEY)
+	    FI_MR_PROV_KEY)
 		uet_mr_list_finalize(mr_desc->uet_ep);
 	else
 		uet_mr_hash_finalize(mr_desc->uet_ep);
@@ -4394,6 +4393,11 @@ int uet_ep_close(uet_ep_handle_t ep_handle)
 	uet_ep = (struct uet_ep *) ep_handle;
 	pds = &uet_ep->uet_domain->uet->pds;
 
+	/* Error if there are outstanding msg transmits */
+	if ((uet_ep->num_active_sends)) {
+		UET_API_ERR("Outstanding sends associated with EP being closed");
+		return -FI_EBUSY;
+	}
 
 	if (uet_ep->uet_domain->info->domain_attr->mr_mode & FI_MR_PROV_KEY)
 		uet_mr_list_finalize(uet_ep);
@@ -4513,14 +4517,12 @@ int uet_cq_close(uet_cq_handle_t cq_handle)
 	uet_cq = (struct uet_cq *) cq_handle;
 	uet_ep = uet_cq->uet_ep;
 
-	/* fail if closing tx cq & there are outstanding msg transmits */
-	if ((uet_cq == &uet_ep->send_cq) && (uet_ep->num_active_sends)) {
-		UET_API_ERR("Outstanding sends associated with CQ being closed");
-		return -FI_EBUSY;
-	}
-
-	if (uet_ep_has_cq(uet_ep)) {
-		UET_API_ERR("There is opened endpoint");
+	/*
+	 * At this point their must not be any associated ep with cq,
+	 * we check if there is one like that
+	 */
+	if ((uet_ep) && uet_ep_has_cq(uet_ep)) {
+		UET_API_ERR("There is opened endpoint associated with cq");
 		return -FI_EBUSY;
 	}
 
@@ -4856,10 +4858,12 @@ int uet_mr_enable(uet_mr_handle_t mr_handle)
 		return -FI_EINVAL;
 	}
 
-	rc = uet_nic_mr_reg(UET_NIC(mr_desc->uet_ep->uet_domain->uet),
-			    &mr_desc->buf_desc, &mr_desc->nic_mr_handle);
-	if (rc != FI_SUCCESS)
-		return rc;
+	if (mr_desc->buf_desc.type != UET_MR_BUF_TYPE_CONTIG) {
+		UET_API_ERR("MR reg only supported for contiguous buf type");
+		return -FI_EINVAL;
+	}
+
+	mr_desc->buf_desc.contig.dma_addr = (uet_dma_addr_t) mr_desc->buf_desc.buf;
 
 	if (mr_desc->uet_ep->uet_domain->info->domain_attr->mr_mode &
 	    FI_MR_PROV_KEY)

--- a/uet_api.c
+++ b/uet_api.c
@@ -4355,6 +4355,27 @@ int uet_ep_bind_cq(uet_ep_handle_t ep_handle, struct fi_cq_attr *attr,
 	return FI_SUCCESS;
 }
 
+int uet_mr_disable(uet_mr_handle_t mr_handle)
+{
+	int rc;
+	struct uet_mr_desc *mr_desc;
+
+	mr_desc = (struct uet_mr_desc *) mr_handle;
+
+	if (mr_desc->state != UET_MR_DESC_STATE_ENABLED) {
+		UET_API_ERR("Bad MR state for disable");
+		return -FI_EINVAL;
+	}
+
+	if (mr_desc->uet_ep->uet_domain->info->domain_attr->mr_mode &
+			FI_MR_PROV_KEY)
+		uet_mr_list_finalize(mr_desc->uet_ep);
+	else
+		uet_mr_hash_finalize(mr_desc->uet_ep);
+
+	return FI_SUCCESS;
+}
+
 int uet_ep_enable(uet_ep_handle_t ep_handle)
 {
 	struct uet_ep *uet_ep;
@@ -4373,10 +4394,6 @@ int uet_ep_close(uet_ep_handle_t ep_handle)
 	uet_ep = (struct uet_ep *) ep_handle;
 	pds = &uet_ep->uet_domain->uet->pds;
 
-	if (uet_ep_has_cq(uet_ep)) {
-		UET_API_ERR("Completion Q is associated with EP being closed");
-		return -FI_EBUSY;
-	}
 
 	if (uet_ep->uet_domain->info->domain_attr->mr_mode & FI_MR_PROV_KEY)
 		uet_mr_list_finalize(uet_ep);
@@ -4502,8 +4519,12 @@ int uet_cq_close(uet_cq_handle_t cq_handle)
 		return -FI_EBUSY;
 	}
 
+	if (uet_ep_has_cq(uet_ep)) {
+		UET_API_ERR("There is opened endpoint");
+		return -FI_EBUSY;
+	}
+
 	uet_cq->cq_state = UET_CQ_DOWN;
-	uet_ring_free_entries(&uet_cq->ring);
 
 	return FI_SUCCESS;
 }

--- a/uet_api.h
+++ b/uet_api.h
@@ -329,6 +329,18 @@ uint64_t uet_mr_refresh(uet_mr_handle_t mr_handle,
 int uet_mr_enable(uet_mr_handle_t mr_handle);
 
 /*
+ * disable MR state and remove all entries
+ *
+ * parms:
+ *   mr_handle - handle identifying uet memory region instance
+ *
+ * returns:
+ *   0 on success,
+ *   negative value corresponding to fabric errno on error
+ */
+int uet_mr_disable(uet_mr_handle_t mr_handle);
+
+/*
  * close a memory region
  *
  * parms:

--- a/uet_api_private.h
+++ b/uet_api_private.h
@@ -152,7 +152,6 @@ struct uet_mr_desc {
 	uet_mr_desc_state_t state;                 /* state of the descriptor */
 	struct uet_domain *uet_dom;   /* domain descriptor is associated with */
 	struct uet_ep *uet_ep;      /* endpoint descriptor is associated with */
-	uet_nic_mr_handle_t nic_mr_handle;    /* nic handle for memory region */
 	struct uet_mr_buf_desc buf_desc;   /* memory region buffer descriptor */
 	uint64_t full_key;                      /* full key for memory region */
 	uint64_t access;            /* operations supported for memory region */


### PR DESCRIPTION
Changes required for libfabric fabtests to pass.

Additionally, we removed MR registration/deregistration at the NIC SHIM level. MR is now handled at the transport layer of the OSI model. The NIC SHIM operates at the lowest logical level, below the MAC, and is not the appropriate place for MR.