### PR TITLE
pds: allocate packet memory for CRC

### DIFF
--- a/uet_pds.c
+++ b/uet_pds.c
@@ -1331,7 +1331,7 @@ static int uet_pds_tx_ack_pkt(struct uet_instance *uet,
 				 ((pdc->sec_enabled)
 				  ? (UET_SEC_MAX_HDR_LEN +
 				     UET_SEC_TAG_LEN)
-				  : 0)) *
+				  : CRC64_LEN)) *
 				((pdc->sec_enabled) ? 2 : 1));
 	pdc_pkt->ack_buf = calloc(1, pdc_pkt->ack_buf_len);
 	if (pdc_pkt->ack_buf == NULL) {
@@ -1390,7 +1390,7 @@ static int uet_pds_tx_def_rsp_ack_pkt(struct uet_instance *uet,
 			     ((pdc->sec_enabled)
 			      ? (UET_SEC_MAX_HDR_LEN +
 				 UET_SEC_TAG_LEN)
-			      : 0)) *
+			      : CRC64_LEN)) *
 			   ((pdc->sec_enabled) ? 2 : 1));
 	def_rsp_buf = calloc(1, def_rsp_buf_len);
 	if (def_rsp_buf == NULL) {


### PR DESCRIPTION
Writing the CRC when constructing a packet writes past the allocated packet buffer.  Found by valgrind:

	==102== Invalid write of size 8
	==102==    at 0x520052A: uet_pds_sec_tx_pkt (uet_pds.c:311)
	==102==    by 0x5206645: uet_pds_tx_ack_pkt (uet_pds.c:1367)
	==102==    by 0x5206F60: uet_pds_upcall_ses_rx_req (uet_pds.c:1586)
	==102==    by 0x5207A0E: uet_pds_process_syn_pkt (uet_pds.c:1895)
	==102==    by 0x5207C15: uet_pds_process_request (uet_pds.c:1951)
	==102==    by 0x52081D1: uet_pds_progress_rx (uet_pds.c:2093)

	==102==  Address 0x5c62cec is 0 bytes after a block of size 60 alloc'd
	==102==    at 0x48465EF: calloc (vg_replace_malloc.c:1328)
	==102==    by 0x520656B: uet_pds_tx_ack_pkt (uet_pds.c:1350)
	==102==    by 0x5206F60: uet_pds_upcall_ses_rx_req (uet_pds.c:1586)
	==102==    by 0x5207A0E: uet_pds_process_syn_pkt (uet_pds.c:1895)
	==102==    by 0x5207C15: uet_pds_process_request (uet_pds.c:1951)
	==102==    by 0x52081D1: uet_pds_progress_rx (uet_pds.c:2093)

Reserve more buffer space to fit (unless encryption is enabled).