### PR TITLE
PDS added support for closing PDCs and other fixes

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Check out the code
-        uses: actions/checkout@v3  
+        uses: actions/checkout@v3
 
       - name: Install bridge-utils
         run: |
@@ -51,7 +51,7 @@ jobs:
       - name: Compile uet-ref-prov
         run: |
           make
-          
+
       - name: Check network brm to vm
         run: |
           ping -c1 10.1.0.2
@@ -70,29 +70,29 @@ jobs:
           ip link show vm2 | awk '/link\/ether/ {print $2}'
           MAC1=$(ip link show vm2 | awk '/link\/ether/ {print $2}')
           MAC2=$(ip link show brm | awk '/link\/ether/ {print $2}')
-          
+
           echo "Discovered MAC2 Address: $MAC2"
           echo "Discovered MAC2 Address: $MAC1"
           sudo arp -i vm2 -s 10.1.0.1 $MAC2
           sudo arp -i brm -s 10.1.0.2 $MAC1
 
-      - name: run tests in SNG mode
+      - name: run all tests in SNG mode
         run: |
           arp -a
-          sudo LD_LIBRARY_PATH=../libfabric/src/.libs UET_IFNAME=brm ./uet server test 10.1.0.2 &
+          sudo LD_LIBRARY_PATH=../libfabric/src/.libs UET_IFNAME=brm ./uet server all 10.1.0.2 &
           echo "Server started in background."
           sleep 2
           echo "Client started."
-          sudo LD_LIBRARY_PATH=../libfabric/src/.libs UET_IFNAME=vm2 ./uet client test 10.1.0.1
-          echo "Client finished."  
+          sudo LD_LIBRARY_PATH=../libfabric/src/.libs UET_IFNAME=vm2 ./uet client all 10.1.0.1
+          echo "Client finished."
 
-
-      - name: run tests in PDS mode
+      - name: run all tests in PDS mode
         run: |
           arp -a
-          sudo LD_LIBRARY_PATH=../libfabric/src/.libs UET_PDS=pds UET_IFNAME=brm ./uet server test 10.1.0.2 &
+          sudo LD_LIBRARY_PATH=../libfabric/src/.libs UET_PDS=pds UET_IFNAME=brm ./uet server all 10.1.0.2 &
           echo "Server started in background."
           sleep 2
           echo "Client started."
-          sudo LD_LIBRARY_PATH=../libfabric/src/.libs UET_PDS=pds UET_IFNAME=vm2 ./uet client test 10.1.0.1
-          echo "Client finished."   
+          sudo LD_LIBRARY_PATH=../libfabric/src/.libs UET_PDS=pds UET_IFNAME=vm2 ./uet client all 10.1.0.1
+          echo "Client finished."
+

--- a/nic_shim/nic_rawsock.c
+++ b/nic_shim/nic_rawsock.c
@@ -23,59 +23,30 @@ struct rawsock_data {
 	struct sockaddr_ll sadr;           /* link-level socket addr */
 };
 
-/* get nic info for libfabric fid_nic struct */
+/* get nic info */
 int nic_rawsock_getinfo(struct uet_nic *nic,
-			struct fid_nic *fnic)
+			struct uet_nic_info *nic_info)
 {
 	struct rawsock_data *rdata =
 		(struct rawsock_data *)nic->nic_priv_data;
-
-	int rc;
-
-	/* allocate memory for nic structs */
-	fnic->device_attr = calloc(1, sizeof(struct fi_device_attr));
-	if (fnic->device_attr == NULL) {
-		UET_API_PRINT_ERRNO("calloc");
-		rc = -FI_ENOMEM;
-		goto err_return;
-	}
-
-	fnic->link_attr = calloc(1, sizeof(struct fi_link_attr));
-	if (fnic->link_attr == NULL) {
-		UET_API_PRINT_ERRNO("calloc");
-		rc = -FI_ENOMEM;
-		goto err_return;
-	}
 
 	/* get interface flags */
 	if ((ioctl(rdata->sock_fd.fd, SIOCGIFFLAGS, &rdata->ifr)) < 0) {
 		UET_API_PRINT_ERRNO("socket ioctl");
 		UET_API_ERR("Error getting interface flags");
-		goto err_return;
+		return -ENODEV;
 	}
 
-	/* init nic info */
-	fnic->device_attr->name = nic->ifname;
-	fnic->link_attr->mtu = nic->mtu;
-	fnic->link_attr->network_type = nic->network_type;
-	fnic->link_attr->address = nic->mac_addr_str;
-	if (rdata->ifr.ifr_flags & IFF_UP)
-		fnic->link_attr->state = FI_LINK_UP;
-	else
-		fnic->link_attr->state = FI_LINK_DOWN;
+	nic_info->ifname = nic->ifname;
+	nic_info->network_type = nic->network_type;
+	nic_info->mac_addr_str = nic->mac_addr_str;
+	nic_info->mtu = nic->mtu;
 
-	return FI_SUCCESS;
+	nic_info->link_state =
+		(rdata->ifr.ifr_flags & IFF_UP)
+			? UET_NIC_LINK_STATE_UP : UET_NIC_LINK_STATE_DOWN;
 
-err_return:
-	if (fnic->device_attr != NULL) {
-		free(fnic->device_attr);
-		fnic->device_attr = NULL;
-	}
-	if (fnic->link_attr != NULL) {
-		free(fnic->link_attr);
-		fnic->link_attr = NULL;
-	}
-	return rc;
+	return 0;
 }
 
 /* get next-hop info for ipv4 destination address */
@@ -109,7 +80,7 @@ int nic_rawsock_get_ipv4_nh(struct uet_nic *nic,
 		UET_API_PRINT_ERRNO("popen");
 		UET_API_ERR("Error getting next-hop IP address");
 		pclose(cmd_stream);
-		return -FI_EIO;
+		return -EIO;
 	}
 	for (i = 0; i < INET_ADDRSTRLEN; i++) {
 		nic->nh_ip_addr_str[i] = getc(cmd_stream);
@@ -121,7 +92,7 @@ int nic_rawsock_get_ipv4_nh(struct uet_nic *nic,
 	if (i == INET_ADDRSTRLEN) {
 		UET_API_ERR("Error parsing next-hop IP address");
 		pclose(cmd_stream);
-		return -FI_EIO;
+		return -EIO;
 	}
 	inet_pton(AF_INET, nic->nh_ip_addr_str, &nh_ipv4);
 	pclose(cmd_stream);
@@ -154,15 +125,15 @@ int nic_rawsock_get_ipv4_nh(struct uet_nic *nic,
 	if (ioctl(rdata->sock_fd.fd, SIOCGARP, (caddr_t) &areq) < 0) {
 		UET_API_PRINT_ERRNO("socket ioctl");
 		UET_API_ERR("Error getting ARP entry");
-		return -FI_EIO;
+		return -EIO;
 	}
 	memcpy(mac, areq.arp_ha.sa_data, ETH_ALEN);
 
-	rc = FI_SUCCESS;
+	rc = 0;
 	memset(invalid_mac, 0, ETH_ALEN);
 	if (memcmp(mac, invalid_mac, ETH_ALEN) == 0) {
 		UET_API_ERR("Unable to resolve next-hop MAC addr");
-		rc = -FI_ENETUNREACH;
+		rc = -ENETUNREACH;
 	}
 
 	printf("Next-Hop Address Resolution\n");
@@ -205,10 +176,10 @@ int nic_rawsock_tx_pkt(struct uet_nic *nic,
 			UET_API_ERR("Error transmitting packet, "
 				    "sent %ld of %ld bytes",
 				    len, pkt_size);
-		return -FI_EIO;
+		return -EIO;
 	}
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 /* receive a packet */
@@ -224,7 +195,7 @@ int nic_rawsock_rx_pkt(struct uet_nic *nic,
 	len = recvfrom(rdata->sock_fd.fd, pkt, pkt_buf_size, 0, NULL, NULL);
 	if (len == -1) {
 		UET_API_PRINT_ERRNO("recvfrom");
-		return -FI_EIO;
+		return -EIO;
 	} else if (len > pkt_buf_size) {
 		UET_API_DEBUG("Error receiving packet: too big: "
 			      "%ld bytes", len);
@@ -261,13 +232,13 @@ int nic_rawsock_rx_poll(struct uet_nic *nic)
 		return 0;
 	case -1:
 		UET_API_PRINT_ERRNO("poll");
-		return -FI_EIO;
+		return -EIO;
 	default:
 		break;
 	}
 
 	UET_API_ERR("unexpected val from poll: %d", ret);
-	return -FI_EIO;
+	return -EIO;
 }
 
 /* free nic resources */
@@ -302,7 +273,7 @@ int nic_rawsock_initialize(struct uet_nic *nic)
 	rdata = calloc(1, sizeof(struct rawsock_data));
 	if (rdata == NULL) {
 		UET_API_ERR("ERROR: Failed to alloc RAWSOCK priv data");
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	nic->nic_priv_data = (void *)rdata;
@@ -315,7 +286,7 @@ int nic_rawsock_initialize(struct uet_nic *nic)
 	ifname = getenv(UET_IFNAME);
 	if (ifname == NULL) {
 		UET_API_ERR("err reading UET_IFNAME environment variable");
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto err_return;
 	}
 
@@ -325,7 +296,7 @@ int nic_rawsock_initialize(struct uet_nic *nic)
 	rdata->sock_fd.fd = socket(AF_PACKET, SOCK_RAW, ETH_P_IP);
 	if (rdata->sock_fd.fd == -1) {
 		UET_API_PRINT_ERRNO("socket");
-		rc = -FI_EIO;
+		rc = -EIO;
 		goto err_return;
 	}
 	rdata->sock_fd.events = POLLIN;
@@ -335,7 +306,7 @@ int nic_rawsock_initialize(struct uet_nic *nic)
 	if ((ioctl(rdata->sock_fd.fd, SIOCGIFINDEX, &rdata->ifr)) < 0) {
 		UET_API_PRINT_ERRNO("socket ioctl");
 		UET_API_ERR("bad interface device name");
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto err_return;
 	}
 
@@ -348,7 +319,7 @@ int nic_rawsock_initialize(struct uet_nic *nic)
 	if (bind(rdata->sock_fd.fd, (struct sockaddr *) &rdata->sadr,
 		 sizeof(struct sockaddr_ll)) < 0) {
 		UET_API_PRINT_ERRNO("socket bind");
-		rc = -FI_EIO;
+		rc = -EIO;
 		goto err_return;
 	}
 
@@ -356,7 +327,7 @@ int nic_rawsock_initialize(struct uet_nic *nic)
 	if ((ioctl(rdata->sock_fd.fd, SIOCGIFADDR, &rdata->ifr)) < 0) {
 		UET_API_PRINT_ERRNO("socket ioctl");
 		UET_API_ERR("Error getting IP address of local device");
-		rc = -FI_EIO;
+		rc = -EIO;
 		goto err_return;
 	}
 	ip = &rdata->ifr.ifr_hwaddr.sa_data[2];
@@ -367,7 +338,7 @@ int nic_rawsock_initialize(struct uet_nic *nic)
 	if ((ioctl(rdata->sock_fd.fd, SIOCGIFHWADDR, &rdata->ifr)) < 0) {
 		UET_API_PRINT_ERRNO("socket ioctl");
 		UET_API_ERR("Error getting MAC addr of local device");
-		rc = -FI_EIO;
+		rc = -EIO;
 		goto err_return;
 	}
 	memcpy(nic->mac_addr, rdata->ifr.ifr_hwaddr.sa_data, ETH_ALEN);
@@ -382,7 +353,7 @@ int nic_rawsock_initialize(struct uet_nic *nic)
 	nic->mtu = (size_t)rdata->ifr.ifr_mtu;
 	nic->max_pkt_size = (nic->mtu + nic->l2_hdr_size);
 
-	return FI_SUCCESS;
+	return 0;
 
 err_return:
 	nic_rawsock_finalize(nic);

--- a/nic_shim/nic_xdp.c
+++ b/nic_shim/nic_xdp.c
@@ -99,63 +99,30 @@ struct xdp_data {
 	int sock_fd;
 };
 
-/* get nic info for libfabric fid_nic struct */
+/* get nic info */
 int nic_xdp_getinfo(struct uet_nic *nic,
-		    struct fid_nic *fnic)
+		    struct uet_nic_info *nic_info)
 {
 	struct xdp_data *xdata = (struct xdp_data *)nic->nic_priv_data;
-	struct ifreq ifr;	  /* socket interface request struct */
-	int rc;
-
-	/* allocate memory for nic structs */
-	fnic->device_attr = calloc(1, sizeof(struct fi_device_attr));
-	if (fnic->device_attr == NULL) {
-		UET_API_PRINT_ERRNO("calloc");
-		rc = -FI_ENOMEM;
-		goto exit_err;
-	}
-
-	fnic->link_attr = calloc(1, sizeof(struct fi_link_attr));
-	if (fnic->link_attr == NULL) {
-		UET_API_PRINT_ERRNO("calloc");
-		rc = -FI_ENOMEM;
-		goto exit_err;
-	}
+	struct ifreq ifr;
 
 	/* get the interface flags */
 	strcpy(ifr.ifr_name, nic->ifname);
 	if ((ioctl(xdata->sock_fd, SIOCGIFFLAGS, &ifr)) < 0) {
 		UET_API_ERR("ERROR: Failed to get interface flags");
-		rc = -FI_ENODEV;
-		goto exit_err;
+		return -ENODEV;
 	}
 
-	/* init from the NIC info */
-	fnic->device_attr->name       = nic->ifname;
-	fnic->link_attr->mtu          = nic->mtu;
-	fnic->link_attr->network_type = nic->network_type;
-	fnic->link_attr->address      = nic->mac_addr_str;
+	nic_info->ifname = nic->ifname;
+	nic_info->network_type = nic->network_type;
+	nic_info->mac_addr_str = nic->mac_addr_str;
+	nic_info->mtu = nic->mtu;
 
-	if (ifr.ifr_flags & IFF_UP)
-		fnic->link_attr->state = FI_LINK_UP;
-	else
-		fnic->link_attr->state = FI_LINK_DOWN;
+	nic_info->link_state =
+		(ifr.ifr_flags & IFF_UP)
+			? UET_NIC_LINK_STATE_UP : UET_NIC_LINK_STATE_DOWN;
 
-	return FI_SUCCESS;
-
-exit_err:
-
-	if (fnic->device_attr) {
-		free(fnic->device_attr);
-		fnic->device_attr = NULL;
-	}
-
-	if (fnic->link_attr) {
-		free(fnic->link_attr);
-		fnic->link_attr = NULL;
-	}
-
-	return rc;
+	return 0;
 }
 
 /* get next-hop info for ipv4 destination address */
@@ -187,7 +154,7 @@ int nic_xdp_get_ipv4_nh(struct uet_nic *nic,
 	if (cmd_stream == NULL) {
 		UET_API_ERR("ERROR: Failed to get next-hop IP address");
 		pclose(cmd_stream);
-		return -FI_EIO;
+		return -EIO;
 	}
 
 	for (i = 0; i < INET_ADDRSTRLEN; i++) {
@@ -201,7 +168,7 @@ int nic_xdp_get_ipv4_nh(struct uet_nic *nic,
 	if (i == INET_ADDRSTRLEN) {
 		UET_API_ERR("ERROR: Failed to parse next-hop IP address");
 		pclose(cmd_stream);
-		return -FI_EIO;
+		return -EIO;
 	}
 
 	inet_pton(AF_INET, nic->nh_ip_addr_str, &nh_ipv4);
@@ -234,15 +201,15 @@ int nic_xdp_get_ipv4_nh(struct uet_nic *nic,
 	strcpy(areq.arp_dev, nic->ifname);
 	if (ioctl(xdata->sock_fd, SIOCGARP, (caddr_t)&areq) < 0) {
 		UET_API_ERR("ERROR: Failed getting ARP entry");
-		return -FI_EIO;
+		return -EIO;
 	}
 	memcpy(mac, areq.arp_ha.sa_data, ETH_ALEN);
 
-	rc = FI_SUCCESS;
+	rc = 0;
 	memset(invalid_mac, 0, ETH_ALEN);
 	if (memcmp(mac, invalid_mac, ETH_ALEN) == 0) {
 		UET_API_ERR("ERROR: Failed to resolve next-hop MAC addr");
-		rc = -FI_ENETUNREACH;
+		rc = -ENETUNREACH;
 	}
 
 	printf("Next-Hop Address Resolution\n");
@@ -313,7 +280,7 @@ int nic_xdp_tx_pkt(struct uet_nic *nic,
 	}
 
 	if (pkt_size > XSK_FRAME_SIZE)
-		return -FI_EIO;
+		return -EIO;
 
 	/* Get the desc at the next Tx ring producer index. */
 	tx_desc = xsk_ring_prod__tx_desc(&xsk->tx, idx);
@@ -341,7 +308,7 @@ int nic_xdp_tx_pkt(struct uet_nic *nic,
 	/* Process any outstanding completions... */
 	nic_xdp_tx_complete(xsk, BATCH_SIZE);
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 /* receive a packet */
@@ -694,7 +661,7 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	/* Make sure we can abuse memory usage! */
 	if (setrlimit(RLIMIT_MEMLOCK, &r)) {
 		UET_API_ERR("ERROR: setrlimit(RLIMIT_MEMLOCK)");
-		return -FI_ENODEV;
+		return -ENODEV;
 	}
 
 	/* Configure sched priority for better wake-up accuracy */
@@ -703,13 +670,13 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	rc = sched_setscheduler(0, SCHED_OTHER, &schparam);
 	if (rc) {
 		UET_API_ERR("ERROR: Failed to set scheduler priority");
-		return -FI_ENODEV;
+		return -ENODEV;
 	}
 
 	xdata = calloc(1, sizeof(struct xdp_data));
 	if (xdata == NULL) {
 		UET_API_ERR("ERROR: Failed to alloc XDP priv data");
-		return -FI_ENODEV;
+		return -ENODEV;
 	}
 
 	nic->nic_priv_data = (void *)xdata;
@@ -723,7 +690,7 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	ifname = getenv(UET_IFNAME);
 	if (ifname == NULL) {
 		UET_API_ERR("ERROR: unknown UET_IFNAME environment variable");
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto exit_err;
 	}
 
@@ -735,7 +702,7 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	if (!xdata->xdp_ifindex) {
 		UET_API_ERR("ERROR: Interface %s does not exist",
 			    nic->ifname);
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto exit_err;
 	}
 
@@ -745,7 +712,7 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	if (rc) {
 		libxdp_strerror(rc, err_msg, sizeof(err_msg));
 		UET_API_ERR("ERROR: Failed to load XDP program: %s", err_msg);
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto exit_err;
 	}
 
@@ -755,7 +722,7 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	if (rc) {
 		libxdp_strerror(rc, err_msg, sizeof(err_msg));
 		UET_API_ERR("ERROR: Failed to attach XDP program: %s", err_msg);
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto exit_err;
 	}
 
@@ -769,7 +736,7 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	if (xdata->mem == MAP_FAILED) {
 		xdata->mem = NULL;
 		UET_API_ERR("ERROR: mmap failed");
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto exit_err;
 	}
 
@@ -778,7 +745,7 @@ int nic_xdp_initialize(struct uet_nic *nic)
 						 xdata->mem_size);
 	if (xdata->umem == NULL) {
 		UET_API_ERR("ERROR: Failed to configure XSK umem");
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto exit_err;
 	}
 
@@ -786,7 +753,7 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	rc = nic_xdp_xsk_init_fill_ring(xdata->umem);
 	if (rc < 0) {
 		UET_API_ERR("ERROR: Failed to fill the fill ring");
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto exit_err;
 	}
 
@@ -797,7 +764,7 @@ int nic_xdp_initialize(struct uet_nic *nic)
 						  nic->ifname);
 		if (xdata->xsks[i] == NULL) {
 			UET_API_ERR("ERROR: Failed to create XSK socket");
-			rc = -FI_ENODEV;
+			rc = -ENODEV;
 			goto exit_err;
 		}
 	}
@@ -806,7 +773,7 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	rc = nic_xdp_config_xsks_map(xdata);
 	if (rc < 0) {
 		UET_API_ERR("ERROR: Failed to configure XSKs map");
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto exit_err;
 	}
 
@@ -818,7 +785,7 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	xdata->sock_fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
 	if (xdata->sock_fd == -1) {
 		UET_API_ERR("ERROR: Failed to create control socket");
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto exit_err;
 	}
 
@@ -828,7 +795,7 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	ifr.ifr_addr.sa_family = AF_INET;
 	if ((ioctl(xdata->sock_fd, SIOCGIFADDR, &ifr)) < 0) {
 		UET_API_ERR("ERROR: Failed to get local IPv4 address");
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto exit_err;
 	}
 	ip = &ifr.ifr_addr.sa_data[2];
@@ -838,7 +805,7 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	/* get the MAC address of the interface */
 	if ((ioctl(xdata->sock_fd, SIOCGIFHWADDR, &ifr)) < 0) {
 		UET_API_ERR("ERROR: Failed to get local MAC address");
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto exit_err;
 	}
 	memcpy(nic->mac_addr, ifr.ifr_hwaddr.sa_data, ETH_ALEN);
@@ -847,13 +814,13 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	/* get the MTU of the interface */
 	if ((ioctl(xdata->sock_fd, SIOCGIFMTU, &ifr)) < 0) {
 		UET_API_ERR("ERROR: Failed to get MTU");
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto exit_err;
 	}
 	nic->mtu = (size_t)ifr.ifr_mtu;
 	nic->max_pkt_size = (nic->mtu + nic->l2_hdr_size);
 
-	return FI_SUCCESS;
+	return 0;
 
 exit_err:
 

--- a/nic_shim/uet_nic.c
+++ b/nic_shim/uet_nic.c
@@ -8,36 +8,23 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <rdma/fabric.h>
-
 #include "uet_api_private.h"
 #include "uet_nic.h"
 
-/* nic operation close function */
-static int uet_nic_close(struct fid *fid)
+int uet_nic_getinfo(struct uet_nic *nic,
+		    struct uet_nic_info *nic_info)
 {
-	struct fid_nic *fnic;
+	if (!nic || !nic_info)
+		assert(0);
 
-	fnic = (struct fid_nic *)fid;
-	if (fnic != NULL) {
-		if (fnic->device_attr != NULL) {
-			free(fnic->device_attr);
-			fnic->device_attr = NULL;
-		}
-		if (fnic->link_attr != NULL) {
-			free(fnic->link_attr);
-			fnic->link_attr = NULL;
-		}
+	memset(nic_info, 0, sizeof(struct uet_nic_info));
 
-		free(fnic);
-	}
-
-	return FI_SUCCESS;
+	return nic->nic_getinfo(nic, nic_info);
 }
 
 /* Raw Socket NIC protocol callbacks */
 extern int nic_rawsock_getinfo(struct uet_nic *nic,
-			       struct fid_nic *fnic);
+			       struct uet_nic_info *nic_info);
 extern int nic_rawsock_get_ipv4_nh(struct uet_nic *nic,
 				   uint32_t dst_ip,
 				   uint8_t *mac);
@@ -56,7 +43,7 @@ extern int nic_rawsock_initialize(struct uet_nic *nic);
 #if ENABLE_XDP
 /* XDP NIC protocol callbacks */
 extern int nic_xdp_getinfo(struct uet_nic *nic,
-			   struct fid_nic *fnic);
+			   struct uet_nic_info *nic_info);
 extern int nic_xdp_get_ipv4_nh(struct uet_nic *nic,
 			       uint32_t dst_ip,
 			       uint8_t *mac);
@@ -107,11 +94,8 @@ int uet_nic_initialize(struct uet_nic *nic)
 #endif
 	} else {
 		UET_API_ERR("invalid UET_NIC_SHIM environment variable");
-		return -FI_ENODEV;
+		return -ENODEV;
 	}
-
-	nic->nic_ops.size = sizeof(struct fi_ops);
-	nic->nic_ops.close = uet_nic_close;
 
 	return nic->nic_initialize(nic);
 }

--- a/nic_shim/uet_nic.h
+++ b/nic_shim/uet_nic.h
@@ -14,8 +14,6 @@
 #include <netinet/in.h>
 #include <linux/if_ether.h>
 
-#include <rdma/fabric.h>
-
 //#define UET_NIC_DEBUG_HEXDUMP
 
 /* environment variables to control the NIC interface */
@@ -29,6 +27,20 @@
 
 struct uet_mr_buf_desc;
 struct uet_instance;
+
+enum uet_nic_link_state {
+	UET_NIC_LINK_STATE_UNKNOWN = 0,
+	UET_NIC_LINK_STATE_DOWN    = 1,
+	UET_NIC_LINK_STATE_UP      = 2
+};
+
+struct uet_nic_info {
+	char *ifname;
+	char *network_type;
+	char *mac_addr_str;
+	size_t mtu;
+	enum uet_nic_link_state link_state;
+};
 
 /* nic control block structure - field of struct uet_instance */
 struct uet_nic {
@@ -51,13 +63,11 @@ struct uet_nic {
 
 	uint8_t uet_ipproto;           /* ip protocol number for uet */
 
-	struct fi_ops nic_ops;     /* libfabric nic operation struct */
-
 	void *nic_priv_data;
 
 	/* function pointers supporting different NIC interfaces */
 	int (*nic_getinfo)(struct uet_nic *nic,
-			   struct fid_nic *fnic);
+			   struct uet_nic_info *nic_info);
 	int (*nic_get_ipv4_nh)(struct uet_nic *nic,
 			       uint32_t dst_ip,
 			       uint8_t *mac);
@@ -85,8 +95,8 @@ struct uet_nic {
  *      uet - ptr to uet nic struct
  *
  * returns:
- *      FI_SUCCESS on success
- *      negative value corresponding to fabric errno on error
+ *      0 on success
+ *      negative value corresponding to errno on error
  */
 int uet_nic_initialize(struct uet_nic *nic);
 
@@ -105,24 +115,18 @@ static inline void uet_nic_finalize(struct uet_nic *nic)
 }
 
 /*
- * get nic info for libfabric fid_nic struct
+ * get nic info
  *
  * parms:
- *      uet - ptr to uet nic struct
- *      nic - ptr to nic info struct to be init
+ *      nic - ptr to uet nic struct
+ *      nic_info - ptr to uet nic info struct to be filled in
  *
  * returns:
- *      FI_SUCCESS on success
- *      negative value corresponding to fabric errno on error
+ *      0 on success
+ *      negative value corresponding to errno on error
  */
-static inline int uet_nic_getinfo(struct uet_nic *nic,
-				  struct fid_nic *fnic)
-{
-	if (!nic || !fnic)
-		assert(0);
-
-	return nic->nic_getinfo(nic, fnic);
-}
+int uet_nic_getinfo(struct uet_nic *nic,
+		    struct uet_nic_info *nic_info);
 
 /*
  * get next-hop info for ipv4 destination address
@@ -133,8 +137,8 @@ static inline int uet_nic_getinfo(struct uet_nic *nic,
  *      mac    - ptr to location where mac address is to be returned
  *
  * returns:
- *      FI_SUCCESS on success
- *      negative value corresponding to fabric errno on error
+ *      0 on success
+ *      negative value corresponding to errno on error
  */
 static inline int uet_nic_get_ipv4_nh(struct uet_nic *nic,
 				      uint32_t dst_ip,
@@ -156,8 +160,8 @@ static inline int uet_nic_get_ipv4_nh(struct uet_nic *nic,
  *      pkt_size - size of packet to send in bytes
  *
  * returns:
- *      FI_SUCCESS on success,
- *      negative value corresponding to fabric errno on error
+ *      0 on success,
+ *      negative value corresponding to errno on error
  */
 static inline int uet_nic_tx_pkt(struct uet_nic *nic,
 				 void *pkt,
@@ -183,7 +187,7 @@ static inline int uet_nic_tx_pkt(struct uet_nic *nic,
  * returns:
  *      0, no valid packet available
  *      1, read a packet
- *      negative value corresponding to fabric errno, err reading packet
+ *      negative value corresponding to errno, err reading packet
  */
 static inline int uet_nic_rx_pkt(struct uet_nic *nic,
 				 void *pkt,
@@ -205,7 +209,7 @@ static inline int uet_nic_rx_pkt(struct uet_nic *nic,
  * returns:
  *      0, no packet is available
  *      1, packet is available
- *      negative value corresponding to fabric errno, poll err
+ *      negative value corresponding to errno, poll err
  */
 static inline int uet_nic_rx_poll(struct uet_nic *nic)
 {

--- a/scripts/uet_test.sh
+++ b/scripts/uet_test.sh
@@ -30,35 +30,36 @@ fi
 
 banner()
 {
-	echo ""
-	echo "**************************************************************"
-	echo "* --> ${1}"
-	echo "**************************************************************"
-	echo ""
+        echo ""
+        echo "**************************************************************"
+        echo "* --> ${1}"
+        echo "**************************************************************"
+        echo ""
 
-	# sleep call is to give enough time for the server to start up
-	if [ -n "$IS_CLI" ]; then
-	    sleep 1
-	fi
+        # sleep call is to give enough time for the server to start up
+        if [ -n "$IS_CLI" ]; then
+            sleep 1
+        fi
 }
 
 CMD_CLI="LD_LIBRARY_PATH=${LIBFABRIC} UET_IFNAME=${CLI_IFACE} ./uet client"
 CMD_SRV="LD_LIBRARY_PATH=${LIBFABRIC} UET_IFNAME=${SRV_IFACE} ./uet server"
 
 tests=("" "tag" "rma")
+tests=("rma")
 
 function sng()
 {
     EX_DEFS="UET_PDS=sng"
     for test in "${tests[@]}"; do
-	banner "SNG $test"
+        banner "SNG $test"
         if [ -n "$IS_CLI" ]; then
-	    CMD="${CMD_CLI} $test ${SRV_IP}"
+            CMD="${CMD_CLI} $test ${SRV_IP}"
         else
-	    CMD="${CMD_SRV} $test ${CLI_IP}"
+            CMD="${CMD_SRV} $test ${CLI_IP}"
         fi
-	CMD="sudo ${EX_DEFS} ${CMD}"
-	echo $CMD; eval $CMD
+        CMD="sudo ${EX_DEFS} ${CMD}"
+        echo $CMD; eval $CMD
     done
 }
 
@@ -66,14 +67,14 @@ function pds()
 {
     EX_DEFS="UET_PDS=pds"
     for test in "${tests[@]}"; do
-	banner "PDS $test"
-	if [ -n "$IS_CLI" ]; then
-	    CMD="${CMD_CLI} ${SRV_IP}"
-	else
-	    CMD="${CMD_SRV} ${CLI_IP}"
-	fi
-	CMD="sudo ${EX_DEFS} ${CMD}"
-	echo $CMD; eval $CMD
+        banner "PDS $test"
+        if [ -n "$IS_CLI" ]; then
+            CMD="${CMD_CLI} $test ${SRV_IP}"
+        else
+            CMD="${CMD_SRV} $test ${CLI_IP}"
+        fi
+        CMD="sudo ${EX_DEFS} ${CMD}"
+        echo $CMD; eval $CMD
     done
 }
 
@@ -81,14 +82,14 @@ function pds_direct()
 {
     EX_DEFS="UET_PDS=pds UET_SEC_MODE=direct"
     for test in "${tests[@]}"; do
-	banner "PDS w/ SEC=direct $test"
-	if [ -n "$IS_CLI" ]; then
-	    CMD="${CMD_CLI} ${SRV_IP}"
-	else
-	    CMD="${CMD_SRV} ${CLI_IP}"
-	fi
-	CMD="sudo ${EX_DEFS} ${CMD}"
-	echo $CMD; eval $CMD
+        banner "PDS w/ SEC=direct $test"
+        if [ -n "$IS_CLI" ]; then
+            CMD="${CMD_CLI} $test ${SRV_IP}"
+        else
+            CMD="${CMD_SRV} $test ${CLI_IP}"
+        fi
+        CMD="sudo ${EX_DEFS} ${CMD}"
+        echo $CMD; eval $CMD
     done
 }
 
@@ -96,14 +97,14 @@ function pds_cluster()
 {
     EX_DEFS="UET_PDS=pds UET_SEC_MODE=cluster"
     for test in "${tests[@]}"; do
-	banner "PDS w/ SEC=cluster $test"
-	if [ -n "$IS_CLI" ]; then
-	    CMD="${CMD_CLI} ${SRV_IP}"
-	else
-	    CMD="${CMD_SRV} ${CLI_IP}"
-	fi
-	CMD="sudo ${EX_DEFS} ${CMD}"
-	echo $CMD; eval $CMD
+        banner "PDS w/ SEC=cluster $test"
+        if [ -n "$IS_CLI" ]; then
+            CMD="${CMD_CLI} $test ${SRV_IP}"
+        else
+            CMD="${CMD_SRV} $test ${CLI_IP}"
+        fi
+        CMD="sudo ${EX_DEFS} ${CMD}"
+        echo $CMD; eval $CMD
     done
 }
 
@@ -111,14 +112,14 @@ function pds_cluster_ssi()
 {
     EX_DEFS="UET_PDS=pds UET_SEC_MODE=cluster"
     for test in "${tests[@]}"; do
-	banner "PDS w/ SEC=cluster (SSI) $test"
-	if [ -n "$IS_CLI" ]; then
-	    CMD="UET_SEC_SSI=${CLI_SSI} ${CMD_CLI} ${SRV_IP}"
-	else
-	    CMD="UET_SEC_SSI=${SRV_SSI} ${CMD_SRV} ${CLI_IP}"
-	fi
-	CMD="sudo ${EX_DEFS} ${CMD}"
-	echo $CMD; eval $CMD
+        banner "PDS w/ SEC=cluster (SSI) $test"
+        if [ -n "$IS_CLI" ]; then
+            CMD="UET_SEC_SSI=${CLI_SSI} ${CMD_CLI} $test ${SRV_IP}"
+        else
+            CMD="UET_SEC_SSI=${SRV_SSI} ${CMD_SRV} $test ${CLI_IP}"
+        fi
+        CMD="sudo ${EX_DEFS} ${CMD}"
+        echo $CMD; eval $CMD
     done
 }
 
@@ -126,14 +127,14 @@ function pds_server_ssi()
 {
     EX_DEFS="UET_PDS=pds UET_SEC_MODE=server"
     for test in "${tests[@]}"; do
-	banner "PDS w/ SEC=server (SSI) $test"
-	if [ -n "$IS_CLI" ]; then
-	    CMD="UET_SEC_SSI=${CLI_SSI} ${CMD_CLI} ${SRV_IP}"
-	else
-	    CMD="UET_SEC_SSI=${SRV_SSI} UET_SEC_CLIENT_SSI=${CLI_SSI} ${CMD_SRV} ${CLI_IP}"
-	fi
-	CMD="sudo ${EX_DEFS} ${CMD}"
-	echo $CMD; eval $CMD
+        banner "PDS w/ SEC=server (SSI) $test"
+        if [ -n "$IS_CLI" ]; then
+            CMD="UET_SEC_SSI=${CLI_SSI} ${CMD_CLI} $test ${SRV_IP}"
+        else
+            CMD="UET_SEC_SSI=${SRV_SSI} UET_SEC_CLIENT_SSI=${CLI_SSI} ${CMD_SRV} $test ${CLI_IP}"
+        fi
+        CMD="sudo ${EX_DEFS} ${CMD}"
+        echo $CMD; eval $CMD
     done
 }
 

--- a/scripts/uet_test.sh
+++ b/scripts/uet_test.sh
@@ -30,23 +30,22 @@ fi
 
 banner()
 {
-        echo ""
-        echo "**************************************************************"
-        echo "* --> ${1}"
-        echo "**************************************************************"
-        echo ""
+    echo ""
+    echo "**************************************************************"
+    echo "* --> ${1}"
+    echo "**************************************************************"
+    echo ""
 
-        # sleep call is to give enough time for the server to start up
-        if [ -n "$IS_CLI" ]; then
-            sleep 1
-        fi
+    # sleep call is to give enough time for the server to start up
+    if [ -n "$IS_CLI" ]; then
+        sleep 1
+    fi
 }
 
 CMD_CLI="LD_LIBRARY_PATH=${LIBFABRIC} UET_IFNAME=${CLI_IFACE} ./uet client"
 CMD_SRV="LD_LIBRARY_PATH=${LIBFABRIC} UET_IFNAME=${SRV_IFACE} ./uet server"
 
 tests=("" "tag" "rma")
-tests=("rma")
 
 function sng()
 {

--- a/scripts/uet_test.sh
+++ b/scripts/uet_test.sh
@@ -15,18 +15,64 @@ SRV_SSI=1
 
 # DON'T EDIT BEYOND THIS POINT
 
+function usage()
+{
+    echo "Usage: $0 <client|server> <test> [<pds>]"
+    echo ""
+    echo "   <test> = all"
+    echo "            rma"
+    echo "            tag"
+    echo "            tag_any_src"
+    echo "            unexp_untag"
+    echo "            unexp_tag"
+    echo "            defer_send"
+    echo "            defer_tag"
+    echo "            defer_tag_any_src"
+    echo ""
+    echo "    <pds> = all"
+    echo "            sng"
+    echo "            pds"
+    echo "            pds_direct"
+    echo "            pds_cluster"
+    echo "            pds_cluster_ssi"
+    echo "            pds_server_ssi"
+    echo ""
+    exit 1
+}
+
 IS_CLI=
 if [ "$1" = client ]; then
     IS_CLI=yes
 elif [ "$1" != server ]; then
-    echo "Usage: $0 <client|server> [<test>]"
-    echo ""
-    echo "  Default is to run ALL tests!"
-    echo "    <test> = sng, pds, pds_direct, pds_cluster,"
-    echo "             pds_cluster_ssi, pds_server_ssi"
-    echo ""
-    exit 1
+    echo "ERROR: must specify client or server"
+    usage
 fi
+
+if [ "$2" != all -a \
+     "$2" != rma -a \
+     "$2" != tag -a \
+     "$2" != tag_any_src -a \
+     "$2" != unexp_untag -a \
+     "$2" != unexp_tag -a \
+     "$2" != defer_send -a \
+     "$2" != defer_tag -a \
+     "$2" != defer_tag_any_src ]; then
+    echo "ERROR: Invalid test name"
+    usage
+fi
+
+if [ "$3" != all -a \
+     "$3" != sng -a \
+     "$3" != pds -a \
+     "$3" != pds_direct -a \
+     "$3" != pds_cluster -a \
+     "$3" != pds_cluster_ssi -a \
+     "$3" != pds_server_ssi ]; then
+    echo "ERROR: Invalid PDS name"
+    usage
+fi
+
+test=$2
 
 banner()
 {
@@ -35,115 +81,95 @@ banner()
     echo "* --> ${1}"
     echo "**************************************************************"
     echo ""
-
-    # sleep call is to give enough time for the server to start up
-    if [ -n "$IS_CLI" ]; then
-        sleep 1
-    fi
 }
 
 CMD_CLI="LD_LIBRARY_PATH=${LIBFABRIC} UET_IFNAME=${CLI_IFACE} ./uet client"
 CMD_SRV="LD_LIBRARY_PATH=${LIBFABRIC} UET_IFNAME=${SRV_IFACE} ./uet server"
 
-#tests=("" "tag" "rma")
-tests=("test")
-
 function sng()
 {
     EX_DEFS="UET_PDS=sng"
-    for test in "${tests[@]}"; do
-        banner "SNG $test"
-        if [ -n "$IS_CLI" ]; then
-            CMD="${CMD_CLI} $test ${SRV_IP}"
-        else
-            CMD="${CMD_SRV} $test ${CLI_IP}"
-        fi
-        CMD="sudo ${EX_DEFS} ${CMD}"
-        echo $CMD; eval $CMD
-    done
+    banner "SNG $test"
+    if [ -n "$IS_CLI" ]; then
+        CMD="${CMD_CLI} $test ${SRV_IP}"
+    else
+        CMD="${CMD_SRV} $test ${CLI_IP}"
+    fi
+    CMD="sudo ${EX_DEFS} ${CMD}"
+    echo $CMD; eval $CMD
 }
 
 function pds()
 {
     EX_DEFS="UET_PDS=pds"
-    for test in "${tests[@]}"; do
-        banner "PDS $test"
-        if [ -n "$IS_CLI" ]; then
-            CMD="${CMD_CLI} $test ${SRV_IP}"
-        else
-            CMD="${CMD_SRV} $test ${CLI_IP}"
-        fi
-        CMD="sudo ${EX_DEFS} ${CMD}"
-        echo $CMD; eval $CMD
-    done
+    banner "PDS $test"
+    if [ -n "$IS_CLI" ]; then
+        CMD="${CMD_CLI} $test ${SRV_IP}"
+    else
+        CMD="${CMD_SRV} $test ${CLI_IP}"
+    fi
+    CMD="sudo ${EX_DEFS} ${CMD}"
+    echo $CMD; eval $CMD
 }
 
 function pds_direct()
 {
     EX_DEFS="UET_PDS=pds UET_SEC_MODE=direct"
-    for test in "${tests[@]}"; do
-        banner "PDS w/ SEC=direct $test"
-        if [ -n "$IS_CLI" ]; then
-            CMD="${CMD_CLI} $test ${SRV_IP}"
-        else
-            CMD="${CMD_SRV} $test ${CLI_IP}"
-        fi
-        CMD="sudo ${EX_DEFS} ${CMD}"
-        echo $CMD; eval $CMD
-    done
+    banner "PDS w/ SEC=direct $test"
+    if [ -n "$IS_CLI" ]; then
+        CMD="${CMD_CLI} $test ${SRV_IP}"
+    else
+        CMD="${CMD_SRV} $test ${CLI_IP}"
+    fi
+    CMD="sudo ${EX_DEFS} ${CMD}"
+    echo $CMD; eval $CMD
 }
 
 function pds_cluster()
 {
     EX_DEFS="UET_PDS=pds UET_SEC_MODE=cluster"
-    for test in "${tests[@]}"; do
-        banner "PDS w/ SEC=cluster $test"
-        if [ -n "$IS_CLI" ]; then
-            CMD="${CMD_CLI} $test ${SRV_IP}"
-        else
-            CMD="${CMD_SRV} $test ${CLI_IP}"
-        fi
-        CMD="sudo ${EX_DEFS} ${CMD}"
-        echo $CMD; eval $CMD
-    done
+    banner "PDS w/ SEC=cluster $test"
+    if [ -n "$IS_CLI" ]; then
+        CMD="${CMD_CLI} $test ${SRV_IP}"
+    else
+        CMD="${CMD_SRV} $test ${CLI_IP}"
+    fi
+    CMD="sudo ${EX_DEFS} ${CMD}"
+    echo $CMD; eval $CMD
 }
 
 function pds_cluster_ssi()
 {
     EX_DEFS="UET_PDS=pds UET_SEC_MODE=cluster"
-    for test in "${tests[@]}"; do
-        banner "PDS w/ SEC=cluster (SSI) $test"
-        if [ -n "$IS_CLI" ]; then
-            CMD="UET_SEC_SSI=${CLI_SSI} ${CMD_CLI} $test ${SRV_IP}"
-        else
-            CMD="UET_SEC_SSI=${SRV_SSI} ${CMD_SRV} $test ${CLI_IP}"
-        fi
-        CMD="sudo ${EX_DEFS} ${CMD}"
-        echo $CMD; eval $CMD
-    done
+    banner "PDS w/ SEC=cluster (SSI) $test"
+    if [ -n "$IS_CLI" ]; then
+        CMD="UET_SEC_SSI=${CLI_SSI} ${CMD_CLI} $test ${SRV_IP}"
+    else
+        CMD="UET_SEC_SSI=${SRV_SSI} ${CMD_SRV} $test ${CLI_IP}"
+    fi
+    CMD="sudo ${EX_DEFS} ${CMD}"
+    echo $CMD; eval $CMD
 }
 
 function pds_server_ssi()
 {
     EX_DEFS="UET_PDS=pds UET_SEC_MODE=server"
-    for test in "${tests[@]}"; do
-        banner "PDS w/ SEC=server (SSI) $test"
-        if [ -n "$IS_CLI" ]; then
-            CMD="UET_SEC_SSI=${CLI_SSI} ${CMD_CLI} $test ${SRV_IP}"
-        else
-            CMD="UET_SEC_SSI=${SRV_SSI} UET_SEC_CLIENT_SSI=${CLI_SSI} ${CMD_SRV} $test ${CLI_IP}"
-        fi
-        CMD="sudo ${EX_DEFS} ${CMD}"
-        echo $CMD; eval $CMD
-    done
+    banner "PDS w/ SEC=server (SSI) $test"
+    if [ -n "$IS_CLI" ]; then
+        CMD="UET_SEC_SSI=${CLI_SSI} ${CMD_CLI} $test ${SRV_IP}"
+    else
+        CMD="UET_SEC_SSI=${SRV_SSI} UET_SEC_CLIENT_SSI=${CLI_SSI} ${CMD_SRV} $test ${CLI_IP}"
+    fi
+    CMD="sudo ${EX_DEFS} ${CMD}"
+    echo $CMD; eval $CMD
 }
 
-if [ -z "$2" -o "$2" = sng             ]; then sng;             fi
-if [ -z "$2" -o "$2" = pds             ]; then pds;             fi
-if [ -z "$2" -o "$2" = pds_direct      ]; then pds_direct;      fi
-if [ -z "$2" -o "$2" = pds_cluster     ]; then pds_cluster;     fi
-if [ -z "$2" -o "$2" = pds_cluster_ssi ]; then pds_cluster_ssi; fi
-if [ -z "$2" -o "$2" = pds_server_ssi  ]; then pds_server_ssi;  fi
+if [ "$3" = all -o "$3" = sng             ]; then sng;             fi
+if [ "$3" = all -o "$3" = pds             ]; then pds;             fi
+if [ "$3" = all -o "$3" = pds_direct      ]; then pds_direct;      fi
+if [ "$3" = all -o "$3" = pds_cluster     ]; then pds_cluster;     fi
+if [ "$3" = all -o "$3" = pds_cluster_ssi ]; then pds_cluster_ssi; fi
+if [ "$3" = all -o "$3" = pds_server_ssi  ]; then pds_server_ssi;  fi
 
 banner "Done!"
 

--- a/scripts/uet_test.sh
+++ b/scripts/uet_test.sh
@@ -45,7 +45,8 @@ banner()
 CMD_CLI="LD_LIBRARY_PATH=${LIBFABRIC} UET_IFNAME=${CLI_IFACE} ./uet client"
 CMD_SRV="LD_LIBRARY_PATH=${LIBFABRIC} UET_IFNAME=${SRV_IFACE} ./uet server"
 
-tests=("" "tag" "rma")
+#tests=("" "tag" "rma")
+tests=("test")
 
 function sng()
 {

--- a/uet.c
+++ b/uet.c
@@ -99,10 +99,21 @@ typedef enum {
 	fprintf(stdout, "%s(): %s:%-4d, ret = %d (%s)\n",                      \
 		(CALL), __FILE__, __LINE__, errno, strerror(errno))
 
-#define UET_USAGE(PROG_NAME)                                                   \
-	fprintf(stdout,                                                        \
-		"USAGE: %s <server | client [tag | rma] <remote IPv4 addr>\n", \
-		PROG_NAME)
+void UET_USAGE(char *cmd)
+{
+	fprintf(stdout,
+"Usage: %s <server|client> <command> <remote IPv4 addr>\n"
+"  <command>: rma\n"
+"             untag\n"
+"             tag\n"
+"             tag_any_src\n"
+"             unexp_untag\n"
+"             unexp_tag\n"
+"             defer_send\n"
+"             defer_tag\n"
+"             defer_tag_any_src\n",
+cmd);
+}
 
 /* config parm struct */
 struct uet_cfg {
@@ -293,9 +304,9 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 		return UET_ERR_RC;
 	}
 
-	if (!strcmp(argv[1], "client")) {
+	if (strcmp(argv[1], "client") == 0) {
 		ctx->cfg.client = true;
-	} else if (strcmp(argv[1], "server")) {
+	} else if (strcmp(argv[1], "server") != 0) {
 		UET_ERR("Invalid usage: 1st arg must be 'client' "
 			"or 'server'");
 		return UET_ERR_RC;
@@ -304,19 +315,21 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 	ctx->cfg.prog_name = argv[0];
 
 	if (argc == 4) {
-		if (strcmp(argv[2], "tag")) {
-			if (strcmp(argv[2], "rma")) {
+		if (strcmp(argv[2], "tag") != 0) {
+			if (strcmp(argv[2], "rma") != 0) {
 				UET_ERR("Invalid usage: 2nd arg must be "
 					"'tag' or 'rma'");
 				return UET_ERR_RC;
 			}
 
 			ctx->cfg.rma = true;
-		} else
+		} else {
 			ctx->cfg.tag = true;
+		}
 		ctx->cfg.peer_ip_addr_string = argv[3];
-	} else
+	} else {
 		ctx->cfg.peer_ip_addr_string = argv[2];
+	}
 
 	if (inet_pton(AF_INET, ctx->cfg.peer_ip_addr_string,
 		      &peer_in_addr) != 1) {
@@ -348,8 +361,9 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 			ctx->cfg.msg_size = UET_TAG_RENDEZVOUS_SIZE * 2;
 		else
 			ctx->cfg.msg_size = UET_MSG_RENDEZVOUS_SIZE * 2;
-	} else
+	} else {
 		ctx->cfg.msg_size = UET_MSG_SIZE;
+	}
 
 	return UET_SUCCESS_RC;
 }
@@ -1487,10 +1501,23 @@ static int uet_run(int argc, char *argv[], struct uet_context *ctx)
 		UET_USAGE(argv[0]);
 		goto exit;
 	}
+
 	/* init transport */
 	rc = uet_init_transport(ctx);
 	if (rc != UET_SUCCESS_RC)
 		goto exit;
+
+	/*
+	 * HACK: This sleep is here in attempt to align the client and
+	 * server iniitialization phases so they're both ready to start
+	 * processing. When uet_init_tranport() and the underlying NIC_SHIM
+	 * is initialized, a system ping command is executed to learn the
+	 * next hop MAC and IP addresses. If using XDP or rawsock and one
+	 * side isn't ready, the Linux stack will process received packets
+	 * and likely return ICMP unreachable errors (possibly messing up
+	 * the desired UET flow).
+	 */
+	sleep(1);
 
 	for (use_iov = 0; use_iov <= 1; use_iov++) {
 		printf("Starting in %s\n",
@@ -1555,131 +1582,182 @@ exit:
 int main(int argc, char *argv[])
 {
 	int rc, test_argc;
-	char **test_argv;
-	char *local_argv[UET_MAX_ARGS+1];
+	char *test_argv[UET_MAX_ARGS+1];
 	struct uet_context *ctx = &uet_ctx;
+	bool do_all = false;
+	char *cmd, *c_s, *test, *ip;
 
-	if ((argc != 3) && (argc != 4))  {
+	if (argc != 4)  {
 		UET_ERR("Invalid usage: wrong number of args");
+		UET_USAGE(argv[0]);
 		return UET_ERR_RC;
 	}
 
-	if (argc == 3)
-		return uet_run(argc, argv, ctx);
-
-	if (strcmp(argv[2], "test"))
-		return uet_run(argc, argv, ctx);
-
-	if (!strcmp(argv[1], "client"))
+	if (strcmp(argv[1], "client") == 0)
 		ctx->cfg.client = true;
 
-	printf("\nUntagged Message Test\n");
-	printf("=====================\n");
-	test_argc = 3;
-	local_argv[0] = argv[0];
-	local_argv[1] = argv[1];
-	local_argv[2] = argv[3];
-	local_argv[3] = NULL;
-	test_argv = local_argv;
+	if (strcmp(argv[2], "all") == 0)
+		do_all = true;
 
-	rc = uet_run(test_argc, test_argv, ctx);
-	if (rc != UET_SUCCESS_RC)
-		exit(rc);
+	cmd  = argv[0];
+	c_s  = argv[1];
+	test = argv[2];
+	ip   = argv[3];
 
-	printf("\nTagged Message Test\n");
-	printf("===================\n");
-	test_argc = 4;
-	local_argv[2] = "tag";
-	local_argv[3] = argv[3];
-	local_argv[4] = NULL;
-	memset(ctx, 0, sizeof(struct uet_context));
+	if (do_all || (strcmp(test, "rma") == 0)) {
+		printf("\nRMA Test\n");
+		printf(  "========\n");
+		test_argc = 4;
+		test_argv[0] = cmd;
+		test_argv[1] = c_s;
+		test_argv[2] = "rma";
+		test_argv[3] = ip;
+		test_argv[4] = NULL;
+		memset(ctx, 0, sizeof(struct uet_context));
 
-	rc = uet_run(test_argc, test_argv, ctx);
-	if (rc != UET_SUCCESS_RC)
-		exit(rc);
+		rc = uet_run(test_argc, test_argv, ctx);
+		if (rc != UET_SUCCESS_RC)
+			exit(rc);
+	}
 
-	printf("\nTagged Message Test (Any Source)\n");
-	printf("================================\n");
-	memset(ctx, 0, sizeof(struct uet_context));
-	ctx->cfg.tag_any_src = true;
+	if (do_all || (strcmp(test, "untag") == 0)) {
+		printf("\nUntagged Message Test\n");
+		printf(  "=====================\n");
+		test_argc = 3;
+		test_argv[0] = cmd;
+		test_argv[1] = c_s;
+		test_argv[2] = ip;
+		test_argv[3] = NULL;
 
-	rc = uet_run(test_argc, test_argv, ctx);
-	if (rc != UET_SUCCESS_RC)
-		exit(rc);
+		rc = uet_run(test_argc, test_argv, ctx);
+		if (rc != UET_SUCCESS_RC)
+			exit(rc);
+	}
 
-	printf("\nRMA Test\n");
-	printf("========\n");
-	test_argc = 4;
-	local_argv[2] = "rma";
-	memset(ctx, 0, sizeof(struct uet_context));
+	if (do_all || (strcmp(test, "tag") == 0)) {
+		printf("\nTagged Message Test\n");
+		printf(  "===================\n");
+		test_argc = 4;
+		test_argv[0] = cmd;
+		test_argv[1] = c_s;
+		test_argv[2] = "tag";
+		test_argv[3] = ip;
+		test_argv[4] = NULL;
+		memset(ctx, 0, sizeof(struct uet_context));
 
-	rc = uet_run(test_argc, test_argv, ctx);
-	if (rc != UET_SUCCESS_RC)
-		exit(rc);
+		rc = uet_run(test_argc, test_argv, ctx);
+		if (rc != UET_SUCCESS_RC)
+			exit(rc);
+	}
 
-	printf("\nUnexpected Untagged Message Test\n");
-	printf("================================\n");
-	test_argc = 3;
-	local_argv[0] = argv[0];
-	local_argv[1] = argv[1];
-	local_argv[2] = argv[3];
-	local_argv[3] = NULL;
-	test_argv = local_argv;
-	memset(ctx, 0, sizeof(struct uet_context));
-	first = true;
-	ctx->cfg.unexpected_msg_test = true;
+	if (do_all || (strcmp(test, "tag_any_src") == 0)) {
+		printf("\nTagged Message Test (Any Source)\n");
+		printf(  "================================\n");
+		test_argc = 4;
+		test_argv[0] = cmd;
+		test_argv[1] = c_s;
+		test_argv[2] = "tag";
+		test_argv[3] = ip;
+		test_argv[4] = NULL;
+		memset(ctx, 0, sizeof(struct uet_context));
+		ctx->cfg.tag_any_src = true;
 
-	rc = uet_run(test_argc, test_argv, ctx);
-	if (rc != UET_SUCCESS_RC)
-		exit(rc);
+		rc = uet_run(test_argc, test_argv, ctx);
+		if (rc != UET_SUCCESS_RC)
+			exit(rc);
+	}
 
-	printf("\nDeferred Send Message Test\n");
-	printf("==========================\n");
-	memset(ctx, 0, sizeof(struct uet_context));
-	first = true;
-	ctx->cfg.unexpected_msg_test = true;
-	ctx->cfg.dsend_test = true;
+	if (do_all || (strcmp(test, "unexp_untag") == 0)) {
+		printf("\nUnexpected Untagged Message Test\n");
+		printf(  "================================\n");
+		test_argc = 3;
+		test_argv[0] = cmd;
+		test_argv[1] = c_s;
+		test_argv[2] = ip;
+		test_argv[3] = NULL;
+		memset(ctx, 0, sizeof(struct uet_context));
+		first = true;
+		ctx->cfg.unexpected_msg_test = true;
 
-	rc = uet_run(test_argc, test_argv, ctx);
-	if (rc != UET_SUCCESS_RC)
-		exit(rc);
+		rc = uet_run(test_argc, test_argv, ctx);
+		if (rc != UET_SUCCESS_RC)
+			exit(rc);
+	}
 
-	printf("\nUnexpected Tagged Message Test\n");
-	printf("==============================\n");
-	test_argc = 4;
-	local_argv[0] = argv[0];
-	local_argv[1] = argv[1];
-	local_argv[2] = "tag";
-	local_argv[3] = argv[3];
-	local_argv[4] = NULL;
-	test_argv = local_argv;
-	memset(ctx, 0, sizeof(struct uet_context));
-	first = true;
-	ctx->cfg.unexpected_msg_test = true;
+	if (do_all || (strcmp(test, "unexp_tag") == 0)) {
+		printf("\nUnexpected Tagged Message Test\n");
+		printf(  "==============================\n");
+		test_argc = 4;
+		test_argv[0] = cmd;
+		test_argv[1] = c_s;
+		test_argv[2] = "tag";
+		test_argv[3] = ip;
+		test_argv[4] = NULL;
+		memset(ctx, 0, sizeof(struct uet_context));
+		first = true;
+		ctx->cfg.unexpected_msg_test = true;
 
-	rc = uet_run(test_argc, test_argv, ctx);
-	if (rc != UET_SUCCESS_RC)
-		exit(rc);
+		rc = uet_run(test_argc, test_argv, ctx);
+		if (rc != UET_SUCCESS_RC)
+			exit(rc);
+	}
 
-	printf("\nDeferred Tagged Send Message Test\n");
-	printf("=================================\n");
-	memset(ctx, 0, sizeof(struct uet_context));
-	first = true;
-	ctx->cfg.unexpected_msg_test = true;
-	ctx->cfg.dsend_test = true;
+	if (do_all || (strcmp(test, "defer_send") == 0)) {
+		printf("\nDeferred Send Message Test\n");
+		printf(  "==========================\n");
+		test_argc = 3;
+		test_argv[0] = cmd;
+		test_argv[1] = c_s;
+		test_argv[2] = ip;
+		test_argv[3] = NULL;
+		memset(ctx, 0, sizeof(struct uet_context));
+		first = true;
+		ctx->cfg.unexpected_msg_test = true;
+		ctx->cfg.dsend_test = true;
 
-	rc = uet_run(test_argc, test_argv, ctx);
-	if (rc != UET_SUCCESS_RC)
-		exit(rc);
+		rc = uet_run(test_argc, test_argv, ctx);
+		if (rc != UET_SUCCESS_RC)
+			exit(rc);
+	}
 
-	printf("\nDeferred Tagged Send Message Test (Any Source)\n");
-	printf("==============================================\n");
-	memset(ctx, 0, sizeof(struct uet_context));
-	first = true;
-	ctx->cfg.unexpected_msg_test = true;
-	ctx->cfg.dsend_test = true;
-	ctx->cfg.tag_any_src = true;
+	if (do_all || (strcmp(test, "defer_tag") == 0)) {
+		printf("\nDeferred Tagged Send Message Test\n");
+		printf(  "=================================\n");
+		test_argc = 4;
+		test_argv[0] = cmd;
+		test_argv[1] = c_s;
+		test_argv[2] = "tag";
+		test_argv[3] = ip;
+		test_argv[4] = NULL;
+		memset(ctx, 0, sizeof(struct uet_context));
+		first = true;
+		ctx->cfg.unexpected_msg_test = true;
+		ctx->cfg.dsend_test = true;
 
-	rc = uet_run(test_argc, test_argv, ctx);
-	exit(rc);
+		rc = uet_run(test_argc, test_argv, ctx);
+		if (rc != UET_SUCCESS_RC)
+			exit(rc);
+	}
+
+	if (do_all || (strcmp(test, "defer_tag_any_src") == 0)) {
+		printf("\nDeferred Tagged Send Message Test (Any Source)\n");
+		printf(  "==============================================\n");
+		test_argc = 4;
+		test_argv[0] = cmd;
+		test_argv[1] = c_s;
+		test_argv[2] = "tag";
+		test_argv[3] = ip;
+		test_argv[4] = NULL;
+		memset(ctx, 0, sizeof(struct uet_context));
+		first = true;
+		ctx->cfg.unexpected_msg_test = true;
+		ctx->cfg.dsend_test = true;
+		ctx->cfg.tag_any_src = true;
+
+		rc = uet_run(test_argc, test_argv, ctx);
+		if (rc != UET_SUCCESS_RC)
+			exit(rc);
+	}
+
+	exit(0);
 }

--- a/uet.c
+++ b/uet.c
@@ -92,15 +92,15 @@ typedef enum {
 		__FILE__, __LINE__, ##__VA_ARGS__)
 
 #define UET_ERR(fmt, ...)                                                      \
-	fprintf(stderr, "[%s] %s:%-4d: " fmt "\n", "error",                    \
+	fprintf(stdout, "[%s] %s:%-4d: " fmt "\n", "error",                    \
 		__FILE__, __LINE__, ##__VA_ARGS__)
 
 #define UET_PRINT_ERRNO(CALL)                                                  \
-	fprintf(stderr, "%s(): %s:%-4d, ret = %d (%s)\n",                      \
+	fprintf(stdout, "%s(): %s:%-4d, ret = %d (%s)\n",                      \
 		(CALL), __FILE__, __LINE__, errno, strerror(errno))
 
 #define UET_USAGE(PROG_NAME)                                                   \
-	fprintf(stderr,                                                        \
+	fprintf(stdout,                                                        \
 		"USAGE: %s <server | client [tag | rma] <remote IPv4 addr>\n", \
 		PROG_NAME)
 

--- a/uet_api.c
+++ b/uet_api.c
@@ -3410,6 +3410,8 @@ static int uet_tx_msg(struct uet_tx_desc *tx_desc)
 			tx_desc->remaining_bytes -= payload_len;
 			if (tx_desc->desc_flags & UET_TX_DESC_FLAG_READ_REQ)
 				tx_desc->rx_desc->expected_rd_rsp++;
+			/* clear SOM flag after first packet */
+			flags &= ~UET_PDS_FLAG_SOM;
 		} else {
 			if (rc != -FI_EAGAIN)
 				uet_tx_desc_set_err(tx_desc, -rc,

--- a/uet_api.c
+++ b/uet_api.c
@@ -3980,11 +3980,30 @@ int uet_finalize(uet_handle_t handle)
 	return FI_SUCCESS;
 }
 
+static int uet_fid_nic_close(struct fid *fid)
+{
+	struct fid_nic *nic = (struct fid_nic *)fid;
+
+	if (nic == NULL)
+		return 0;
+
+	if (nic->device_attr != NULL)
+		free(nic->device_attr);
+	if (nic->link_attr != NULL)
+		free(nic->link_attr);
+	if (nic->fid.ops != NULL)
+		free(nic->fid.ops);
+	free(nic);
+
+	return 0;
+}
+
 int uet_getinfo(uet_handle_t handle, struct uet_addr *node,
 		const struct fi_info *hints, struct fi_info **info)
 {
 	int rc;
 	struct uet_instance *uet;
+	struct uet_nic_info nic_info;
 	struct fi_info *new_info;
 	struct fid_nic *nic = NULL;
 	struct uet_addr *src_addr;
@@ -4004,15 +4023,50 @@ int uet_getinfo(uet_handle_t handle, struct uet_addr *node,
 		rc = -FI_ENOMEM;
 		goto err_return;
 	}
+
+	nic->device_attr = calloc(1, sizeof(struct fi_device_attr));
+	if (nic->device_attr == NULL) {
+		UET_API_PRINT_ERRNO("calloc");
+		rc = -FI_ENOMEM;
+		goto err_return;
+	}
+
+	nic->link_attr = calloc(1, sizeof(struct fi_link_attr));
+	if (nic->link_attr == NULL) {
+		UET_API_PRINT_ERRNO("calloc");
+		rc = -FI_ENOMEM;
+		goto err_return;
+	}
+
 	nic->fid.fclass = FI_CLASS_NIC;
 	nic->fid.context = uet;
-	nic->fid.ops = &uet->nic.nic_ops;
 
-	rc = uet_nic_getinfo(UET_NIC(uet), nic);
+	nic->fid.ops = calloc(1, sizeof(struct fi_ops));
+	if (nic->link_attr == NULL) {
+		UET_API_PRINT_ERRNO("calloc");
+		rc = -FI_ENOMEM;
+		goto err_return;
+	}
+
+	nic->fid.ops->size = sizeof(struct fi_ops);
+	nic->fid.ops->close = uet_fid_nic_close;
+
+	rc = uet_nic_getinfo(UET_NIC(uet), &nic_info);
 	if (rc != FI_SUCCESS) {
 		UET_API_ERR("uet_nic_getinfo");
 		goto err_return;
 	}
+
+	nic->device_attr->name       = nic_info.ifname;
+	nic->link_attr->network_type = nic_info.network_type;
+	nic->link_attr->address      = nic_info.mac_addr_str;
+	nic->link_attr->mtu          = nic_info.mtu;
+	nic->link_attr->state        =
+		(nic_info.link_state == UET_NIC_LINK_STATE_DOWN)
+			? FI_LINK_DOWN
+			: (nic_info.link_state == UET_NIC_LINK_STATE_UP)
+				? FI_LINK_UP
+				: FI_LINK_UNKNOWN;
 
 	/*
 	 * TODO:
@@ -4050,8 +4104,15 @@ int uet_getinfo(uet_handle_t handle, struct uet_addr *node,
 	return FI_SUCCESS;
 
 err_return:
-	if (nic != NULL)
+	if (nic != NULL) {
+		if (nic->device_attr != NULL)
+			free(nic->device_attr);
+		if (nic->link_attr != NULL)
+			free(nic->link_attr);
+		if (nic->fid.ops != NULL)
+			free(nic->fid.ops);
 		free(nic);
+	}
 	if (new_info != NULL)
 		fi_freeinfo(new_info);
 	return rc;

--- a/uet_api_private.h
+++ b/uet_api_private.h
@@ -63,7 +63,7 @@
 #define UET_TAG_RENDEZVOUS_SIZE		8192
 
 #define UET_API_ERR(fmt, ...)				\
-	fprintf(stderr, "UET API: %s:%-4d: " fmt "\n",	\
+	fprintf(stdout, "UET API: %s:%-4d: " fmt "\n",	\
 		__FILE__, __LINE__, ##__VA_ARGS__)
 
 #define UET_API_DEBUG_ENABLED false /* true => debug messages enabled */
@@ -71,12 +71,12 @@
 #define UET_API_DEBUG(fmt, ...)                                              \
 	do {                                                                 \
 		if (UET_API_DEBUG_ENABLED)                                   \
-			fprintf(stderr, "UET API: [%s] %s:%-4d: " fmt "\n",  \
+			fprintf(stdout, "UET API: [%s] %s:%-4d: " fmt "\n",  \
 				"error", __FILE__, __LINE__, ##__VA_ARGS__); \
 	} while (0)
 
 #define UET_API_PRINT_ERRNO(CALL)                                     \
-	fprintf(stderr, "UET_API: %s(): %s:%-4d, ret = %d (%s)\n",    \
+	fprintf(stdout, "UET_API: %s(): %s:%-4d, ret = %d (%s)\n",    \
 		(CALL), __FILE__, __LINE__, errno, strerror(errno))
 
 typedef uint64_t uet_dma_addr_t;

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -313,7 +313,7 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 	if (pdc->sec_enabled == false) {
 		if (*pp_parsed == false) {
 			rc = uet_parse_pkt(uet, *pkt, *pkt_len, pp);
-			if (rc != FI_SUCCESS) {
+			if (rc != 0) {
 				UET_PDS_ERR("malformed %s packet",
 					    (tx_pkt) ? "Tx" : "ACK");
 				return rc;
@@ -344,7 +344,7 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 
 	if (is_rtx) {
 		rc = uet_sec_update_hdr_tsc(*pkt);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 	} else {
 		rc = uet_sec_build_hdr(pdc->sdi,
@@ -355,7 +355,7 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 				       *pkt_len,
 				       &new_pkt,
 				       &new_pkt_len);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 
 		*pkt     = new_pkt;
@@ -369,7 +369,7 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 	/* If the packet hasn't been parsed yet for debug then do it now. */
 	if (*pp_parsed == false) {
 		rc = uet_parse_pkt(uet, *pkt, *pkt_len, pp);
-		if (rc != FI_SUCCESS) {
+		if (rc != 0) {
 			UET_PDS_ERR("malformed %s packet with security",
 				    (tx_pkt) ? "Tx" : "ACK");
 			return rc;
@@ -389,7 +389,7 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 			     *pkt_len,
 			     &new_pkt,
 			     &new_pkt_len);
-	if (rc != FI_SUCCESS)
+	if (rc != 0)
 		return rc;
 
 	if (tx_pkt)
@@ -403,7 +403,7 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
  * Returns:
  *   0, no valid packet available
  *   1, read a packet
- *   negative value corresponding to fabric errno, err reading packet
+ *   negative value corresponding to errno, err reading packet
  */
 static int uet_pds_sec_rx_pkt(struct uet_instance *uet,
 			      uint8_t **pkt,
@@ -425,7 +425,7 @@ static int uet_pds_sec_rx_pkt(struct uet_instance *uet,
 	*pkt = calloc(1, uet->nic.max_pkt_size);
 	if (*pkt == NULL) {
 		UET_PDS_ERR("failed to alloc Rx packet buffer");
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	/* receive the packet */
@@ -438,7 +438,7 @@ static int uet_pds_sec_rx_pkt(struct uet_instance *uet,
 
 	/* decrypt the packet if the security header is present */
 	rc = uet_sec_dec_pkt(uet, *pkt, *pkt_len, &tag_len);
-	if (rc != FI_SUCCESS)
+	if (rc != 0)
 		goto err_exit;
 
 	return 1;
@@ -653,7 +653,7 @@ static struct uet_pdc *uet_pdsm_assign_tgt_pdc(struct uet_parsed_pkt *pp)
 	pdc = uet_pdsm_alloc_pdc();
 	if (!pdc) {
 		UET_PDS_ERR("no free PDCs available for target");
-		return -FI_ENODEV;
+		return -ENODEV;
 	}
 
 	/* initialze this target PDC and stick it in the hashtable */
@@ -709,7 +709,7 @@ static int uet_pdsm_map_msgid_pdc(uint16_t msg_id,
 	/* TODO: pull msgid_map descriptor from a pool (not malloc) */
 	msgid_map = calloc(1, sizeof(*msgid_map));
 	if (msgid_map == NULL)
-		return -FI_ENOMEM;
+		return -ENOMEM;
 
 	msgid_map->msg_id = msg_id;
 	msgid_map->pdc    = pdc;
@@ -717,7 +717,7 @@ static int uet_pdsm_map_msgid_pdc(uint16_t msg_id,
 	HASH_ADD(msgid_hh, pds_state.pdc_msgid_ht, msg_id,
 		 sizeof(uint16_t), msgid_map);
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static int uet_pdsm_unmap_msgid_pdc(uint16_t msg_id)
@@ -730,13 +730,13 @@ static int uet_pdsm_unmap_msgid_pdc(uint16_t msg_id)
 		  sizeof(uint16_t), msgid_map);
 	if (msgid_map == NULL) {
 		UET_PDS_ERR("msg_id %u not found", msg_id);
-		return -FI_ENOKEY;
+		return -ENOKEY;
 	}
 
 	HASH_DELETE(msgid_hh, pds_state.pdc_msgid_ht, msgid_map);
 	free(msgid_map);
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static struct uet_pdc *uet_pdsm_get_msgid_pdc(uint16_t msg_id)
@@ -769,7 +769,7 @@ static int uet_pdsm_check_pkt(struct uet_pdc_pkt *pdc_pkt)
 	PDS_GO();
 
 	/* TODO: not implemented yet */
-	return -FI_ENOSYS;
+	return -ENOSYS;
 }
 
 static struct uet_pdc *uet_pdsm_check_pdc(struct uet_pdc_pkt *pdc_pkt)
@@ -789,7 +789,7 @@ static int uet_pdsm_check_nack_code(struct uet_pdc_pkt *pdc_pkt)
 	PDS_GO();
 
 	/* TODO: not implemented yet */
-	return -FI_ENOSYS;
+	return -ENOSYS;
 }
 #endif
 
@@ -810,7 +810,7 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 	pdc_pkt = calloc(1, sizeof(struct uet_pdc_pkt));
 	if (pdc_pkt == NULL) {
 		UET_PDS_ERR("failed to alloc PDC packet for close command");
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	/* allocate the packet buffer */
@@ -820,7 +820,7 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 	if (pdc_pkt->pkt_buf == NULL) {
 		UET_PDS_ERR("failed to alloc packet buffer for close command");
 		free(pdc_pkt);
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	/* reserve head space for security header if needed */
@@ -888,7 +888,7 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 
 	/* send the packet */
 	rc = uet_pds_sec_tx_pkt(uet, pdc, pdc_pkt, true, false);
-	if (rc != FI_SUCCESS) {
+	if (rc != 0) {
 		UET_PDS_ERR("failed to send close command for PDC %u",
 			    pdc->pdc_id);
 		free(pdc_pkt->pkt_buf);
@@ -912,7 +912,7 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 	UET_PDS_DBG("PDC %u close command sent (psn=%u)",
 		    pdc->pdc_id, pdc_pkt->psn);
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static int uet_pds_initiate_pdc_close(struct uet_instance *uet,
@@ -922,20 +922,20 @@ static int uet_pds_initiate_pdc_close(struct uet_instance *uet,
 
 	/* bail if the close command has already been sent */
 	if (pdc->close_requested && pdc->close_started)
-		return FI_SUCCESS;
+		return 0;
 
 	UET_PDS_DBG("PDC %u sending close command", pdc->pdc_id);
 
 	if (!pdc->is_initiator) {
 		UET_PDS_ERR("PDC %u is not an initiator, cannot close",
 			    pdc->pdc_id);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	if (pdc->state != PDC_STATE_ESTABLISHED) {
 		UET_PDS_DBG("PDC %u not established (state %d), skip close",
 			    pdc->pdc_id, pdc->state);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	/* set close_requested if not already set */
@@ -945,12 +945,12 @@ static int uet_pds_initiate_pdc_close(struct uet_instance *uet,
 	if (pdc->active_msg_id_valid) {
 		UET_PDS_DBG("PDC %u still has an active message (msg_id %u)",
 			    pdc->pdc_id, pdc->active_msg_id);
-		return -FI_EAGAIN;
+		return -EAGAIN;
 	}
 
 	/* the previous active message has drained, send the close command */
 	rc = uet_pds_send_close_cmd(uet, pdc);
-	if (rc != FI_SUCCESS) {
+	if (rc != 0) {
 		UET_PDS_ERR("PDC %u failed to send close command",
 			    pdc->pdc_id);
 		return rc;
@@ -964,7 +964,7 @@ static int uet_pds_initiate_pdc_close(struct uet_instance *uet,
 
 	UET_PDS_DBG("PDC %u transitioned to the CLOSING state", pdc->pdc_id);
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 /****************************************************************************/
@@ -1007,14 +1007,14 @@ int uet_pds_initialize(struct uet_instance *uet)
 		if (!pdc->tx_bm) {
 			UET_PDS_ERR("failed to create Tx bitmap");
 			uet_pdsm_free_pdc(pdc);
-			return -FI_ENOMEM; /* FIXME unwind and free PDCs */
+			return -ENOMEM; /* FIXME unwind and free PDCs */
 		}
 
 		pdc->rx_bm = bm_create(UET_DEFAULT_MPR);
 		if (!pdc->rx_bm) {
 			UET_PDS_ERR("failed to create Rx bitmap");
 			bm_destroy(pdc->tx_bm);
-			return -FI_ENOMEM; /* FIXME unwind and free PDCs */
+			return -ENOMEM; /* FIXME unwind and free PDCs */
 		}
 
 		dlist_insert_tail(&pdc->node, &pds_state.pdc_free_head);
@@ -1023,7 +1023,7 @@ int uet_pds_initialize(struct uet_instance *uet)
 	/* good to go... */
 	pds_state.ready = true;
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 void uet_pds_finalize(struct uet_instance *uet)
@@ -1076,7 +1076,7 @@ int uet_pds_ep_initialize(struct uet_ep *uet_ep)
 	/* TODO: Anything needed here? */
 	uet_ep->pds = &pds_state;
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 void uet_pds_ep_finalize(struct uet_ep *uet_ep)
@@ -1132,13 +1132,13 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 		break;
 	default:
 		UET_PDS_ERR("unsupported pkt delivery mode %d", mode);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	if ((next_hdr != UET_HDR_REQ_STD) &&
 	    (next_hdr != UET_HDR_RSP_DATA)) {
 		UET_PDS_ERR("unsupported next header type %d", next_hdr);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	/*
@@ -1146,7 +1146,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	 * perform a hash lookup to find the PDC. For a SOM the lookup is
 	 * based on the uet_pdc_ini_key. For a middle or EOM the lookup is
 	 * based on the msg_id. In either case, if a PDC is not found then
-	 * -FI_EAGAIN is returned to indicate the caller should retry. In
+	 * -EAGAIN is returned to indicate the caller should retry. In
 	 * this reference implementation, the SES does the right thing by
 	 * calling the Tx routine again later. This prevents the PDS manager
 	 * from having to maintain a pending packet list that is pulled
@@ -1159,7 +1159,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 			    pds_info->opsn);
 		pdc = uet_pdsm_get_pdc(pds_info->pdcid, true);
 		if (pdc == NULL)
-			return -FI_ENODEV;
+			return -ENODEV;
 	} else if (flags & UET_PDS_FLAG_SOM) {
 		UET_PDS_DBG("SES Tx %p msg_id %u [SOM]%s",
 			    tx_pkt_handle, msg_id,
@@ -1173,11 +1173,11 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 					    "msg_id %u (EAGAIN)",
 					    pdc->pdc_id, pdc->active_msg_id,
 					    msg_id);
-				return -FI_EAGAIN;
+				return -EAGAIN;
 			}
 
 			rc = uet_pdsm_map_msgid_pdc(msg_id, pdc);
-			if (rc != FI_SUCCESS)
+			if (rc != 0)
 				return rc;
 
 			/* set the active message for this PDC */
@@ -1187,7 +1187,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 			UET_PDS_DBG("failed to get PDC for SOM %p "
 				    "msg_id %u (EAGAIN)",
 				    tx_pkt_handle, msg_id);
-			return -FI_EAGAIN;
+			return -EAGAIN;
 		}
 	} else {
 		UET_PDS_DBG("SES Tx %p msg_id %u%s",
@@ -1199,7 +1199,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 			UET_PDS_DBG("failed to get PDC for non-SOM %p "
 				    "msg_id %u (EAGAIN)",
 				    tx_pkt_handle, msg_id);
-			return -FI_EAGAIN;
+			return -EAGAIN;
 		}
 	}
 
@@ -1207,7 +1207,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	    ((pdc->uet_ep != uet_ep) || (pdc->av_entry != av_entry))) {
 		UET_PDS_ERR("PDC %u does not match EP/AV for Tx pkt %p",
 			    pdc->pdc_id, tx_pkt_handle);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	/* for non-SOM packets, verify msg_id matches the active message */
@@ -1216,14 +1216,14 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 			UET_PDS_ERR("PDC %u has no active message, cannot send "
 				    "non-SOM packet for msg_id %u",
 				    pdc->pdc_id, msg_id);
-			return -FI_EINVAL;
+			return -EINVAL;
 		}
 
 		if (pdc->active_msg_id != msg_id) {
 			UET_PDS_ERR("PDC %u active_msg_id %u does not match "
 				    "msg_id %u",
 				    pdc->pdc_id, pdc->active_msg_id, msg_id);
-			return -FI_EINVAL;
+			return -EINVAL;
 		}
 	}
 
@@ -1233,7 +1233,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 		pdc->active_msg_id_valid = false;
 
 		rc = uet_pdsm_unmap_msgid_pdc(msg_id);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 
 		if (flags & UET_PDS_FLAG_MAINTAIN_PDC) {
@@ -1261,7 +1261,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	pdc_pkt = calloc(1, sizeof(struct uet_pdc_pkt));
 	if (pdc_pkt == NULL) {
 		UET_PDS_ERR("failed to alloc PDC packet");
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	pdc_pkt->pkt_buf_len = (uet->nic.max_pkt_size *
@@ -1270,7 +1270,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	if (pdc_pkt->pkt_buf == NULL) {
 		UET_PDS_ERR("failed to alloc packet buffer");
 		free(pdc_pkt);
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	/* reserve head space for security header if needed */
@@ -1369,7 +1369,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 
 	/* send the packet */
 	rc = uet_pds_sec_tx_pkt(uet, pdc, pdc_pkt, true, false);
-	if (rc != FI_SUCCESS) {
+	if (rc != 0) {
 		free(pdc_pkt->pkt_buf);
 		free(pdc_pkt);
 		return rc;
@@ -1398,13 +1398,13 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	if ((pdc->state == PDC_STATE_ESTABLISHED) && pdc->is_initiator &&
 	    pdc->close_requested && !pdc->close_started) {
 		rc = uet_pds_initiate_pdc_close(uet, pdc);
-		if ((rc != FI_SUCCESS) && (rc != -FI_EAGAIN)) {
+		if ((rc != 0) && (rc != -EAGAIN)) {
 			UET_PDS_WARN("PDC %u failed to initiate close (rc=%d)",
 				     pdc->pdc_id, rc);
 		}
 	}
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static int uet_pds_rtx_pkt(struct uet_instance *uet,
@@ -1424,7 +1424,7 @@ static int uet_pds_rtx_pkt(struct uet_instance *uet,
 
 	/* retransmit the packet */
 	rc = uet_pds_sec_tx_pkt(uet, pdc, pdc_pkt, true, true);
-	if (rc != FI_SUCCESS)
+	if (rc != 0)
 		return rc;
 
 	/* the packet was sent successfully */
@@ -1433,7 +1433,7 @@ static int uet_pds_rtx_pkt(struct uet_instance *uet,
 
 	uet_pds_pkt_dbg(uet, &pdc_pkt->pkt_pp, true, "TX PACKET (retransmit)");
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static int uet_pds_check_rtx_pkt(struct uet_instance *uet,
@@ -1446,24 +1446,24 @@ static int uet_pds_check_rtx_pkt(struct uet_instance *uet,
 	uet_gettime(&now);
 	delta = (now - pdc_pkt->tx_time);
 	if (delta < uet->pds.tx_timeout)
-		return FI_SUCCESS; /* no retransmit */
+		return 0; /* no retransmit */
 
 	if (pdc_pkt->tx_retry_cnt >= uet->pds.max_tx_retries) {
 		UET_PDS_ERR("PDC %u PSN %u retry exceeded",
 			    pdc->pdc_id, pdc_pkt->psn);
-		return -FI_EIO; /* assume this PDC is dead */
+		return -EIO; /* assume this PDC is dead */
 	}
 
 	UET_PDS_WARN("PDC %u PSN %u retransmit", pdc->pdc_id, pdc_pkt->psn);
 
 	rc = uet_pds_rtx_pkt(uet, pdc, pdc_pkt);
-	if (rc != FI_SUCCESS) {
+	if (rc != 0) {
 		UET_PDS_ERR("PDC %u PSN %u retransmit failed",
 			    pdc->pdc_id, pdc_pkt->psn);
-		return -FI_EIO; /* assume this PDC is dead */
+		return -EIO; /* assume this PDC is dead */
 	}
 
-	return -FI_EAGAIN; /* pkt retransmitted, could be more */
+	return -EAGAIN; /* pkt retransmitted, could be more */
 }
 
 int uet_pds_progress_tx(struct uet_ep *uet_ep,
@@ -1500,13 +1500,13 @@ int uet_pds_progress_tx(struct uet_ep *uet_ep,
 					     struct uet_pdc_pkt, pdc_pkt,
 					     node, tmp2) {
 			rc = uet_pds_check_rtx_pkt(uet, pdc, pdc_pkt);
-			if (rc == FI_SUCCESS) {
+			if (rc == 0) {
 				break; /* no retransmit, done with this PDC */
-			} else if (rc == -FI_EIO) {
+			} else if (rc == -EIO) {
 				/* TODO: Need to destroy this PDC... */
 				dlist_remove(&pdc_pkt->node);
 				break; /* done with this PDC */
-			} else if (rc == -FI_EAGAIN) {
+			} else if (rc == -EAGAIN) {
 				/*
 				 * This packet was retransmitted, move this
 				 * packet to the end of the list and continue.
@@ -1518,7 +1518,7 @@ int uet_pds_progress_tx(struct uet_ep *uet_ep,
 		}
 	}
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 int uet_pds_msg_cmpl_ind(struct uet_ep *uet_ep,
@@ -1531,7 +1531,7 @@ int uet_pds_msg_cmpl_ind(struct uet_ep *uet_ep,
 
 	pdc = uet_pdsm_get_msgid_pdc(msg_id);
 	if (pdc == NULL)
-		return -FI_EINVAL;
+		return -EINVAL;
 
 	UET_PDS_DBG("PDC %d msg_id %u completion indication from SES",
 		    pdc->pdc_id, msg_id);
@@ -1541,20 +1541,20 @@ int uet_pds_msg_cmpl_ind(struct uet_ep *uet_ep,
 	pdc->active_msg_id_valid = false;
 
 	rc = uet_pdsm_unmap_msgid_pdc(msg_id);
-	if (rc != FI_SUCCESS)
+	if (rc != 0)
 		return rc;
 
 	/* if close was requested and not started, send it now */
 	if (pdc->close_requested && !pdc->close_started) {
 		rc = uet_pds_initiate_pdc_close(uet_ep->uet_domain->uet, pdc);
-		if ((rc != FI_SUCCESS) && (rc != -FI_EAGAIN)) {
+		if ((rc != 0) && (rc != -EAGAIN)) {
 			UET_PDS_ERR("PDC %u failed to initiate close (rc=%d)",
 				    pdc->pdc_id, rc);
 			return rc;
 		}
 	}
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static void uet_pds_build_ack_pkt(struct uet_instance *uet,
@@ -1661,7 +1661,7 @@ static int uet_pds_tx_ack_pkt(struct uet_instance *uet,
 	pdc_pkt->ack_buf = calloc(1, pdc_pkt->ack_buf_len);
 	if (pdc_pkt->ack_buf == NULL) {
 		UET_PDS_ERR("failed to alloc ACK packet buffer");
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	/* reserve head space for security header if needed */
@@ -1677,7 +1677,7 @@ static int uet_pds_tx_ack_pkt(struct uet_instance *uet,
 
 	/* send the ACK packet */
 	rc = uet_pds_sec_tx_pkt(uet, pdc, pdc_pkt, false, false);
-	if (rc != FI_SUCCESS) {
+	if (rc != 0) {
 		pdc_pkt->needs_clear = false;
 		pdc_pkt->ack_len = 0;
 		free(pdc_pkt->ack_buf);
@@ -1686,7 +1686,7 @@ static int uet_pds_tx_ack_pkt(struct uet_instance *uet,
 
 	uet_pds_pkt_dbg(uet, &pdc_pkt->ack_pp, true, "TX ACK PACKET");
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static int uet_pds_tx_def_rsp_ack_pkt(struct uet_instance *uet,
@@ -1719,7 +1719,7 @@ static int uet_pds_tx_def_rsp_ack_pkt(struct uet_instance *uet,
 	def_rsp_buf = calloc(1, def_rsp_buf_len);
 	if (def_rsp_buf == NULL) {
 		UET_PDS_ERR("failed to alloc DEF_RSP ACK packet buffer");
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	/* reserve head space for security header if needed */
@@ -1782,7 +1782,7 @@ static int uet_pds_tx_def_rsp_ack_pkt(struct uet_instance *uet,
 
 	/* send the default response ACK packet */
 	rc = uet_pds_sec_tx_pkt(uet, pdc, &tmp_pdc_pkt, false, false);
-	if (rc != FI_SUCCESS) {
+	if (rc != 0) {
 		free(def_rsp_buf);
 		return rc;
 	}
@@ -1791,7 +1791,7 @@ static int uet_pds_tx_def_rsp_ack_pkt(struct uet_instance *uet,
 			"TX DEF_RSP ACK PACKET (duplicate)");
 
 	free(def_rsp_buf);
-	return FI_SUCCESS;
+	return 0;
 }
 
 static int uet_pds_check_duplicate_and_rtx(struct uet_instance *uet,
@@ -1815,13 +1815,13 @@ static int uet_pds_check_duplicate_and_rtx(struct uet_instance *uet,
 		if (!bm_get(pdc->rx_bm,
 			    (pdc_pkt->pkt_pp.pds_psn - pdc->rx_bm_base_psn),
 			    (void **)&orig_pkt)) {
-			return FI_SUCCESS; /* new PSN */
+			return 0; /* new PSN */
 		}
 	} else {
 		UET_PDS_WARN("invalid PSN %u on PDC %u (outside MPR %u[+/-%u])",
 			     pdc_pkt->pkt_pp.pds_psn, pdc->pdc_id,
 			     pdc->rx_bm_base_psn, UET_DEFAULT_MPR);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	UET_PDS_WARN("duplicate %sPSN %u on PDC %u (ACK retransmit)",
@@ -1832,14 +1832,14 @@ static int uet_pds_check_duplicate_and_rtx(struct uet_instance *uet,
 	if (orig_pkt == NULL) {
 		/* send a default response */
 		rc = uet_pds_tx_def_rsp_ack_pkt(uet, pdc, pdc_pkt);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 
 		*rtx = true;
 	} else if (orig_pkt->ack) {
 		/* resend previous ACK/response */
 		rc = uet_pds_sec_tx_pkt(uet, pdc, orig_pkt, false, true);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 
 		uet_pds_pkt_dbg(uet, &orig_pkt->ack_pp, true,
@@ -1849,10 +1849,10 @@ static int uet_pds_check_duplicate_and_rtx(struct uet_instance *uet,
 	} else {
 		UET_PDS_ERR("no ACK to retransmit PSN %u on PDC %u",
 			    pdc_pkt->pkt_pp.pds_psn, pdc->pdc_id);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static int uet_pds_upcall_ses_rx_req(struct uet_instance *uet,
@@ -1876,7 +1876,7 @@ static int uet_pds_upcall_ses_rx_req(struct uet_instance *uet,
 				 uet->pds.max_ack_data));
 	if (rsp_ses_hdr == NULL) {
 		UET_PDS_ERR("failed to alloc SES response buffer");
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	rc = uet->pds.upcall.rx_req((uet_pkt_handle_t)pdc_pkt, uet,
@@ -1884,7 +1884,7 @@ static int uet_pds_upcall_ses_rx_req(struct uet_instance *uet,
 				    &rsp_next_hdr, rsp_ses_hdr,
 				    &rsp_ses_hdr_len, &ses_nack,
 				    &gtd_del);
-	if (rc == FI_SUCCESS) {
+	if (rc == 0) {
 		/* TODO: add support for sending a PDS NACK
 		 * For now, if this is a bad request, not sending a
 		 * NACK will cause a retransmit of the request packet
@@ -1893,7 +1893,7 @@ static int uet_pds_upcall_ses_rx_req(struct uet_instance *uet,
 		if (ses_nack) {
 			UET_PDS_ERR("PDC %u PSN %u SES NACK",
 				    pdc->pdc_id, pdc_pkt->pkt_pp.pds_psn);
-			rc = -FI_EINVAL;
+			rc = -EINVAL;
 		} else {
 			/* transmit ACK */
 			rc = uet_pds_tx_ack_pkt(uet, pdc, pdc_pkt,
@@ -1958,7 +1958,7 @@ static int uet_pds_shift_rx_window(struct uet_instance *uet,
 				     pdc_pkt->pkt_pp.pds_clear_psn,
 				     pdc_pkt->pkt_pp.pds_dpdcid,
 				     pdc->rx_bm_base_psn, UET_DEFAULT_MPR);
-			return -FI_EINVAL;
+			return -EINVAL;
 		}
 
 		if (clear_to_base_diff > 0) {
@@ -1971,7 +1971,7 @@ static int uet_pds_shift_rx_window(struct uet_instance *uet,
 
 		if (is_rod && !pdc_pkt->reordered) { /* reorder using rx_bm */
 			rc = uet_pds_upcall_ses_rx_req(uet, pdc, pdc_pkt);
-			if (rc != FI_SUCCESS)
+			if (rc != 0)
 				return rc;
 
 			pdc_pkt->reordered = true;
@@ -2001,7 +2001,7 @@ static int uet_pds_shift_rx_window(struct uet_instance *uet,
 #endif
 	(void)shifted;
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static int uet_pds_shift_tx_window(struct uet_instance *uet,
@@ -2044,7 +2044,7 @@ static int uet_pds_shift_tx_window(struct uet_instance *uet,
 #endif
 	(void)shifted;
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static int uet_pds_process_ack(struct uet_instance *uet,
@@ -2074,13 +2074,13 @@ static int uet_pds_process_ack(struct uet_instance *uet,
 
 	pdc = uet_pdsm_get_pdc(pp->pds_dpdcid, false);
 	if (pdc == NULL)
-		return -FI_ENODEV;
+		return -ENODEV;
 
 	if ((pdc->state != PDC_STATE_SYN) &&
 	    (pdc->dpdcid != pp->pds_spdcid)) {
 		UET_PDS_WARN("invalid PDC %u (dpdcid %u != spdcid %u)",
 			     pdc->pdc_id, pdc->dpdcid, pp->pds_spdcid);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	if (!PSN_IN_MPR(pp->pds_psn, pdc->tx_bm_base_psn)) {
@@ -2088,20 +2088,20 @@ static int uet_pds_process_ack(struct uet_instance *uet,
 			     "(outside MPR %u[+%u])",
 			     pp->pds_psn, pp->pds_dpdcid,
 			     pdc->tx_bm_base_psn, UET_DEFAULT_MPR);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	if (!bm_get(pdc->tx_bm, (pp->pds_psn - pdc->tx_bm_base_psn),
 		    (void **)&pdc_pkt)) {
 		UET_PDS_WARN("invalid ACK PSN %u on PDC %u (packet not found)",
 			     pp->pds_psn, pp->pds_dpdcid);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	if (pdc_pkt->tx_pkt_acked) {
 		UET_PDS_WARN("duplicate ACK PSN %u on PDC %u",
 			     pp->pds_psn, pp->pds_dpdcid);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	pdc_pkt->tx_pkt_acked = true;
@@ -2121,7 +2121,7 @@ static int uet_pds_process_ack(struct uet_instance *uet,
 
 		/* shift the tx_bm window for all left edge ACK'ed PSNs */
 		rc = uet_pds_shift_tx_window(uet, pdc);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 
 		/* FIXME, make sure there are no more pending packets */
@@ -2129,7 +2129,7 @@ static int uet_pds_process_ack(struct uet_instance *uet,
 		/* free the PDC */
 		uet_pdsm_free_pdc(pdc);
 
-		return FI_SUCCESS;
+		return 0;
 	}
 
 	if (pdc->state == PDC_STATE_SYN) {
@@ -2142,7 +2142,7 @@ static int uet_pds_process_ack(struct uet_instance *uet,
 	/* upcall for SES processing */
 	if (pp->next_hdr != UET_HDR_NONE) {
 		rc = uet->pds.upcall.rx_rsp(pdc_pkt->tx_pkt_handle, pp);
-		if (rc != FI_SUCCESS) {
+		if (rc != 0) {
 			UET_PDS_ERR("PDC %u ACK PSN %u SES upcall "
 				    "failed (rx_rsp=%d)",
 				    pp->pds_dpdcid, pp->pds_psn, rc);
@@ -2152,7 +2152,7 @@ static int uet_pds_process_ack(struct uet_instance *uet,
 
 	/* shift the tx_bm window for all left edge ACK'ed PSNs */
 	rc = uet_pds_shift_tx_window(uet, pdc);
-	if (rc != FI_SUCCESS)
+	if (rc != 0)
 		return rc;
 
 	/* TODO:
@@ -2172,13 +2172,13 @@ static int uet_pds_process_ack(struct uet_instance *uet,
 	    pdc->close_requested && !pdc->close_started &&
 	    !pdc->active_msg_id_valid) {
 		rc = uet_pds_initiate_pdc_close(uet, pdc);
-		if ((rc != FI_SUCCESS) && (rc != -FI_EAGAIN)) {
+		if ((rc != 0) && (rc != -EAGAIN)) {
 			UET_PDS_WARN("PDC %u failed to initiate close (rc=%d)",
 				     pdc->pdc_id, rc);
 		}
 	}
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static int uet_pds_process_syn_pkt(struct uet_instance *uet,
@@ -2205,15 +2205,15 @@ static int uet_pds_process_syn_pkt(struct uet_instance *uet,
 
 	pdc = uet_pdsm_assign_tgt_pdc(pp);
 	if (pdc == NULL)
-		return -FI_ENODEV;
+		return -ENODEV;
 
 	/* check if this packet is a duplicate */
 	rc = uet_pds_check_duplicate_and_rtx(uet, pdc, pdc_pkt, &rtx);
 	/* TODO: if error, free PDC if allocated with this SYN */
-	if (rc != FI_SUCCESS)
+	if (rc != 0)
 		return rc;
 	else if (rtx)
-		return FI_SUCCESS;
+		return 0;
 
 	UET_PDS_DBG("PDC %u rx_bm: base=%u psn=%u SET bit=%u",
 		    pdc->pdc_id, pdc->rx_bm_base_psn, pp->pds_psn,
@@ -2230,20 +2230,20 @@ static int uet_pds_process_syn_pkt(struct uet_instance *uet,
 	if (pp->pds_type == UET_PDS_TYPE_RUD_REQ) {
 		/* for RUD, call into SES immediately ignoring order */
 		rc = uet_pds_upcall_ses_rx_req(uet, pdc, pdc_pkt);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 
 		rc = uet_pds_shift_rx_window(uet, pdc, false);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 	} else if (pp->pds_type == UET_PDS_TYPE_ROD_REQ) {
 		/* for ROD, reorder before calling into SES */
 		rc = uet_pds_shift_rx_window(uet, pdc, true);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 	}
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static int uet_pds_process_control(struct uet_instance *uet,
@@ -2269,21 +2269,21 @@ static int uet_pds_process_control(struct uet_instance *uet,
 		if (!pdc) {
 			UET_PDS_WARN("CLOSE command for unknown PDC %u",
 				     pp->pds_dpdcid);
-			return -FI_EINVAL;
+			return -EINVAL;
 		}
 
 		/* verify the PDC is in correct state */
 		if (pdc->state != PDC_STATE_ESTABLISHED) {
 			UET_PDS_WARN("PDC %u not ESTABLISHED (state=%d)",
 				     pdc->pdc_id, pdc->state);
-			return -FI_EINVAL;
+			return -EINVAL;
 		}
 
 		/* verify dpdcid matches spdcid */
 		if (pdc->dpdcid != pp->pds_spdcid) {
 			UET_PDS_WARN("PDC %u dpdcid mismatch (%u != %u)",
 				     pdc->pdc_id, pdc->dpdcid, pp->pds_spdcid);
-			return -FI_EINVAL;
+			return -EINVAL;
 		}
 
 		/* send ACK if requested */
@@ -2301,7 +2301,7 @@ static int uet_pds_process_control(struct uet_instance *uet,
 			rc = uet_pds_tx_ack_pkt(uet, pdc, &temp_pkt,
 						UET_HDR_NONE, 0,
 						NULL, false);
-			if (rc != FI_SUCCESS) {
+			if (rc != 0) {
 				UET_PDS_ERR("failed to send ACK for CLOSE");
 				return rc;
 			}
@@ -2320,14 +2320,14 @@ static int uet_pds_process_control(struct uet_instance *uet,
 	case UET_PDS_CTRL_TYPE_NEGOTIATION:
 		UET_PDS_ERR("Control type %d not yet supported",
 			     pp->pds_ctrl_type);
-		return -FI_EINVAL;
+		return -EINVAL;
 
 	default:
 		UET_PDS_ERR("Unknown control type %d", pp->pds_ctrl_type);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static int uet_pds_process_request(struct uet_instance *uet,
@@ -2351,13 +2351,13 @@ static int uet_pds_process_request(struct uet_instance *uet,
 	    (pp->pds_type != UET_PDS_TYPE_ROD_REQ)) {
 		UET_PDS_WARN("Rx packet type not supported %d",
 			     pp->pds_type);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	pdc_pkt = calloc(1, sizeof(struct uet_pdc_pkt));
 	if (pdc_pkt == NULL) {
 		UET_PDS_ERR("failed to alloc PDC packet");
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	pdc_pkt->psn = pp->pds_psn;
@@ -2370,9 +2370,9 @@ static int uet_pds_process_request(struct uet_instance *uet,
 	/* if this is a SYN packet then a new PDC might be needed */
 	if (pdc_pkt->pkt_pp.pds_flags & UET_PDS_REQ_FLAGS_SYN) {
 		rc = uet_pds_process_syn_pkt(uet, pdc_pkt);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			goto exit_err;
-		return FI_SUCCESS;
+		return 0;
 	}
 
 	/* TODO:
@@ -2395,7 +2395,7 @@ static int uet_pds_process_request(struct uet_instance *uet,
 
 	pdc = uet_pdsm_get_pdc(pdc_pkt->pkt_pp.pds_dpdcid, false);
 	if (pdc == NULL) {
-		rc = -FI_ENODEV;
+		rc = -ENODEV;
 		goto exit_err;
 	}
 
@@ -2403,16 +2403,16 @@ static int uet_pds_process_request(struct uet_instance *uet,
 		UET_PDS_WARN("invalid PDC %u (spdcid %u != dpdcid %u)",
 			     pdc->pdc_id, pdc_pkt->pkt_pp.pds_spdcid,
 			     pdc->dpdcid);
-		rc = -FI_EINVAL;
+		rc = -EINVAL;
 		goto exit_err;
 	}
 
 	/* check if this packet is a duplicate */
 	rc = uet_pds_check_duplicate_and_rtx(uet, pdc, pdc_pkt, &rtx);
-	if (rc != FI_SUCCESS)
+	if (rc != 0)
 		goto exit_err;
 	else if (rtx)
-		return FI_SUCCESS;
+		return 0;
 
 	UET_PDS_DBG("PDC %u rx_bm: base=%u psn=%u SET bit=%u",
 		    pdc->pdc_id, pdc->rx_bm_base_psn, pdc_pkt->pkt_pp.pds_psn,
@@ -2430,20 +2430,20 @@ static int uet_pds_process_request(struct uet_instance *uet,
 	if (pp->pds_type == UET_PDS_TYPE_RUD_REQ) {
 		/* for RUD, call into SES immediately ignoring order */
 		rc = uet_pds_upcall_ses_rx_req(uet, pdc, pdc_pkt);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 
 		rc = uet_pds_shift_rx_window(uet, pdc, false);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 	} else if (pp->pds_type == UET_PDS_TYPE_ROD_REQ) {
 		/* for ROD, reorder before calling into SES */
 		rc = uet_pds_shift_rx_window(uet, pdc, true);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 	}
 
-	return FI_SUCCESS;
+	return 0;
 
 exit_err:
 	free(pdc_pkt);
@@ -2464,7 +2464,7 @@ int uet_pds_progress_rx(struct uet_instance *uet)
 	bool ses_nack, gtd_del, rtx;
 	uint32_t crc;
 	uint8_t *crc_start;
-	int rc = FI_SUCCESS;
+	int rc = 0;
 
 	PDS_GO();
 
@@ -2478,13 +2478,13 @@ int uet_pds_progress_rx(struct uet_instance *uet)
 				&pkt_is_rd_rsp,
 				&pkt_is_ctrl)) {
 		UET_PDS_WARN("invalid Rx packet (len=%ld)", pkt_len);
-		rc = -FI_EINVAL;
+		rc = -EINVAL;
 		goto exit_err;
 	}
 
 	/* parse the packet */
 	rc = uet_parse_pkt(uet, pkt, pkt_len, &pp);
-	if (rc != FI_SUCCESS) {
+	if (rc != 0) {
 		UET_PDS_ERR("malformed Rx packet");
 		goto exit_err;
 	}
@@ -2501,7 +2501,7 @@ int uet_pds_progress_rx(struct uet_instance *uet)
 			    pp.ip_payload_len - CRC_LEN),
 			   CRC_LEN) != 0) {
 			UET_PDS_WARN("Rx packet CRC mismatch");
-			rc = -FI_EINVAL;
+			rc = -EINVAL;
 			goto exit_err;
 		}
 	}
@@ -2511,24 +2511,24 @@ int uet_pds_progress_rx(struct uet_instance *uet)
 	if (pkt_is_ack) {
 
 		rc = uet_pds_process_ack(uet, &pp);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			goto exit_err;
 
 	} else if (pkt_is_ctrl) {
 
 		rc = uet_pds_process_control(uet, &pp, pkt, pkt_len);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			goto exit_err;
 
 	} else { /* request packet */
 
 		rc = uet_pds_process_request(uet, &pp, pkt, pkt_len);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			goto exit_err;
 
 	}
 
-	return FI_SUCCESS;
+	return 0;
 
 exit_err:
 	free(pkt);

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -121,7 +121,6 @@ struct uet_pdc {
 	uint16_t             syn_offset; /* initiator SYN offset until ACK */
 	uint32_t             next_psn; /* next Tx pkt seq number */
 	struct bitmap       *tx_bm;
-	struct bitmap       *ack_bm;
 	uint32_t             tx_bm_base_psn; /* start PSN for initiator MPR */
 
 	/* target side fields */
@@ -251,6 +250,18 @@ int16_t psn_2c_offset(uint32_t base_psn, uint32_t psn)
 	assert((base_psn + offset) == psn);
 
 	return offset;
+}
+
+char uet_pdc_tx_bit_char(void *data)
+{
+	struct uet_pdc_pkt *pdc_pkt = (struct uet_pdc_pkt *)data;
+	return (pdc_pkt == NULL) ? '.' : (pdc_pkt->tx_pkt_acked ? 'X' : 'O');
+}
+
+char uet_pdc_rx_bit_char(void *data)
+{
+	struct uet_pdc_pkt *pdc_pkt = (struct uet_pdc_pkt *)data;
+	return (pdc_pkt == NULL) ? '.' : '*';
 }
 
 /****************************************************************************/
@@ -446,7 +457,6 @@ static void uet_init_pdc(struct uet_pdc *pdc,
 			 pdc_state_t state,
 			 bool is_initiator)
 {
-	/* initialze this PDC and stick it in the hashtable */
 	pdc->state = state;
 	pdc->is_initiator = is_initiator;
 
@@ -455,12 +465,17 @@ static void uet_init_pdc(struct uet_pdc *pdc,
 	pdc->active_msg_id = 0;
 	pdc->active_msg_id_valid = false;
 
+	pdc->close_requested = false;
+	pdc->close_started = false;
+	pdc->close_cmd_psn = 0;
+
 	dlist_init(&pdc->tx_pkt_list_head);
 
+	pdc->uet_ep = NULL;
+	pdc->av_entry = NULL;
 	pdc->syn_offset = 0;
 	pdc->next_psn = 0;
 	bm_clear(pdc->tx_bm);
-	bm_clear(pdc->ack_bm);
 	pdc->tx_bm_base_psn = 0;
 
 	bm_clear(pdc->rx_bm);
@@ -991,22 +1006,14 @@ int uet_pds_initialize(struct uet_instance *uet)
 		if (!pdc->tx_bm) {
 			UET_PDS_ERR("failed to create Tx bitmap");
 			uet_pdsm_free_pdc(pdc);
-			return -FI_ENOMEM; /* TODO: unwind and free PDCs */
-		}
-
-		pdc->ack_bm = bm_create(UET_DEFAULT_MPR);
-		if (!pdc->ack_bm) {
-			UET_PDS_ERR("failed to create ACK bitmap");
-			bm_destroy(pdc->tx_bm);
-			return -FI_ENOMEM; /* TODO: unwind and free PDCs */
+			return -FI_ENOMEM; /* FIXME unwind and free PDCs */
 		}
 
 		pdc->rx_bm = bm_create(UET_DEFAULT_MPR);
 		if (!pdc->rx_bm) {
 			UET_PDS_ERR("failed to create Rx bitmap");
 			bm_destroy(pdc->tx_bm);
-			bm_destroy(pdc->ack_bm);
-			return -FI_ENOMEM; /* TODO: unwind and free PDCs */
+			return -FI_ENOMEM; /* FIXME unwind and free PDCs */
 		}
 
 		dlist_insert_tail(&pdc->node, &pds_state.pdc_free_head);
@@ -1040,9 +1047,6 @@ void uet_pds_finalize(struct uet_instance *uet)
 		if (pdc->tx_bm)
 			bm_destroy(pdc->tx_bm);
 
-		if (pdc->ack_bm)
-			bm_destroy(pdc->ack_bm);
-
 		if (pdc->rx_bm)
 			bm_destroy(pdc->rx_bm);
 	}
@@ -1054,9 +1058,6 @@ void uet_pds_finalize(struct uet_instance *uet)
 
 		if (pdc->tx_bm)
 			bm_destroy(pdc->tx_bm);
-
-		if (pdc->ack_bm)
-			bm_destroy(pdc->ack_bm);
 
 		if (pdc->rx_bm)
 			bm_destroy(pdc->rx_bm);
@@ -1385,10 +1386,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	if (UET_LOG_LVL >= UET_LOG_DBG) {
 		UET_PDS_DBG("PDC %u tx_bm (base %u):",
 			    pdc->pdc_id, pdc->tx_bm_base_psn);
-		bm_print_bits(pdc->tx_bm);
-		UET_PDS_DBG("PDC %u ack_bm (base %u):",
-			    pdc->pdc_id, pdc->tx_bm_base_psn);
-		bm_print_bits(pdc->ack_bm);
+		bm_print_bits(pdc->tx_bm, uet_pdc_tx_bit_char);
 	}
 
 	/* insert the packet to the end of the timeout queue */
@@ -1921,7 +1919,6 @@ static int uet_pds_shift_rx_window(struct uet_instance *uet,
 	int clear_to_base_diff;
 
 	while (true) {
-
 		/*
 		 * Previous Behavior and Bug Description:
 		 * - When handling unexpected messages, if the Receiver has not
@@ -1994,10 +1991,10 @@ static int uet_pds_shift_rx_window(struct uet_instance *uet,
 	}
 
 #if 0
-	if (shifted && (UET_LOG_LVL >= UET_LOG_DBG)) {
+	if (shifted) {
 		UET_PDS_DBG("PDC %d rx_bm (base %u):",
 			    pdc->pdc_id, pdc->rx_bm_base_psn);
-		bm_print_bits(pdc->rx_bm);
+		bm_print_bits(pdc->rx_bm, uet_pdc_rx_bit_char);
 	}
 #endif
 	(void)shifted;
@@ -2016,7 +2013,7 @@ static int uet_pds_shift_tx_window(struct uet_instance *uet,
 		if (!bm_get(pdc->tx_bm, 0, (void **)&pdc_pkt))
 			break;
 
-		if (!bm_get(pdc->ack_bm, 0, NULL))
+		if (!pdc_pkt->tx_pkt_acked)
 			break;
 
 		/*
@@ -2027,7 +2024,6 @@ static int uet_pds_shift_tx_window(struct uet_instance *uet,
 
 		shifted = true;
 		bm_shift_right(pdc->tx_bm, 1);
-		bm_shift_right(pdc->ack_bm, 1);
 		pdc->tx_bm_base_psn++;
 
 		if (pdc_pkt->ack_buf)
@@ -2038,13 +2034,10 @@ static int uet_pds_shift_tx_window(struct uet_instance *uet,
 	}
 
 #if 0
-	if (shifted && (UET_LOG_LVL >= UET_LOG_DBG)) {
+	if (shifted) {
 		UET_PDS_DBG("PDC %d tx_bm (base %u):",
 			    pdc->pdc_id, pdc->tx_bm_base_psn);
-		bm_print_bits(pdc->tx_bm);
-		UET_PDS_DBG("PDC %d ack_bm (base %u):",
-			    pdc->pdc_id, pdc->tx_bm_base_psn);
-		bm_print_bits(pdc->ack_bm);
+		bm_print_bits(pdc->tx_bm, uet_pdc_tx_bit_char);
 	}
 #endif
 	(void)shifted;
@@ -2109,19 +2102,10 @@ static int uet_pds_process_ack(struct uet_instance *uet,
 		return -FI_EINVAL;
 	}
 
-	UET_PDS_DBG("PDC %u tx_bm: base=%u psn=%u SET bit=%u",
-		    pdc->pdc_id, pdc->tx_bm_base_psn, pdc_pkt->psn,
-		    (pdc_pkt->psn - pdc->tx_bm_base_psn));
-
-	bm_set(pdc->ack_bm, (pdc_pkt->psn - pdc->tx_bm_base_psn), NULL);
-
 	if (UET_LOG_LVL >= UET_LOG_DBG) {
 		UET_PDS_DBG("PDC %d tx_bm (base %u):",
 			    pdc->pdc_id, pdc->tx_bm_base_psn);
-		bm_print_bits(pdc->tx_bm);
-		UET_PDS_DBG("PDC %d ack_bm (base %u):",
-			    pdc->pdc_id, pdc->tx_bm_base_psn);
-		bm_print_bits(pdc->ack_bm);
+		bm_print_bits(pdc->tx_bm, uet_pdc_tx_bit_char);
 	}
 
 	pdc_pkt->tx_pkt_acked = true;
@@ -2238,7 +2222,7 @@ static int uet_pds_process_syn_pkt(struct uet_instance *uet,
 	if (UET_LOG_LVL >= UET_LOG_DBG) {
 		UET_PDS_DBG("PDC %d rx_bm (base %u):",
 			    pdc->pdc_id, pdc->rx_bm_base_psn);
-		bm_print_bits(pdc->rx_bm);
+		bm_print_bits(pdc->rx_bm, uet_pdc_rx_bit_char);
 	}
 
 	if (pp->pds_type == UET_PDS_TYPE_RUD_REQ) {
@@ -2438,7 +2422,7 @@ static int uet_pds_process_request(struct uet_instance *uet,
 	if (UET_LOG_LVL >= UET_LOG_DBG) {
 		UET_PDS_DBG("PDC %d rx_bm (base %u):",
 			    pdc->pdc_id, pdc->rx_bm_base_psn);
-		bm_print_bits(pdc->rx_bm);
+		bm_print_bits(pdc->rx_bm, uet_pdc_rx_bit_char);
 	}
 
 	if (pp->pds_type == UET_PDS_TYPE_RUD_REQ) {

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -1203,7 +1203,8 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 		}
 	}
 
-	if ((pdc->uet_ep != uet_ep) || (pdc->av_entry != av_entry)) {
+	if (pdc->is_initiator &&
+	    ((pdc->uet_ep != uet_ep) || (pdc->av_entry != av_entry))) {
 		UET_PDS_ERR("PDC %u does not match EP/AV for Tx pkt %p",
 			    pdc->pdc_id, tx_pkt_handle);
 		return -FI_EINVAL;
@@ -2103,14 +2104,14 @@ static int uet_pds_process_ack(struct uet_instance *uet,
 		return -FI_EINVAL;
 	}
 
+	pdc_pkt->tx_pkt_acked = true;
+	dlist_remove(&pdc_pkt->node); /* remove from Tx list */
+
 	if (UET_LOG_LVL >= UET_LOG_DBG) {
 		UET_PDS_DBG("PDC %d tx_bm (base %u):",
 			    pdc->pdc_id, pdc->tx_bm_base_psn);
 		bm_print_bits(pdc->tx_bm, uet_pdc_tx_bit_char);
 	}
-
-	pdc_pkt->tx_pkt_acked = true;
-	dlist_remove(&pdc_pkt->node); /* remove from Tx list */
 
 	/* check if this is an ACK for the close command */
 	if ((pdc->state == PDC_STATE_CLOSING) &&
@@ -2264,7 +2265,7 @@ static int uet_pds_process_control(struct uet_instance *uet,
 			    pp->pds_spdcid, pp->pds_dpdcid);
 
 		/* find the target PDC */
-		pdc = uet_pdsm_get_pdc(pp->pds_dpdcid, true);
+		pdc = uet_pdsm_get_pdc(pp->pds_dpdcid, false);
 		if (!pdc) {
 			UET_PDS_WARN("CLOSE command for unknown PDC %u",
 				     pp->pds_dpdcid);
@@ -2457,7 +2458,6 @@ int uet_pds_progress_rx(struct uet_instance *uet)
 	bool pkt_is_ack, pkt_is_rd_rsp, pkt_is_ctrl;
 	struct uet_pdc_pkt *pdc_pkt = NULL;
 	struct uet_pdc *pdc;
-	struct uet_pds_info pds_info;
 	uet_pds_next_hdr_t rsp_next_hdr;
 	void *rsp_ses_hdr = NULL;
 	size_t rsp_ses_hdr_len;

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 #include <ofi_list.h>
 #include <uthash.h>
@@ -29,6 +30,9 @@
 #define UET_DEFAULT_ENTROPY   0x4242
 
 #define UET_PDC_MAX 64
+
+#define UET_RANDOM_PDC_CLOSE
+#define UET_RANDOM_PDC_CLOSE_THRESH 10 /* percent */
 
 typedef enum {
 	PDC_STATE_UNALLOC,
@@ -77,12 +81,14 @@ struct uet_pdc_pkt {
 struct uet_pdc_ini_key {
 	pdc_type_t    type;
 	uint32_t      job_id;
+	struct uet_fa src_ip;
 	struct uet_fa dst_ip;
 	uint8_t       tc;
 };
 
 struct uet_pdc_tgt_key {
 	struct uet_fa src_ip;
+	struct uet_fa dst_ip;
 	uint16_t      spdcid;
 };
 
@@ -94,7 +100,13 @@ struct uet_pdc {
 
 	uint16_t            pdc_id; /* local PDC identifier */
 	uint16_t            dpdcid; /* peer PDC identifier */
-	uint32_t            open_msg_cnt; /* can only free the PDC if zero */
+
+	uint16_t            active_msg_id; /* msg_id currently being sent */
+	bool                active_msg_id_valid;
+
+	bool                close_requested; /* close has been requested */
+	bool                close_started; /* close has started */
+	uint32_t            close_cmd_psn; /* PSN of the close command */
 
 	struct uet_pdc_ini_key ini_hkey;
 	UT_hash_handle         pdc_ini_hh; /* initiator hash handle for the PDC */
@@ -104,11 +116,13 @@ struct uet_pdc {
 	struct dlist_entry  tx_pkt_list_head; /* 'tx_time' order (for rtx) */
 
 	/* initiator side fields (and target side reverse direction) */
-	uint16_t            syn_offset; /* initiator SYN offset until ACK */
-	uint32_t            next_psn; /* next Tx pkt seq number */
-	struct bitmap      *tx_bm;
-	struct bitmap      *ack_bm;
-	uint32_t            tx_bm_base_psn; /* start PSN for initiator MPR */
+	struct uet_ep       *uet_ep;
+	struct uet_av_entry *av_entry; /* destination address */
+	uint16_t             syn_offset; /* initiator SYN offset until ACK */
+	uint32_t             next_psn; /* next Tx pkt seq number */
+	struct bitmap       *tx_bm;
+	struct bitmap       *ack_bm;
+	uint32_t             tx_bm_base_psn; /* start PSN for initiator MPR */
 
 	/* target side fields */
 	struct bitmap      *rx_bm;
@@ -131,10 +145,9 @@ struct uet_pds_state {
 	struct uet_pdc        pdc[UET_PDC_MAX];
 	struct dlist_entry    pdc_alloc_head;
 	struct dlist_entry    pdc_free_head;
-	struct uet_pdc       *pdc_ini_ht; /* key = "type|job_id|dst_ip|tc" */
-	struct uet_pdc       *pdc_tgt_ht; /* key = "src_addr|spdcid" */
-	struct uet_msgid_map *pdc_msgid_ht; /* key = "msg_id" */
-	struct dlist_entry    pending_pkts_head; /* TODO: not implemented yet */
+	struct uet_pdc       *pdc_ini_ht; /* key=[type|jobid|srcip|dstip|tc] */
+	struct uet_pdc       *pdc_tgt_ht; /* key=[srcip|dstip|spdcid] */
+	struct uet_msgid_map *pdc_msgid_ht; /* key=[msg_id] */
 };
 
 static struct uet_pds_state pds_state;
@@ -154,18 +167,38 @@ static struct uet_pds_state pds_state;
 #define PSN_IN_PRIOR_MPR(psn, base_psn)                             \
 	PSN_IN_MPR((psn), (uint32_t)((base_psn) - UET_DEFAULT_MPR))
 
-#define PDS_TYPE_TO_STR(t)                              \
-	(((t) == UET_PDS_TYPE_RUD_REQ)   ? "RUD_REQ" :  \
-	 ((t) == UET_PDS_TYPE_ROD_REQ)   ? "ROD_REQ" :  \
-	 ((t) == UET_PDS_TYPE_RUDI_REQ)  ? "RUDI_REQ" : \
-	 ((t) == UET_PDS_TYPE_UUD_REQ)   ? "UUD_REQ" :  \
-	 ((t) == UET_PDS_TYPE_RUDI_RESP) ? "RUDI_RSP" : \
-	 ((t) == UET_PDS_TYPE_ACK)       ? "ACK" :      \
-	 ((t) == UET_PDS_TYPE_NACK)      ? "NACK" :     \
-	 ((t) == UET_PDS_TYPE_CTRL)      ? "CTRL" :     \
+#define PDS_TYPE_TO_STR(t)                                 \
+	(((t) == UET_PDS_TYPE_RUD_REQ)    ? "RUD_REQ" :    \
+	 ((t) == UET_PDS_TYPE_ROD_REQ)    ? "ROD_REQ" :    \
+	 ((t) == UET_PDS_TYPE_RUDI_REQ)   ? "RUDI_REQ" :   \
+	 ((t) == UET_PDS_TYPE_RUDI_RESP)  ? "RUDI_RSP" :   \
+	 ((t) == UET_PDS_TYPE_UUD_REQ)    ? "UUD_REQ" :    \
+	 ((t) == UET_PDS_TYPE_ACK)        ? "ACK" :        \
+	 ((t) == UET_PDS_TYPE_ACK_CC)     ? "ACK_CC" :     \
+	 ((t) == UET_PDS_TYPE_ACK_CCX)    ? "ACK_CCX" :    \
+	 ((t) == UET_PDS_TYPE_NACK)       ? "NACK" :       \
+	 ((t) == UET_PDS_TYPE_CTRL)       ? "CTRL" :       \
+	 ((t) == UET_PDS_TYPE_NACK_CCX)   ? "NACK_CCX" :   \
+	 ((t) == UET_PDS_TYPE_RUD_CC_REQ) ? "RUD_CC_REQ" : \
+	 ((t) == UET_PDS_TYPE_ROD_CC_REQ) ? "ROD_CC_REQ" : \
 					   "UNKNOWN")
+
+#define PDS_CTRL_TO_STR(n)                                        \
+	(((n) == UET_PDS_CTRL_TYPE_NOP)         ? "NOP" :         \
+	 ((n) == UET_PDS_CTRL_TYPE_ACK_REQ)     ? "ACK_REQ" :     \
+	 ((n) == UET_PDS_CTRL_TYPE_CLEAR)       ? "CLEAR" :       \
+	 ((n) == UET_PDS_CTRL_TYPE_CLEAR_REQ)   ? "CLEAR_REQ" :   \
+	 ((n) == UET_PDS_CTRL_TYPE_CLOSE)       ? "CLOSE" :       \
+	 ((n) == UET_PDS_CTRL_TYPE_CLOSE_REQ)   ? "CLOSE_REQ" :   \
+	 ((n) == UET_PDS_CTRL_TYPE_PROBE)       ? "PROBE" :       \
+	 ((n) == UET_PDS_CTRL_TYPE_CREDIT)      ? "CREDIT" :      \
+	 ((n) == UET_PDS_CTRL_TYPE_CREDIT_REQ)  ? "CREDIT_REQ" :  \
+	 ((n) == UET_PDS_CTRL_TYPE_NEGOTIATION) ? "NEGOTIATION" : \
+						  "UNKNOWN")
+
 #define NEXT_HDR_TO_STR(n)                                    \
-	(((n) == UET_HDR_REQ_SMALL)      ? "REQ_SMALL" :      \
+	(((n) == UET_HDR_NONE)           ? "NONE" :           \
+	 ((n) == UET_HDR_REQ_SMALL)      ? "REQ_SMALL" :      \
 	 ((n) == UET_HDR_REQ_MEDIUM)     ? "REQ_MEDIUM" :     \
 	 ((n) == UET_HDR_REQ_STD)        ? "REQ_STD" :        \
 	 ((n) == UET_HDR_RSP)            ? "RSP" :            \
@@ -178,7 +211,9 @@ static struct uet_pds_state pds_state;
 		    (pp)->pds_spdcid, (pp)->pds_dpdcid,          \
 		    (pp)->pds_psn,                               \
 		    PDS_TYPE_TO_STR((pp)->pds_type),             \
-		    NEXT_HDR_TO_STR((pp)->next_hdr),             \
+		    ((pp)->pds_type == UET_PDS_TYPE_CTRL)        \
+			? PDS_CTRL_TO_STR((pp)->pds_ctrl_type)   \
+			: NEXT_HDR_TO_STR((pp)->next_hdr),       \
 		    (msg),                                       \
 		    (pp)->pkt_len)
 
@@ -187,7 +222,9 @@ static struct uet_pds_state pds_state;
 		    (pp)->pds_dpdcid, (pp)->pds_spdcid,          \
 		    (pp)->pds_psn,                               \
 		    PDS_TYPE_TO_STR((pp)->pds_type),             \
-		    NEXT_HDR_TO_STR((pp)->next_hdr),             \
+		    ((pp)->pds_type == UET_PDS_TYPE_CTRL)        \
+			? PDS_CTRL_TO_STR((pp)->pds_ctrl_type)   \
+			: NEXT_HDR_TO_STR((pp)->next_hdr),       \
 		    (msg),                                       \
 		    (pp)->pkt_len)
 
@@ -414,7 +451,9 @@ static void uet_init_pdc(struct uet_pdc *pdc,
 	pdc->is_initiator = is_initiator;
 
 	pdc->dpdcid = 0;
-	pdc->open_msg_cnt = 0;
+
+	pdc->active_msg_id = 0;
+	pdc->active_msg_id_valid = false;
 
 	dlist_init(&pdc->tx_pkt_list_head);
 
@@ -451,7 +490,25 @@ static void uet_pdsm_free_pdc(struct uet_pdc *pdc)
 {
 	PDS_GO();
 
+	UET_PDS_DBG("freeing PDC %u (state=UNALLOC) (is_initiator=%d)",
+		    pdc->pdc_id, pdc->is_initiator);
+
+	/* remove from hash tables */
+	if (pdc->is_initiator)
+		HASH_DELETE(pdc_ini_hh, pds_state.pdc_ini_ht, pdc);
+	else
+		HASH_DELETE(pdc_tgt_hh, pds_state.pdc_tgt_ht, pdc);
+
 	pdc->state = PDC_STATE_UNALLOC;
+
+	/* reset close tracking fields */
+	pdc->close_requested = false;
+	pdc->close_started = false;
+	pdc->close_cmd_psn = 0;
+
+	/* reset active message tracking */
+	pdc->active_msg_id = 0;
+	pdc->active_msg_id_valid = false;
 
 	/* free a PDC by inserting to the tail of the free list */
 	dlist_remove(&pdc->node);
@@ -473,7 +530,7 @@ static void uet_pdsm_get_sdi(struct uet_pdc *pdc)
 }
 
 static struct uet_pdc *uet_pdsm_assign_ini_pdc(struct uet_ep *uet_ep,
-					       struct uet_addr *dst_addr,
+					       struct uet_av_entry *av_entry,
 					       uet_pds_mode_t mode)
 {
 	struct uet_pdc_ini_key pdc_key;
@@ -488,12 +545,20 @@ static struct uet_pdc *uet_pdsm_assign_ini_pdc(struct uet_ep *uet_ep,
 						     PDC_TYPE_NONE);
 	pdc_key.job_id = uet_ep->job_id;
 	pdc_key.tc = UET_DEFAULT_TC;
-	memcpy(&pdc_key.dst_ip, &dst_addr->fa, sizeof(struct uet_fa));
+	/* TODO: IPv6 support */
+	memcpy(&pdc_key.src_ip, &uet_ep->ipv4_addr, sizeof(uet_ep->ipv4_addr));
+	memcpy(&pdc_key.dst_ip, &av_entry->addr->fa, sizeof(struct uet_fa));
 
 	HASH_FIND(pdc_ini_hh, pds_state.pdc_ini_ht, &pdc_key,
 		  sizeof(pdc_key), pdc);
 	if (pdc) {
-		UET_PDS_DBG("lookup found initiator PDC %u", pdc->pdc_id);
+		/* if the PDC is closing, don't use it for new messages */
+		if (pdc->close_requested) {
+			UET_PDS_DBG("initiator lookup found a closing PDC %u",
+				    pdc->pdc_id);
+			return NULL;
+		}
+
 		return pdc;
 	}
 
@@ -506,6 +571,8 @@ static struct uet_pdc *uet_pdsm_assign_ini_pdc(struct uet_ep *uet_ep,
 
 	/* initialze this initiator PDC and stick it in the hashtable */
 	uet_init_pdc(pdc, PDC_STATE_SYN, true);
+	pdc->uet_ep         = uet_ep;
+	pdc->av_entry       = av_entry;
 	pdc->next_psn       = UET_DEFAULT_START_PSN;
 	pdc->tx_bm_base_psn = UET_DEFAULT_START_PSN;
 	pdc->rx_bm_base_psn = UET_DEFAULT_START_PSN;
@@ -515,7 +582,7 @@ static struct uet_pdc *uet_pdsm_assign_ini_pdc(struct uet_ep *uet_ep,
 
 	uet_pdsm_get_sdi(pdc);
 
-	UET_PDS_DBG("allocated initiator PDC %u", pdc->pdc_id);
+	UET_PDS_DBG("allocated initiator PDC %u (state=SYN)", pdc->pdc_id);
 
 	return pdc;
 }
@@ -542,6 +609,7 @@ static struct uet_pdc *uet_pdsm_assign_tgt_pdc(struct uet_parsed_pkt *pp)
 	memset(&pdc_key, 0, sizeof(pdc_key));
 	/* TODO: IPv6 support */
 	pdc_key.src_ip.v4 = ntohl(ipv4->saddr);
+	pdc_key.dst_ip.v4 = ntohl(ipv4->daddr);
 	pdc_key.spdcid = pp->pds_spdcid; /* target side needs spdcid */
 
 	HASH_FIND(pdc_tgt_hh, pds_state.pdc_tgt_ht, &pdc_key,
@@ -562,7 +630,7 @@ static struct uet_pdc *uet_pdsm_assign_tgt_pdc(struct uet_parsed_pkt *pp)
 		return pdc;
 	}
 
-	UET_PDS_DBG("First SYN request from PDC %u (PSN %u offset %u)",
+	UET_PDS_DBG("first SYN request from PDC %u (PSN %u offset %u)",
 		    pp->pds_spdcid, pp->pds_psn, pp->pds_syn_off);
 
 	/* allocate a new PDC from the head of the free list */
@@ -584,7 +652,7 @@ static struct uet_pdc *uet_pdsm_assign_tgt_pdc(struct uet_parsed_pkt *pp)
 
 	uet_pdsm_get_sdi(pdc);
 
-	UET_PDS_DBG("allocated target PDC %u (established with PDC %u)",
+	UET_PDS_DBG("allocated target PDC %u (state=ESTABLISHED) (dpdcid=%u)",
 		    pdc->pdc_id, pdc->dpdcid);
 
 	return pdc;
@@ -672,22 +740,6 @@ static struct uet_pdc *uet_pdsm_get_msgid_pdc(uint16_t msg_id)
 }
 
 #if 0
-static int uet_pdsm_insert_pend_pkt(struct uet_pdc_pkt *pdc_pkt)
-{
-	PDS_GO();
-
-	/* TODO: not implemented yet */
-	return -FI_ENOSYS;
-}
-
-static struct uet_pdc_pkt *uet_pdsm_remove_pend_pkt(void)
-{
-	PDS_GO();
-
-	/* TODO: not implemented yet */
-	return NULL;
-}
-
 static struct uet_pdc *uet_pdsm_select_pdc_to_close(void)
 {
 	PDS_GO();
@@ -729,6 +781,176 @@ static int uet_pdsm_check_nack_code(struct uet_pdc_pkt *pdc_pkt)
 /*                            PDC Initiator APIs                            */
 /****************************************************************************/
 
+static int uet_pds_send_close_cmd(struct uet_instance *uet,
+				  struct uet_pdc *pdc)
+{
+	struct uet_pdc_pkt *pdc_pkt;
+	struct uet_pds_ctrl *ctrl_hdr;
+	struct uet_entropy *entropy_hdr;
+	uint16_t ctrl_flags;
+	int rc;
+
+	/* allocate the packet descriptor */
+	pdc_pkt = calloc(1, sizeof(struct uet_pdc_pkt));
+	if (pdc_pkt == NULL) {
+		UET_PDS_ERR("failed to alloc PDC packet for close command");
+		return -FI_ENOMEM;
+	}
+
+	/* allocate the packet buffer */
+	pdc_pkt->pkt_buf_len = (uet->nic.max_pkt_size *
+				((pdc->sec_enabled) ? 2 : 1));
+	pdc_pkt->pkt_buf = calloc(1, pdc_pkt->pkt_buf_len);
+	if (pdc_pkt->pkt_buf == NULL) {
+		UET_PDS_ERR("failed to alloc packet buffer for close command");
+		free(pdc_pkt);
+		return -FI_ENOMEM;
+	}
+
+	/* reserve head space for security header if needed */
+	pdc_pkt->pkt = (pdc->sec_enabled)
+			? (pdc_pkt->pkt_buf + UET_SEC_MAX_HDR_LEN)
+			: pdc_pkt->pkt_buf;
+
+	/* build Ethernet header */
+	uet_build_eth_hdr((struct ethhdr *)pdc_pkt->pkt,
+			  pdc->av_entry->nh_mac_addr,
+			  uet->nic.mac_addr);
+
+	/* set up pointers to headers */
+	entropy_hdr = (struct uet_entropy *)(pdc_pkt->pkt +
+					     sizeof(struct ethhdr) +
+					     sizeof(struct iphdr));
+	ctrl_hdr = (struct uet_pds_ctrl *)(pdc_pkt->pkt +
+					   sizeof(struct ethhdr) +
+					   sizeof(struct iphdr) +
+					   sizeof(struct uet_entropy));
+
+	pdc_pkt->pkt_len = (sizeof(struct ethhdr) +
+			    sizeof(struct iphdr) +
+			    sizeof(struct uet_entropy) +
+			    sizeof(struct uet_pds_ctrl));
+
+	/* fill in the entropy header */
+	entropy_hdr->entropy = htons(UET_DEFAULT_ENTROPY);
+
+	/* fill in the control packet header */
+	ctrl_flags = ((UET_PDS_TYPE_CTRL << UET_PDS_TYPE_SHIFT) |
+		      (UET_PDS_CTRL_TYPE_CLOSE << UET_PDS_CTRL_TYPE_SHIFT) |
+		      (UET_PDS_CTRL_FLAGS_AR << UET_PDS_FLAGS_SHIFT));
+
+	ctrl_hdr->prlg.type_ctrl_flags = htons(ctrl_flags);
+	ctrl_hdr->rsvd = 0;
+
+	/* assign PSN for close command */
+	pdc->close_cmd_psn = pdc->next_psn++;
+	pdc_pkt->psn = pdc->close_cmd_psn;
+	ctrl_hdr->psn = htonl(pdc_pkt->psn);
+
+	ctrl_hdr->spdcid = htons(pdc->pdc_id);
+	ctrl_hdr->dpdcid = htons(pdc->dpdcid);
+
+	/* payload is 0x0 for close command */
+	ctrl_hdr->payload = 0;
+
+	/* build the IP header */
+	uet_build_ipv4_hdr(uet,
+			   (struct iphdr *)(pdc_pkt->pkt +
+					    sizeof(struct ethhdr)),
+			   htonl(pdc->av_entry->addr->fa.v4),
+			   htonl(pdc->uet_ep->ipv4_addr),
+			   (pdc_pkt->pkt_len - uet->nic.l2_hdr_size),
+			   uet->pds.ack_ip_tos,
+			   !pdc->sec_enabled);
+
+	/* save packet params */
+	pdc_pkt->msg_id = 0; /* control packets have no msg_id */
+	pdc_pkt->tx_retry_cnt = 0;
+	pdc_pkt->tx_pkt_handle = NULL; /* no SES handle for control packets */
+	pdc_pkt->tx_pkt_acked = false;
+	pdc_pkt->flags = 0;
+
+	/* send the packet */
+	rc = uet_pds_sec_tx_pkt(uet, pdc, pdc_pkt, true, false);
+	if (rc != FI_SUCCESS) {
+		UET_PDS_ERR("failed to send close command for PDC %u",
+			    pdc->pdc_id);
+		free(pdc_pkt->pkt_buf);
+		free(pdc_pkt);
+		return rc;
+	}
+
+	/* the packet was sent successfully */
+	uet_pds_pkt_dbg(uet, &pdc_pkt->pkt_pp, true, "TX CLOSE COMMAND");
+
+	/* set this packet in the tx_bm for tracking ACK */
+	UET_PDS_DBG("PDC %u tx_bm: base=%u psn=%u SET bit=%u (close cmd)",
+		    pdc->pdc_id, pdc->tx_bm_base_psn, pdc_pkt->psn,
+		    (pdc_pkt->psn - pdc->tx_bm_base_psn));
+
+	bm_set(pdc->tx_bm, (pdc_pkt->psn - pdc->tx_bm_base_psn), pdc_pkt);
+
+	/* insert the packet to the end of the timeout queue for retries */
+	dlist_insert_tail(&pdc_pkt->node, &pdc->tx_pkt_list_head);
+
+	UET_PDS_DBG("PDC %u close command sent (psn=%u)",
+		    pdc->pdc_id, pdc_pkt->psn);
+
+	return FI_SUCCESS;
+}
+
+static int uet_pds_initiate_pdc_close(struct uet_instance *uet,
+				      struct uet_pdc *pdc)
+{
+	int rc;
+
+	/* bail if the close command has already been sent */
+	if (pdc->close_requested && pdc->close_started)
+		return FI_SUCCESS;
+
+	UET_PDS_DBG("PDC %u sending close command", pdc->pdc_id);
+
+	if (!pdc->is_initiator) {
+		UET_PDS_ERR("PDC %u is not an initiator, cannot close",
+			    pdc->pdc_id);
+		return -FI_EINVAL;
+	}
+
+	if (pdc->state != PDC_STATE_ESTABLISHED) {
+		UET_PDS_DBG("PDC %u not established (state %d), skip close",
+			    pdc->pdc_id, pdc->state);
+		return -FI_EINVAL;
+	}
+
+	/* set close_requested if not already set */
+	pdc->close_requested = true;
+
+	/* check if the active message has drained */
+	if (pdc->active_msg_id_valid) {
+		UET_PDS_DBG("PDC %u still has an active message (msg_id %u)",
+			    pdc->pdc_id, pdc->active_msg_id);
+		return -FI_EAGAIN;
+	}
+
+	/* the previous active message has drained, send the close command */
+	rc = uet_pds_send_close_cmd(uet, pdc);
+	if (rc != FI_SUCCESS) {
+		UET_PDS_ERR("PDC %u failed to send close command",
+			    pdc->pdc_id);
+		return rc;
+	}
+
+	/* close command packet has been sent */
+	pdc->close_started = true;
+
+	/* transition to the CLOSING state */
+	pdc->state = PDC_STATE_CLOSING;
+
+	UET_PDS_DBG("PDC %u transitioned to the CLOSING state", pdc->pdc_id);
+
+	return FI_SUCCESS;
+}
+
 /****************************************************************************/
 /*                             PDC Target APIs                              */
 /****************************************************************************/
@@ -741,6 +963,9 @@ int uet_pds_initialize(struct uet_instance *uet)
 {
 	struct uet_pdc *pdc;
 	int i;
+
+	/* seed random number generator for PDC close decisions */
+	srand(time(NULL));
 
 	uet->pds.tx_timeout     = UET_DEFAULT_TX_TIMEOUT;
 	uet->pds.max_tx_retries = UET_DEFAULT_MAX_TX_RETRIES;
@@ -787,10 +1012,6 @@ int uet_pds_initialize(struct uet_instance *uet)
 		dlist_insert_tail(&pdc->node, &pds_state.pdc_free_head);
 	}
 
-	/* initialize the pending packets list */
-
-	dlist_init(&pds_state.pending_pkts_head);
-
 	/* good to go... */
 	pds_state.ready = true;
 
@@ -810,14 +1031,18 @@ void uet_pds_finalize(struct uet_instance *uet)
 	while (!dlist_empty(&pds_state.pdc_alloc_head)) {
 		dlist_pop_front(&pds_state.pdc_alloc_head,
 				struct uet_pdc, pdc, node);
+
 		if (pdc->is_initiator)
 			HASH_DELETE(pdc_ini_hh, pds_state.pdc_ini_ht, pdc);
 		else
 			HASH_DELETE(pdc_tgt_hh, pds_state.pdc_tgt_ht, pdc);
+
 		if (pdc->tx_bm)
 			bm_destroy(pdc->tx_bm);
+
 		if (pdc->ack_bm)
 			bm_destroy(pdc->ack_bm);
+
 		if (pdc->rx_bm)
 			bm_destroy(pdc->rx_bm);
 	}
@@ -826,23 +1051,15 @@ void uet_pds_finalize(struct uet_instance *uet)
 	while (!dlist_empty(&pds_state.pdc_free_head)) {
 		dlist_pop_front(&pds_state.pdc_free_head,
 				struct uet_pdc, pdc, node);
+
 		if (pdc->tx_bm)
 			bm_destroy(pdc->tx_bm);
+
 		if (pdc->ack_bm)
 			bm_destroy(pdc->ack_bm);
+
 		if (pdc->rx_bm)
 			bm_destroy(pdc->rx_bm);
-	}
-
-	/* free all the packets in the pending list */
-	while (!dlist_empty(&pds_state.pending_pkts_head)) {
-		dlist_pop_front(&pds_state.pending_pkts_head,
-				struct uet_pdc_pkt, pdc_pkt, node);
-		if (pdc_pkt->pkt_buf)
-			free(pdc_pkt->pkt_buf);
-		if (pdc_pkt->ack_buf)
-			free(pdc_pkt->ack_buf);
-		free(pdc_pkt);
 	}
 
 	/* wipe out all existing state */
@@ -884,7 +1101,6 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 {
 	struct uet_instance *uet;
 	struct uet_av_entry *av_entry;
-	struct uet_addr *dst_addr;
 	struct uet_pdc_pkt *pdc_pkt;
 	uet_pds_pkt_type_t pds_pkt_type;
 	struct uet_pdc *pdc;
@@ -898,7 +1114,6 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 
 	uet = uet_ep->uet_domain->uet;
 	av_entry = (struct uet_av_entry *)dst_addr_handle;
-	dst_addr = av_entry->addr;
 
 	switch (mode) {
 	case UET_PDS_MODE_RUD:
@@ -924,44 +1139,113 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 		return -FI_EINVAL;
 	}
 
-	/* if pds_info is specified, take the PDC from its pdcid */
+	/*
+	 * If pds_info is specified, take the PDC from its pdcid, else
+	 * perform a hash lookup to find the PDC. For a SOM the lookup is
+	 * based on the uet_pdc_ini_key. For a middle or EOM the lookup is
+	 * based on the msg_id. In either case, if a PDC is not found then
+	 * -FI_EAGAIN is returned to indicate the caller should retry. In
+	 * this reference implementation, the SES does the right thing by
+	 * calling the Tx routine again later. This prevents the PDS manager
+	 * from having to maintain a pending packet list that is pulled
+	 * from when PDCs become available.
+	 */
+
 	if (pds_info) {
-		UET_PDS_DBG("SES Tx %p (pds_info pdcid %u psn %u)",
-			    tx_pkt_handle, pds_info->pdcid, pds_info->opsn);
+		UET_PDS_DBG("SES Tx %p msg_id %u (pds_info pdcid %u psn %u)",
+			    tx_pkt_handle, msg_id, pds_info->pdcid,
+			    pds_info->opsn);
 		pdc = uet_pdsm_get_pdc(pds_info->pdcid, true);
 		if (pdc == NULL)
 			return -FI_ENODEV;
 	} else if (flags & UET_PDS_FLAG_SOM) {
-		UET_PDS_DBG("SES Tx %p SOM", tx_pkt_handle);
-		pdc = uet_pdsm_assign_ini_pdc(uet_ep, dst_addr, mode);
+		UET_PDS_DBG("SES Tx %p msg_id %u [SOM]%s",
+			    tx_pkt_handle, msg_id,
+			    ((flags & UET_PDS_FLAG_EOM) ? " [EOM]" : ""));
+		pdc = uet_pdsm_assign_ini_pdc(uet_ep, av_entry, mode);
 		if (pdc) {
+			/* verify PDC has no active message */
+			if (pdc->active_msg_id_valid) {
+				UET_PDS_DBG("PDC %u already has "
+					    "active_msg_id %u, cannot start "
+					    "msg_id %u (EAGAIN)",
+					    pdc->pdc_id, pdc->active_msg_id,
+					    msg_id);
+				return -FI_EAGAIN;
+			}
+
 			rc = uet_pdsm_map_msgid_pdc(msg_id, pdc);
 			if (rc != FI_SUCCESS)
 				return rc;
-			pdc->open_msg_cnt++;
+
+			/* set the active message for this PDC */
+			pdc->active_msg_id = msg_id;
+			pdc->active_msg_id_valid = true;
+		} else {
+			UET_PDS_DBG("failed to get PDC for SOM %p "
+				    "msg_id %u (EAGAIN)",
+				    tx_pkt_handle, msg_id);
+			return -FI_EAGAIN;
 		}
 	} else {
-		UET_PDS_DBG("SES Tx %p", tx_pkt_handle);
+		UET_PDS_DBG("SES Tx %p msg_id %u%s",
+			    tx_pkt_handle, msg_id,
+			    ((flags & UET_PDS_FLAG_EOM) ? " [EOM]" : ""));
+
 		pdc = uet_pdsm_get_msgid_pdc(msg_id);
+		if (!pdc) {
+			UET_PDS_DBG("failed to get PDC for non-SOM %p "
+				    "msg_id %u (EAGAIN)",
+				    tx_pkt_handle, msg_id);
+			return -FI_EAGAIN;
+		}
 	}
 
-	if (!pdc) {
-		UET_PDS_ERR("failed to get PDC, put on pending list %p",
-			    tx_pkt_handle);
-		/* TODO: put this packet on the PDS pending pkt list */
-		return -FI_ENODEV;
+	if ((pdc->uet_ep != uet_ep) || (pdc->av_entry != av_entry)) {
+		UET_PDS_ERR("PDC %u does not match EP/AV for Tx pkt %p",
+			    pdc->pdc_id, tx_pkt_handle);
+		return -FI_EINVAL;
+	}
+
+	/* for non-SOM packets, verify msg_id matches the active message */
+	if (!(flags & UET_PDS_FLAG_SOM)) {
+		if (!pdc->active_msg_id_valid) {
+			UET_PDS_ERR("PDC %u has no active message, cannot send "
+				    "non-SOM packet for msg_id %u",
+				    pdc->pdc_id, msg_id);
+			return -FI_EINVAL;
+		}
+
+		if (pdc->active_msg_id != msg_id) {
+			UET_PDS_ERR("PDC %u active_msg_id %u does not match "
+				    "msg_id %u",
+				    pdc->pdc_id, pdc->active_msg_id, msg_id);
+			return -FI_EINVAL;
+		}
 	}
 
 	if (!pds_info && (flags & UET_PDS_FLAG_EOM)) {
-		UET_PDS_DBG("SES Tx %p EOM%s", tx_pkt_handle,
-			    (flags & UET_PDS_FLAG_MAINTAIN_PDC)
-				? " (maintain PDC)" : "");
-		if (!(flags & UET_PDS_FLAG_MAINTAIN_PDC)) {
-			rc = uet_pdsm_unmap_msgid_pdc(msg_id);
-			if (rc != FI_SUCCESS)
-				return rc;
-			pdc->open_msg_cnt--;
+		/* clear the active message on this PDC */
+		pdc->active_msg_id = 0;
+		pdc->active_msg_id_valid = false;
+
+		rc = uet_pdsm_unmap_msgid_pdc(msg_id);
+		if (rc != FI_SUCCESS)
+			return rc;
+
+		if (flags & UET_PDS_FLAG_MAINTAIN_PDC) {
+			UET_PDS_DBG("PDC %u flagged with MAINTAIN_PDC on EOM",
+				    pdc->pdc_id);
 		}
+#ifdef UET_RANDOM_PDC_CLOSE
+		else if (pdc->is_initiator && !pdc->close_requested &&
+			 ((rand() % 100) < UET_RANDOM_PDC_CLOSE_THRESH)) {
+			/* randomly mark PDC for close after message sent */
+			UET_PDS_DBG("PDC %u randomly marked for close!",
+				    pdc->pdc_id);
+			pdc->close_requested = true;
+		}
+#endif /* UET_RANDOM_PDC_CLOSE */
 	}
 
 	/* allocate descriptor and buffer to build packet */
@@ -1067,7 +1351,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	uet_build_ipv4_hdr(uet,
 			   (struct iphdr *)(pdc_pkt->pkt +
 					    sizeof(struct ethhdr)),
-			   htonl(dst_addr->fa.v4),
+			   htonl(av_entry->addr->fa.v4),
 			   htonl(uet_ep->ipv4_addr),
 			   (pdc_pkt->pkt_len - uet->nic.l2_hdr_size),
 			   uet_ep->msg_ip_tos,
@@ -1109,6 +1393,16 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 
 	/* insert the packet to the end of the timeout queue */
 	dlist_insert_tail(&pdc_pkt->node, &pdc->tx_pkt_list_head);
+
+	/* if close was requested, send it now */
+	if ((pdc->state == PDC_STATE_ESTABLISHED) && pdc->is_initiator &&
+	    pdc->close_requested && !pdc->close_started) {
+		rc = uet_pds_initiate_pdc_close(uet, pdc);
+		if ((rc != FI_SUCCESS) && (rc != -FI_EAGAIN)) {
+			UET_PDS_WARN("PDC %u failed to initiate close (rc=%d)",
+				     pdc->pdc_id, rc);
+		}
+	}
 
 	return FI_SUCCESS;
 }
@@ -1182,6 +1476,8 @@ int uet_pds_progress_tx(struct uet_ep *uet_ep,
 	time_t now, delta;
 	int rc;
 
+	PDS_GO();
+
 	uet = uet_ep->uet_domain->uet;
 
 	/* TODO:
@@ -1237,13 +1533,26 @@ int uet_pds_msg_cmpl_ind(struct uet_ep *uet_ep,
 	if (pdc == NULL)
 		return -FI_EINVAL;
 
+	UET_PDS_DBG("PDC %d msg_id %u completion indication from SES",
+		    pdc->pdc_id, msg_id);
+
+	/* clear active message for MAINTAIN_PDC messages */
+	pdc->active_msg_id = 0;
+	pdc->active_msg_id_valid = false;
+
 	rc = uet_pdsm_unmap_msgid_pdc(msg_id);
 	if (rc != FI_SUCCESS)
 		return rc;
 
-	UET_PDS_DBG("PDC %d complete indication for msg_id %u",
-		    pdc->pdc_id, msg_id);
-	pdc->open_msg_cnt--;
+	/* if close was requested and not started, send it now */
+	if (pdc->close_requested && !pdc->close_started) {
+		rc = uet_pds_initiate_pdc_close(uet_ep->uet_domain->uet, pdc);
+		if ((rc != FI_SUCCESS) && (rc != -FI_EAGAIN)) {
+			UET_PDS_ERR("PDC %u failed to initiate close (rc=%d)",
+				    pdc->pdc_id, rc);
+			return rc;
+		}
+	}
 
 	return FI_SUCCESS;
 }
@@ -1268,7 +1577,6 @@ static void uet_pds_build_ack_pkt(struct uet_instance *uet,
 					 sizeof(struct ethhdr) +
 					 sizeof(struct iphdr) +
 					 sizeof(struct uet_entropy));
-	ack_ses = (uint8_t *)(ack_pds + 1);
 
 	uet_build_eth_hdr((struct ethhdr *)pdc_pkt->ack,
 			  ((struct ethhdr *)pdc_pkt->pkt_pp.eth)->h_source,
@@ -1295,14 +1603,18 @@ static void uet_pds_build_ack_pkt(struct uet_instance *uet,
 		      (next_hdr << UET_PDS_NEXT_HDR_SHIFT) |
 		      (flags << UET_PDS_FLAGS_SHIFT));
 
-	/* XXX start tracking a real cumulative ack value */
+	/* FIXME start tracking a real cumulative ack value */
 	ack_pds->ack_psn_offset = 0;
 	ack_pds->cack_psn = htonl(pdc_pkt->pkt_pp.pds_psn);
 
 	ack_pds->spdcid = htons(pdc->pdc_id);
 	ack_pds->dpdcid = htons(pdc->dpdcid);
 
-	memcpy(ack_ses, ses_hdr, ses_hdr_len);
+	/* only copy SES header if needed */
+	if (ses_hdr && ses_hdr_len > 0) {
+		ack_ses = (uint8_t *)(ack_pds + 1);
+		memcpy(ack_ses, ses_hdr, ses_hdr_len);
+	}
 }
 
 static int uet_pds_tx_ack_pkt(struct uet_instance *uet,
@@ -1318,7 +1630,13 @@ static int uet_pds_tx_ack_pkt(struct uet_instance *uet,
 	int rc;
 
 	/* TODO: IPv6 support and UDP support */
-	if (next_hdr == UET_HDR_RSP) {
+
+	if (next_hdr == UET_HDR_NONE) {
+		pdc_pkt->ack_len = (sizeof(struct ethhdr) +
+				    sizeof(struct iphdr) +
+				    sizeof(struct uet_entropy) +
+				    sizeof(struct uet_pds_ack));
+	} else if (next_hdr == UET_HDR_RSP) {
 		pdc_pkt->ack_len = (sizeof(struct ethhdr) +
 				    sizeof(struct iphdr) +
 				    sizeof(struct uet_entropy) +
@@ -1365,10 +1683,6 @@ static int uet_pds_tx_ack_pkt(struct uet_instance *uet,
 		free(pdc_pkt->ack_buf);
 		return rc;
 	}
-
-	/* the packet was sent successfully */
-
-	pdc_pkt->ack_parsed = true;
 
 	uet_pds_pkt_dbg(uet, &pdc_pkt->ack_pp, true, "TX ACK PACKET");
 
@@ -1453,7 +1767,7 @@ static int uet_pds_tx_def_rsp_ack_pkt(struct uet_instance *uet,
 		      (UET_HDR_RSP << UET_PDS_NEXT_HDR_SHIFT) |
 		      (UET_PDS_ACK_FLAGS_NONE << UET_PDS_FLAGS_SHIFT));
 
-	/* XXX start tracking a real cumulative ack value */
+	/* FIXME start tracking a real cumulative ack value */
 	ack_pds->ack_psn_offset = 0;
 	ack_pds->cack_psn = htonl(pdc_pkt->pkt_pp.pds_psn);
 
@@ -1705,11 +2019,11 @@ static int uet_pds_shift_tx_window(struct uet_instance *uet,
 		if (!bm_get(pdc->ack_bm, 0, NULL))
 			break;
 
-		 /*
-		  * This transmitted packet has been ACK'ed. Note that when
-		  * the ACK was processed, the packet was removed from the
-		  * PDC's tx list that is managed for retransmissions.
-		  */
+		/*
+		 * This transmitted packet has been ACK'ed. Note that when
+		 * the ACK was processed, the packet was removed from the
+		 * PDC's tx list that is managed for retransmissions.
+		 */
 
 		shifted = true;
 		bm_shift_right(pdc->tx_bm, 1);
@@ -1813,17 +2127,41 @@ static int uet_pds_process_ack(struct uet_instance *uet,
 	pdc_pkt->tx_pkt_acked = true;
 	dlist_remove(&pdc_pkt->node); /* remove from Tx list */
 
-	/* upcall for SES processing */
-	rc = uet->pds.upcall.rx_rsp(pdc_pkt->tx_pkt_handle, pp);
-	if (rc != FI_SUCCESS) {
-		UET_PDS_ERR("PDC %u ACK PSN %u SES upcall failed (rx_rsp=%d)",
-			    pp->pds_dpdcid, pp->pds_psn, rc);
-		return rc;
+	/* check if this is an ACK for the close command */
+	if ((pdc->state == PDC_STATE_CLOSING) &&
+	    (pp->pds_psn == pdc->close_cmd_psn)) {
+		UET_PDS_DBG("PDC %u received ACK for close command (psn=%u)",
+			    pdc->pdc_id, pp->pds_psn);
+
+		/* shift the tx_bm window for all left edge ACK'ed PSNs */
+		rc = uet_pds_shift_tx_window(uet, pdc);
+		if (rc != FI_SUCCESS)
+			return rc;
+
+		/* FIXME, make sure there are no more pending packets */
+
+		/* free the PDC */
+		uet_pdsm_free_pdc(pdc);
+
+		return FI_SUCCESS;
 	}
 
 	if (pdc->state == PDC_STATE_SYN) {
+		UET_PDS_DBG("PDC %u transitioned to the ESTABLISHED state",
+			    pdc->pdc_id);
 		pdc->state  = PDC_STATE_ESTABLISHED;
 		pdc->dpdcid = pp->pds_spdcid;
+	}
+
+	/* upcall for SES processing */
+	if (pp->next_hdr != UET_HDR_NONE) {
+		rc = uet->pds.upcall.rx_rsp(pdc_pkt->tx_pkt_handle, pp);
+		if (rc != FI_SUCCESS) {
+			UET_PDS_ERR("PDC %u ACK PSN %u SES upcall "
+				    "failed (rx_rsp=%d)",
+				    pp->pds_dpdcid, pp->pds_psn, rc);
+			return rc;
+		}
 	}
 
 	/* shift the tx_bm window for all left edge ACK'ed PSNs */
@@ -1837,6 +2175,22 @@ static int uet_pds_process_ack(struct uet_instance *uet,
 	 * CLEAR to be acknowledged right away instead of waiting for the
 	 * next request to be sent that would contain a cumulative clear PSN.
 	 */
+
+	/*
+	 * Check if PDC has close_requested set and all messages have drained.
+	 * This handles the case where messages don't use MAINTAIN_PDC flag.
+	 *
+	 * FIXME Remove this code block, not sure it's possible to hit.
+	 */
+	if ((pdc->state == PDC_STATE_ESTABLISHED) && pdc->is_initiator &&
+	    pdc->close_requested && !pdc->close_started &&
+	    !pdc->active_msg_id_valid) {
+		rc = uet_pds_initiate_pdc_close(uet, pdc);
+		if ((rc != FI_SUCCESS) && (rc != -FI_EAGAIN)) {
+			UET_PDS_WARN("PDC %u failed to initiate close (rc=%d)",
+				     pdc->pdc_id, rc);
+		}
+	}
 
 	return FI_SUCCESS;
 }
@@ -1901,6 +2255,90 @@ static int uet_pds_process_syn_pkt(struct uet_instance *uet,
 		rc = uet_pds_shift_rx_window(uet, pdc, true);
 		if (rc != FI_SUCCESS)
 			return rc;
+	}
+
+	return FI_SUCCESS;
+}
+
+static int uet_pds_process_control(struct uet_instance *uet,
+				   struct uet_parsed_pkt *pp,
+				   uint8_t *pkt,
+				   int pkt_len)
+{
+	struct uet_pdc *pdc;
+	bool send_ack = false;
+	int rc;
+
+	/* check if ACK is requested */
+	if (pp->pds_flags & UET_PDS_CTRL_FLAGS_AR)
+		send_ack = true;
+
+	switch (pp->pds_ctrl_type) {
+	case UET_PDS_CTRL_TYPE_CLOSE:
+		UET_PDS_DBG("Received CLOSE command (spdcid=%u dpdcid=%u)",
+			    pp->pds_spdcid, pp->pds_dpdcid);
+
+		/* find the target PDC */
+		pdc = uet_pdsm_get_pdc(pp->pds_dpdcid, true);
+		if (!pdc) {
+			UET_PDS_WARN("CLOSE command for unknown PDC %u",
+				     pp->pds_dpdcid);
+			return -FI_EINVAL;
+		}
+
+		/* verify the PDC is in correct state */
+		if (pdc->state != PDC_STATE_ESTABLISHED) {
+			UET_PDS_WARN("PDC %u not ESTABLISHED (state=%d)",
+				     pdc->pdc_id, pdc->state);
+			return -FI_EINVAL;
+		}
+
+		/* verify dpdcid matches spdcid */
+		if (pdc->dpdcid != pp->pds_spdcid) {
+			UET_PDS_WARN("PDC %u dpdcid mismatch (%u != %u)",
+				     pdc->pdc_id, pdc->dpdcid, pp->pds_spdcid);
+			return -FI_EINVAL;
+		}
+
+		/* send ACK if requested */
+		if (send_ack) {
+			struct uet_pdc_pkt temp_pkt;
+
+			UET_PDS_DBG("PDC %u Tx ACK for CLOSE command",
+				    pdc->pdc_id);
+
+			/* set up temp pdc_pkt with parsed control packet */
+			memset(&temp_pkt, 0, sizeof(temp_pkt));
+			memcpy(&temp_pkt.pkt_pp, pp, sizeof(*pp));
+
+			/* build and send an ACK packet */
+			rc = uet_pds_tx_ack_pkt(uet, pdc, &temp_pkt,
+						UET_HDR_NONE, 0,
+						NULL, false);
+			if (rc != FI_SUCCESS) {
+				UET_PDS_ERR("failed to send ACK for CLOSE");
+				return rc;
+			}
+
+			/* FIXME Is the control packet freed here? */
+		}
+
+		/* free the PDC */
+		uet_pdsm_free_pdc(pdc);
+
+		break;
+
+	case UET_PDS_CTRL_TYPE_PROBE:
+	case UET_PDS_CTRL_TYPE_CREDIT:
+	case UET_PDS_CTRL_TYPE_CREDIT_REQ:
+	case UET_PDS_CTRL_TYPE_NEGOTIATION:
+		UET_PDS_ERR("Control type %d not yet supported",
+			     pp->pds_ctrl_type);
+		return -FI_EINVAL;
+
+	default:
+		UET_PDS_ERR("Unknown control type %d", pp->pds_ctrl_type);
+		return -FI_EINVAL;
 	}
 
 	return FI_SUCCESS;
@@ -2031,7 +2469,7 @@ int uet_pds_progress_rx(struct uet_instance *uet)
 	uint8_t *pkt;
 	size_t pkt_len;
 	struct uet_parsed_pkt pp;
-	bool pkt_is_ack, pkt_is_rd_rsp;
+	bool pkt_is_ack, pkt_is_rd_rsp, pkt_is_ctrl;
 	struct uet_pdc_pkt *pdc_pkt = NULL;
 	struct uet_pdc *pdc;
 	struct uet_pds_info pds_info;
@@ -2043,6 +2481,8 @@ int uet_pds_progress_rx(struct uet_instance *uet)
 	uint8_t *crc_start;
 	int rc = FI_SUCCESS;
 
+	PDS_GO();
+
 	rc = uet_pds_sec_rx_pkt(uet, &pkt, &pkt_len);
 	if (rc != 1)
 		return rc;
@@ -2050,8 +2490,9 @@ int uet_pds_progress_rx(struct uet_instance *uet)
 	/* validate the packet */
 	if (!uet_pds_rx_pkt_chk(uet, pkt, pkt_len,
 				&pkt_is_ack,
-				&pkt_is_rd_rsp)) {
-		UET_PDS_WARN("invalid Rx packet");
+				&pkt_is_rd_rsp,
+				&pkt_is_ctrl)) {
+		UET_PDS_WARN("invalid Rx packet (len=%ld)", pkt_len);
 		rc = -FI_EINVAL;
 		goto exit_err;
 	}
@@ -2067,12 +2508,13 @@ int uet_pds_progress_rx(struct uet_instance *uet)
 		/* calculate the CRC (include src/dst IP and UDP) */
 		/* TODO: IPv6 support */
 		crc_start = ((uint8_t *)pp.ip + 12);
-		crc = crc32c(crc_start,
-			     (pp.pkt_len - CRC_LEN -
-			      (crc_start - (uint8_t *)pp.eth)));
+		crc = crc32c(crc_start, (8 + pp.ip_payload_len - CRC_LEN));
 
 		/* verify the CRC */
-		if (memcmp(&crc, (pkt + pkt_len - CRC_LEN), CRC_LEN) != 0) {
+		if (memcmp(&crc,
+			   ((uint8_t *)pp.ip + pp.ip_len +
+			    pp.ip_payload_len - CRC_LEN),
+			   CRC_LEN) != 0) {
 			UET_PDS_WARN("Rx packet CRC mismatch");
 			rc = -FI_EINVAL;
 			goto exit_err;
@@ -2084,6 +2526,12 @@ int uet_pds_progress_rx(struct uet_instance *uet)
 	if (pkt_is_ack) {
 
 		rc = uet_pds_process_ack(uet, &pp);
+		if (rc != FI_SUCCESS)
+			goto exit_err;
+
+	} else if (pkt_is_ctrl) {
+
+		rc = uet_pds_process_control(uet, &pp, pkt, pkt_len);
 		if (rc != FI_SUCCESS)
 			goto exit_err;
 
@@ -2118,13 +2566,13 @@ void uet_pds_ep_close_wait(struct uet_ep *uet_ep)
 	 */
 
 	if (uet_gettime(&start_time)) {
-		UET_PDS_ERR("Aborting endpoint close wait state");
+		UET_PDS_ERR("aborting endpoint close wait state");
 		return;
 	}
 
 	while (1) {
 		if (uet_gettime(&now)) {
-			UET_PDS_ERR("Aborting endpoint close wait state");
+			UET_PDS_ERR("aborting endpoint close wait state");
 			break;
 		}
 

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -1252,27 +1252,28 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	}
 
 	if (!pds_info && (flags & UET_PDS_FLAG_EOM)) {
-		/* clear the active message on this PDC */
-		pdc->active_msg_id = 0;
-		pdc->active_msg_id_valid = false;
-
-		rc = uet_pdsm_unmap_msgid_pdc(msg_id);
-		if (rc != 0)
-			return rc;
-
 		if (flags & UET_PDS_FLAG_MAINTAIN_PDC) {
 			UET_PDS_DBG("PDC %u flagged with MAINTAIN_PDC on EOM",
 				    pdc->pdc_id);
-		}
+		} else {
+			/* clear the active message on this PDC */
+			pdc->active_msg_id = 0;
+			pdc->active_msg_id_valid = false;
+
+			rc = uet_pdsm_unmap_msgid_pdc(msg_id);
+			if (rc != 0)
+				return rc;
+
 #ifdef UET_RANDOM_PDC_CLOSE
-		else if (pdc->is_initiator && !pdc->close_requested &&
-			 ((rand() % 100) < UET_RANDOM_PDC_CLOSE_THRESH)) {
-			/* randomly mark PDC for close after message sent */
-			UET_PDS_DBG("PDC %u randomly marked for close!",
-				    pdc->pdc_id);
-			pdc->close_requested = true;
-		}
+			if (pdc->is_initiator && !pdc->close_requested &&
+			    ((rand() % 100) < UET_RANDOM_PDC_CLOSE_THRESH)) {
+				/* randomly mark PDC for close */
+				UET_PDS_DBG("PDC %u randomly marked for close!",
+					    pdc->pdc_id);
+				pdc->close_requested = true;
+			}
 #endif /* UET_RANDOM_PDC_CLOSE */
+		}
 	}
 
 	/* allocate descriptor and buffer to build packet */

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -116,8 +116,10 @@ struct uet_pdc {
 	struct dlist_entry  tx_pkt_list_head; /* 'tx_time' order (for rtx) */
 
 	/* initiator side fields (and target side reverse direction) */
-	struct uet_ep       *uet_ep;
-	struct uet_av_entry *av_entry; /* destination address */
+	uint8_t              src_mac_addr[ETH_ALEN];
+	uint8_t              dst_mac_addr[ETH_ALEN];
+	struct uet_fa        src_addr;
+	struct uet_fa        dst_addr;
 	uint16_t             syn_offset; /* initiator SYN offset until ACK */
 	uint32_t             next_psn; /* next Tx pkt seq number */
 	struct bitmap       *tx_bm;
@@ -472,8 +474,11 @@ static void uet_init_pdc(struct uet_pdc *pdc,
 
 	dlist_init(&pdc->tx_pkt_list_head);
 
-	pdc->uet_ep = NULL;
-	pdc->av_entry = NULL;
+	memset(pdc->src_mac_addr, 0, ETH_ALEN);
+	memset(pdc->dst_mac_addr, 0, ETH_ALEN);
+	memset(&pdc->src_addr, 0, sizeof(struct uet_fa));
+	memset(&pdc->dst_addr, 0, sizeof(struct uet_fa));
+
 	pdc->syn_offset = 0;
 	pdc->next_psn = 0;
 	bm_clear(pdc->tx_bm);
@@ -587,8 +592,18 @@ static struct uet_pdc *uet_pdsm_assign_ini_pdc(struct uet_ep *uet_ep,
 
 	/* initialze this initiator PDC and stick it in the hashtable */
 	uet_init_pdc(pdc, PDC_STATE_SYN, true);
-	pdc->uet_ep         = uet_ep;
-	pdc->av_entry       = av_entry;
+
+	memcpy(pdc->src_mac_addr, uet_ep->uet_domain->uet->nic.mac_addr,
+	       ETH_ALEN);
+	memcpy(pdc->dst_mac_addr, av_entry->nh_mac_addr,
+	       ETH_ALEN);
+
+	/* TODO: IPv6 support */
+	memcpy(&pdc->src_addr, &uet_ep->ipv4_addr,
+	       sizeof(pdc->src_addr.v4));
+	memcpy(&pdc->dst_addr, &av_entry->addr->fa.v4,
+	       sizeof(pdc->dst_addr.v4));
+
 	pdc->next_psn       = UET_DEFAULT_START_PSN;
 	pdc->tx_bm_base_psn = UET_DEFAULT_START_PSN;
 	pdc->rx_bm_base_psn = UET_DEFAULT_START_PSN;
@@ -606,6 +621,7 @@ static struct uet_pdc *uet_pdsm_assign_ini_pdc(struct uet_ep *uet_ep,
 static struct uet_pdc *uet_pdsm_assign_tgt_pdc(struct uet_parsed_pkt *pp)
 {
 	struct uet_ses_req_cmn *ses_cmn = (struct uet_ses_req_cmn *)pp->ses;
+	struct ethhdr *eth = (struct ethhdr *)pp->eth;
 	struct iphdr *ipv4 = (struct iphdr *)pp->ip; /* TODO: IPv6 support */
 	struct uet_pdc_tgt_key pdc_key;
 	struct uet_pdc *pdc;
@@ -658,6 +674,14 @@ static struct uet_pdc *uet_pdsm_assign_tgt_pdc(struct uet_parsed_pkt *pp)
 
 	/* initialze this target PDC and stick it in the hashtable */
 	uet_init_pdc(pdc, PDC_STATE_ESTABLISHED, false);
+
+	memcpy(pdc->src_mac_addr, eth->h_dest, ETH_ALEN);
+	memcpy(pdc->dst_mac_addr, eth->h_source, ETH_ALEN);
+
+	/* TODO: IPv6 support */
+	pdc->src_addr.v4 = ntohl(ipv4->daddr);
+	pdc->dst_addr.v4 = ntohl(ipv4->saddr);
+
 	pdc->dpdcid         = pp->pds_spdcid;
 	pdc->rx_bm_base_psn = (pp->pds_psn - pp->pds_syn_off);
 	pdc->tx_bm_base_psn = pdc->rx_bm_base_psn;
@@ -830,8 +854,7 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 
 	/* build Ethernet header */
 	uet_build_eth_hdr((struct ethhdr *)pdc_pkt->pkt,
-			  pdc->av_entry->nh_mac_addr,
-			  uet->nic.mac_addr);
+			  pdc->dst_mac_addr, pdc->src_mac_addr);
 
 	/* set up pointers to headers */
 	entropy_hdr = (struct uet_entropy *)(pdc_pkt->pkt +
@@ -873,8 +896,8 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 	uet_build_ipv4_hdr(uet,
 			   (struct iphdr *)(pdc_pkt->pkt +
 					    sizeof(struct ethhdr)),
-			   htonl(pdc->av_entry->addr->fa.v4),
-			   htonl(pdc->uet_ep->ipv4_addr),
+			   htonl(pdc->dst_addr.v4),
+			   htonl(pdc->src_addr.v4),
 			   (pdc_pkt->pkt_len - uet->nic.l2_hdr_size),
 			   uet->pds.ack_ip_tos,
 			   !pdc->sec_enabled);
@@ -1203,9 +1226,10 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 		}
 	}
 
-	if (pdc->is_initiator &&
-	    ((pdc->uet_ep != uet_ep) || (pdc->av_entry != av_entry))) {
-		UET_PDS_ERR("PDC %u does not match EP/AV for Tx pkt %p",
+	/* TODO: IPv6 support */
+	if (memcmp(&pdc->dst_addr.v4, &av_entry->addr->fa.v4,
+		   sizeof(pdc->dst_addr.v4)) != 0) {
+		UET_PDS_ERR("PDC %u dst_addr does not match AV for Tx pkt %p",
 			    pdc->pdc_id, tx_pkt_handle);
 		return -EINVAL;
 	}
@@ -1279,8 +1303,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 			: pdc_pkt->pkt_buf;
 
 	uet_build_eth_hdr((struct ethhdr *)pdc_pkt->pkt,
-			  av_entry->nh_mac_addr,
-			  uet->nic.mac_addr);
+			  pdc->dst_mac_addr, pdc->src_mac_addr);
 
 	/* TODO: IPv6 support and UDP support */
 	entropy_hdr = (struct uet_entropy *)(pdc_pkt->pkt +
@@ -1354,8 +1377,8 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	uet_build_ipv4_hdr(uet,
 			   (struct iphdr *)(pdc_pkt->pkt +
 					    sizeof(struct ethhdr)),
-			   htonl(av_entry->addr->fa.v4),
-			   htonl(uet_ep->ipv4_addr),
+			   htonl(pdc->dst_addr.v4),
+			   htonl(pdc->src_addr.v4),
 			   (pdc_pkt->pkt_len - uet->nic.l2_hdr_size),
 			   uet_ep->msg_ip_tos,
 			   !pdc->sec_enabled);

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -382,7 +382,8 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 	if (update_ipv4_tl)
 		uet_update_ipv4_tl(pp->ip, (*pkt_len - uet->nic.l2_hdr_size));
 
-	rc = uet_sec_enc_pkt(pkt_buf,
+	rc = uet_sec_enc_pkt(uet,
+			     pkt_buf,
 			     pkt_buf_len,
 			     *pkt,
 			     *pkt_len,
@@ -436,7 +437,7 @@ static int uet_pds_sec_rx_pkt(struct uet_instance *uet,
 		goto err_exit;
 
 	/* decrypt the packet if the security header is present */
-	rc = uet_sec_dec_pkt(*pkt, *pkt_len, &tag_len);
+	rc = uet_sec_dec_pkt(uet, *pkt, *pkt_len, &tag_len);
 	if (rc != FI_SUCCESS)
 		goto err_exit;
 

--- a/uet_pds.h
+++ b/uet_pds.h
@@ -46,10 +46,10 @@ typedef enum {
 
 /* pds tx flags */
 typedef enum {
-	UET_PDS_FLAG_SOM        = 0x01,   /* start of message */
-	UET_PDS_FLAG_EOM        = 0x02,   /* end of message */
-	UET_PDS_FLAG_EAGER_REQ  = 0x04,   /* request eager length predition */
-	UET_PDS_FLAG_RETRANSMIT = 0x08,   /* retransmit of pkt  */
+	UET_PDS_FLAG_SOM          = 0x01, /* start of message */
+	UET_PDS_FLAG_EOM          = 0x02, /* end of message */
+	UET_PDS_FLAG_EAGER_REQ    = 0x04, /* request eager length predition */
+	UET_PDS_FLAG_RETRANSMIT   = 0x08, /* retransmit of pkt  */
 	UET_PDS_FLAG_MAINTAIN_PDC = 0x10, /* don't allow PDC teardown */
 } uet_pds_tx_flags_t;
 
@@ -149,7 +149,7 @@ struct uet_ses_to_pds_funcs {
 	 * returns:
 	 *      FI_SUCCESS on success
 	 *      negative value corresponding to fabric errno on error
-	 *        -FI_AGAIN indicates caller should queue packet and retry later
+	 *        -FI_EAGAIN indicates caller should queue packet and retry later
 	 */
 	int (*tx_pkt)(uet_pkt_handle_t tx_pkt_handle, struct uet_ep *uet_ep,
 		      uet_addr_handle_t dst_addr_handle, uet_pds_mode_t mode,

--- a/uet_pds.h
+++ b/uet_pds.h
@@ -80,8 +80,8 @@ struct uet_ses_to_pds_funcs {
 	 *            for
 	 *
 	 * returns:
-	 *      FI_SUCCESS on success
-	 *      negative value corresponding to fabric errno on error
+	 *      0 on success
+	 *      negative value corresponding to errno on error
 	 */
 	int (*initialize)(struct uet_instance *uet);
 
@@ -102,8 +102,8 @@ struct uet_ses_to_pds_funcs {
 	 *               being initialized for
 	 *
 	 * returns:
-	 *      FI_SUCCESS on success
-	 *      negative value corresponding to fabric errno on error
+	 *      0 on success
+	 *      negative value corresponding to errno on error
 	 */
 	int (*ep_initialize)(struct uet_ep *uet_ep);
 
@@ -147,9 +147,9 @@ struct uet_ses_to_pds_funcs {
 	 *      dma_rdy         - true => msg payload buffer can be DMA'ed
 	 *
 	 * returns:
-	 *      FI_SUCCESS on success
-	 *      negative value corresponding to fabric errno on error
-	 *        -FI_EAGAIN indicates caller should queue packet and retry later
+	 *      0 on success
+	 *      negative value corresponding to errno on error
+	 *     -EAGAIN indicates caller should queue packet and retry later
 	 */
 	int (*tx_pkt)(uet_pkt_handle_t tx_pkt_handle, struct uet_ep *uet_ep,
 		      uet_addr_handle_t dst_addr_handle, uet_pds_mode_t mode,
@@ -171,8 +171,8 @@ struct uet_ses_to_pds_funcs {
 	 *      msg_id          - id of message that has completed
 	 *
 	 * returns:
-	 *      FI_SUCCESS on success
-	 *      negative value corresponding to fabric errno on error
+	 *      0 on success
+	 *      negative value corresponding to errno on error
 	 */
 	int (*msg_cmpl_ind)(struct uet_ep *uet_ep,
 			    uet_addr_handle_t dst_addr_handle,
@@ -187,8 +187,8 @@ struct uet_ses_to_pds_funcs {
 	 *                       returned in err case
 	 *
 	 * returns:
-	 *      FI_SUCCESS on success
-	 *      negative value corresponding to fabric errno on error
+	 *      0 on success
+	 *      negative value corresponding to errno on error
 	 */
 	int (*progress_tx)(struct uet_ep *uet_ep,
 			   uet_pkt_handle_t *err_pkt_handle);
@@ -200,8 +200,8 @@ struct uet_ses_to_pds_funcs {
 	 *      uet - ptr to uet instance struct
 	 *
 	 * returns:
-	 *      FI_SUCCESS to indicate no error
-	 *      negative value corresponding to fabric errno on error
+	 *      0 to indicate no error
+	 *      negative value corresponding to errno on error
 	 */
 	int (*progress_rx)(struct uet_instance *uet);
 
@@ -229,30 +229,30 @@ struct uet_pds_to_ses_funcs {
 	 *      rsp_next_hdr    - address of location where identifer of ses
 	 *                        header format for response is to be returned,
 	 *                        return contents are only valid when function
-	 *                        FI_SUCCESS
+	 *                        returns 0
 	 *      rsp_ses_hdr     - ptr to buffer where ses header for response
 	 *                        is to be returned, return contents are only
-	 *                        valid when function returns FI_SUCCESS,
+	 *                        valid when function returns 0,
 	 *                        buffer must be large enough to hold maximum
 	 *                        size ses response
 	 *      rsp_ses_hdr_len - address of location where length of ses
 	 *                        header for response is to be returned, return
 	 *                        contents are only valid when function returns
-	 *                        FI_SUCCESS
+	 *                        0
 	 *      ses_nack        - ptr to location where ses indicates whether
 	 *                        pds should send pds nack instead of pds ack,
 	 *                        return contents are only valid when function
-	 *                        returns FI_SUCCESS, true => pds must send
+	 *                        returns 0, true => pds must send
 	 *                        nack ses response state
 	 *      gtd_del         - ptr to location where ses indicates whether
 	 *                        pds needs to maintain ses response state,
 	 *                        return contents are only valid when function
-	 *                        returns FI_SUCCESS, true => pds must
+	 *                        returns 0, true => pds must
 	 *                        guarantee delivery of ses response state
 	 *
 	 * returns:
-	 *   - FI_SUCCESS when ses response is to be returned to initiator
-	 *   - negative value corresponding to fabric errno on error
+	 *   - 0 when ses response is to be returned to initiator
+	 *   - negative value corresponding to errno on error
 	 */
 	int (*rx_req)(uet_pkt_handle_t rx_pkt_handle, struct uet_instance *uet,
 		      struct uet_parsed_pkt *pp, struct uet_pds_info *pds_info,
@@ -268,8 +268,8 @@ struct uet_pds_to_ses_funcs {
 	 *      rsp_pp        - ptr to parsed packet struct for response
 	 *
 	 * returns:
-	 *      FI_SUCCESS when ack processed
-	 *      negative value corresponding to fabric errno on error
+	 *      0 when ack processed
+	 *      negative value corresponding to errno on error
 	 */
 	int (*rx_rsp)(uet_pkt_handle_t tx_pkt_handle,
 		      struct uet_parsed_pkt *rsp_pp);
@@ -284,8 +284,8 @@ struct uet_pds_to_ses_funcs {
 	 *      reason        - error reason code
 	 *
 	 * returns:
-	 *      FI_SUCCESS on success
-	 *      negative value corresponding to fabric errno on error
+	 *      0 on success
+	 *      negative value corresponding to errno on error
 	 */
 	int (*pds_err)(uet_pkt_handle_t tx_pkt_handle,
 		       uet_pds_err_code_t reason);

--- a/uet_pds_init.c
+++ b/uet_pds_init.c
@@ -85,7 +85,7 @@ int uet_pds_init(struct uet_instance *uet)
 		downcall->ep_close_wait = uet_pds_ep_close_wait;
 	} else {
 		UET_API_ERR("invalid UET_PDS environment variable");
-		return -FI_ENODEV;
+		return -ENODEV;
 	}
 
 	return downcall->initialize(uet);

--- a/uet_pds_sng.c
+++ b/uet_pds_sng.c
@@ -823,7 +823,7 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 	int rc;
 	uet_ses_rc_t ses_rc;
 	size_t rx_pkt_size;
-	bool pkt_is_ack, pkt_is_rd_rsp, ses_nack, gtd_del;
+	bool pkt_is_ack, pkt_is_rd_rsp, pkt_is_ctrl, ses_nack, gtd_del;
 	union uet_pkt *pkt;
 	struct uet_parsed_pkt pp;
 	struct uet_ep *dst_uet_ep;
@@ -876,7 +876,7 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 
 	/* validate the packet */
 	if (!uet_pds_rx_pkt_chk(uet, (uint8_t *)pkt, rx_pkt_size,
-				&pkt_is_ack, &pkt_is_rd_rsp))
+				&pkt_is_ack, &pkt_is_rd_rsp, &pkt_is_ctrl))
 		goto exit;
 
 	UET_PDS_PKT_HDR_TRACE(uet, &pp, pp.eth, pp.pkt_len, "RX PACKET");

--- a/uet_pds_sng.c
+++ b/uet_pds_sng.c
@@ -135,7 +135,7 @@ struct uet_pds_sng_state {
  * overlay struct for fields in pds headers
  *
  * the stop-and-go reliability layer is simpler if the sequence number
- * state is maintained between libfabric endpoints (rather than between
+ * state is maintained between endpoints (rather than between
  * FEPs as is done in the real pds reliability layer), so to enable that
  * a couple of fields in the pds headers are repurposed as follows:
  *
@@ -382,8 +382,8 @@ static void uet_pds_build_ack_pkt(struct uet_instance *uet, union uet_pkt *pkt,
  *      ses_hdr     - ptr to ses header
  *
  * returns:
- *      FI_SUCCESS on success,
- *      negative value corresponding to fabric errno on error
+ *      0 on success,
+ *      negative value corresponding to errno on error
  */
 static int uet_pds_tx_ack_pkt(struct uet_ep *uet_ep, union uet_pkt *pkt,
 			      uet_pds_next_hdr_t next_hdr, size_t ses_hdr_len,
@@ -414,7 +414,7 @@ static int uet_pds_tx_ack_pkt(struct uet_ep *uet_ep, union uet_pkt *pkt,
 	ack_state = calloc(1, sizeof(struct uet_pds_ack_state) + ack_pkt_len);
 	if (ack_state == NULL) {
 		UET_API_PRINT_ERRNO("calloc");
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 	ack = (union uet_pkt *) ack_state->ack;
 	ack_state->ack_len = ack_pkt_len;
@@ -438,7 +438,7 @@ static int uet_pds_tx_ack_pkt(struct uet_ep *uet_ep, union uet_pkt *pkt,
 	UET_PDS_PKT_HDR_TRACE(uet, NULL, ack, ack_pkt_len, "TX ACK PACKET");
 	rc = uet_nic_tx_pkt(UET_NIC(uet), ack, &ack->common.ipv4,
 			    (size_t) ack_pkt_len);
-	if (rc == FI_SUCCESS) {
+	if (rc == 0) {
 		uet_gettime(&now);
 		ack_state->ack_time = now;
 		dlist_insert_head(&ack_state->list_entry,
@@ -452,7 +452,7 @@ static int uet_pds_tx_ack_pkt(struct uet_ep *uet_ep, union uet_pkt *pkt,
 /*
  * build and transmit a uet ack packet with ses error code,
  * specifically for case where the packet is not deliverable because
- * there is no libfabric endpoint with the uet address in the request
+ * there is no endpoint with the uet address in the request
  *
  * parms:
  *      uet    - ptr to uet instance struct
@@ -460,8 +460,8 @@ static int uet_pds_tx_ack_pkt(struct uet_ep *uet_ep, union uet_pkt *pkt,
  *      ses_rc - ses return code
  *
  * returns:
- *      FI_SUCCESS on success,
- *      negative value corresponding to fabric errno on error
+ *      0 on success,
+ *      negative value corresponding to errno on error
  */
 static int uet_pds_tx_err_ack_pkt(struct uet_instance *uet,
 				  union uet_pkt *pkt, uet_ses_rc_t ses_rc)
@@ -479,7 +479,7 @@ static int uet_pds_tx_err_ack_pkt(struct uet_instance *uet,
 	ack = calloc(1, sizeof(struct uet_std_rsp_pkt));
 	if (ack == NULL) {
 		UET_API_PRINT_ERRNO("calloc");
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	/* build ses header */
@@ -526,7 +526,7 @@ int uet_pds_sng_initialize(struct uet_instance *uet)
 	uet->pds.msl = UET_DEFAULT_MSL;
 	uet->pds.ack_ip_tos = uet_dscp_to_tos(UET_IP_DEFAULT_ACK_DSCP);
 	uet->pds.max_ack_data = UET_DEFAULT_PDS_MAX_ACK_DATA;
-	return FI_SUCCESS;
+	return 0;
 }
 
 /* free pds resources for uet instance */
@@ -542,13 +542,13 @@ int uet_pds_sng_ep_initialize(struct uet_ep *uet_ep)
 	pds_state = calloc(1, sizeof(struct uet_pds_sng_state));
 	if (pds_state == NULL) {
 		UET_API_PRINT_ERRNO("calloc");
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	uet_ep->pds = pds_state;
 
 	dlist_init(&pds_state->ack_state_list_head);
-	return FI_SUCCESS;
+	return 0;
 }
 
 /* free pds resources for endpoint */
@@ -605,14 +605,14 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, struct uet_ep *uet_ep,
 	/* done for now if transmit in progress and not retry */
 	if (uet_pds_ep_tx_active(uet_ep) &&
 	    !(flags & UET_PDS_FLAG_RETRANSMIT))
-		return -FI_EAGAIN;
+		return -EAGAIN;
 
 	/* allocate buffer to build packet   */
 	/* TODO: add support for gather send */
 	uet_pkt = calloc(1, uet->nic.max_pkt_size);
 	if (uet_pkt == NULL) {
 		UET_API_PRINT_ERRNO("calloc");
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	uet_build_eth_hdr(&uet_pkt->common.eth, av_entry->nh_mac_addr,
@@ -631,7 +631,7 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, struct uet_ep *uet_ep,
 		default:
 			UET_API_ERR("Unsupported packet delivery mode = %d",
 				    mode);
-			return -FI_EINVAL;
+			return -EINVAL;
 		}
 
 		/* TODO: IPv6 support and UDP support */
@@ -670,7 +670,7 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, struct uet_ep *uet_ep,
 		break;
 	default:
 		UET_API_ERR("Unsupported next header type  = %d", next_hdr);
-		return -FI_EINVAL;
+		return -EINVAL;
 	};
 
 	uet_build_ipv4_hdr(uet, &uet_pkt->common.ipv4, htonl(dst_addr->fa.v4),
@@ -719,7 +719,7 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, struct uet_ep *uet_ep,
 	UET_PDS_PKT_HDR_TRACE(uet, NULL, uet_pkt, uet_pkt_len, "TX PACKET");
 	rc = uet_nic_tx_pkt(UET_NIC(uet), uet_pkt, &uet_pkt->common.ipv4,
 			    uet_pkt_len);
-	if (rc == FI_SUCCESS)
+	if (rc == 0)
 		pds_state->tx.tx_active = true;
 	free(uet_pkt);
 	return rc;
@@ -730,7 +730,7 @@ int uet_pds_sng_msg_cmpl_ind(struct uet_ep *uet_ep,
 			     uet_addr_handle_t dst_addr_handle,
 			     uet_pds_mode_t mode, uint16_t msg_id)
 {
-	return FI_SUCCESS;
+	return 0;
 }
 
 /* progress tx operations for endpoint */
@@ -748,7 +748,7 @@ int uet_pds_sng_progress_tx(struct uet_ep *uet_ep,
 
 	/* check if tx is active on endpoint */
 	if (!uet_pds_ep_tx_active(uet_ep))
-		return -FI_EAGAIN;
+		return -EAGAIN;
 
 	pds_tx = &pds_state->tx;
 	*err_pkt_handle = pds_tx->pkt_parms.tx_pkt_handle;
@@ -757,12 +757,12 @@ int uet_pds_sng_progress_tx(struct uet_ep *uet_ep,
 	uet_gettime(&now);
 	delta = now - pds_tx->start_time;
 	if (delta < uet->pds.tx_timeout)
-		return FI_SUCCESS;
+		return 0;
 
 	if (pds_tx->retry_cnt >= uet->pds.max_tx_retries) {
 		/* retries exhausted */
 		pds_state->tx.tx_active = false;
-		return -FI_EIO;
+		return -EIO;
 	}
 
 	/* retransmit the packet */
@@ -848,7 +848,7 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 	pkt = (union uet_pkt *) malloc(uet->nic.max_pkt_size);
 	if (pkt == NULL) {
 		UET_API_PRINT_ERRNO("malloc");
-		return -FI_ENOMEM;
+		return -ENOMEM;
 	}
 
 	/* allocate space for ses response header + ack data for read */
@@ -856,7 +856,7 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 			     uet->pds.max_ack_data);
 	if (rsp_ses_hdr == NULL) {
 		UET_API_PRINT_ERRNO("malloc");
-		rc = -FI_ENOMEM;
+		rc = -ENOMEM;
 		goto exit;
 	}
 
@@ -868,8 +868,8 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 
 	/* parse the packet */
 	rc = uet_parse_pkt(uet, pkt, rx_pkt_size, &pp);
-	if (rc != FI_SUCCESS) {
-		if (rc == -FI_EFAULT)
+	if (rc != 0) {
+		if (rc == -EFAULT)
 			UET_API_ERR("RX of malformed UET packet");
 		goto exit;
 	}
@@ -931,7 +931,7 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 
 		/* upcall for ses processing */
 		rc = ses_upcall->rx_rsp(pds_tx->pkt_parms.tx_pkt_handle, &pp);
-		if (rc == FI_SUCCESS) {
+		if (rc == 0) {
 			/* update seq num for transmission of next packet */
 			pds_tx->psn++;
 			pds_tx->tx_active = false;
@@ -964,7 +964,7 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 					uet, &pp, &pds_info,
 					&rsp_next_hdr, rsp_ses_hdr,
 					&rsp_ses_hdr_len, &ses_nack, &gtd_del);
-		if (rc == FI_SUCCESS) {
+		if (rc == 0) {
 			/* TODO: add support for pds nack               */
 			/*   - for now, just don't send ack, which will */
 			/*     retrigger retransmit, similar to nack    */

--- a/uet_pkt_hdr.h
+++ b/uet_pkt_hdr.h
@@ -72,7 +72,7 @@ struct uet_vlan_tag {
 /*                               ENTROPY                                    */
 /****************************************************************************/
 
-/* uet entropy header - used when running directory over IPv4/IPv6 */
+/* uet entropy header - used when running directly over IPv4/IPv6 */
 struct UET_PACKED uet_entropy {
 	uint16_t entropy;
 	uint16_t rsvd;
@@ -692,8 +692,7 @@ struct UET_PACKED uet_ses_rsp_ds {
 /* TODO: IPv6 support */
 #define UET_MIN_PKT_SIZE (sizeof(struct ethhdr) + \
 			  sizeof(struct iphdr) + \
-			  sizeof(struct uet_pds_ack) + \
-			  sizeof(struct uet_pds_def_rsp))
+			  sizeof(struct uet_pds_ctrl))
 
 /* get job id from standard request packet */
 static inline uint32_t uet_get_std_req_job_id(struct uet_ses_req_std *ses)

--- a/uet_sec.c
+++ b/uet_sec.c
@@ -124,18 +124,18 @@ int uet_sec_build_hdr(uint32_t sdi,
 	if ((pkt == NULL) || (pkt_len <= 0) ||
 	    (new_pkt == NULL) || (new_pkt_len == NULL)) {
 		UET_TSS_ERR("invalid args to build security header\n");
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	if (sdi >= UET_SEC_MAX_SD) {
 		UET_TSS_ERR("invalid SDI %u\n", sdi);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	sd = &sdkdb[sdi];
 	if (!sd->enabled) {
 		UET_TSS_ERR("SDI %u is not enabled\n", sdi);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	/* TODO: IPv6 support and UDP support */
@@ -147,7 +147,7 @@ int uet_sec_build_hdr(uint32_t sdi,
 	if (sd->use_ssi) {
 		if ((pkt - sizeof(struct uet_sec_ssi)) < pkt_buf) {
 			UET_TSS_ERR("no headroom for uet_sec_ssi header\n");
-			return -FI_EINVAL;
+			return -EINVAL;
 		}
 
 		*new_pkt     = (pkt - sizeof(struct uet_sec_ssi));
@@ -156,7 +156,7 @@ int uet_sec_build_hdr(uint32_t sdi,
 	} else {
 		if ((pkt - sizeof(struct uet_sec)) < pkt_buf) {
 			UET_TSS_ERR("no headroom for uet_sec header\n");
-			return -FI_EINVAL;
+			return -EINVAL;
 		}
 
 		*new_pkt     = (pkt - sizeof(struct uet_sec));
@@ -206,7 +206,7 @@ int uet_sec_build_hdr(uint32_t sdi,
 		sec->epoch_tsc = htonll(sec->epoch_tsc);
 	}
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 int uet_sec_update_hdr_tsc(uint8_t *pkt)
@@ -229,7 +229,7 @@ int uet_sec_update_hdr_tsc(uint8_t *pkt)
 	if (((tfs & UET_SEC_TYPE_MASK) >> UET_SEC_TYPE_SHIFT) !=
 	     UET_PDS_TYPE_SECURITY) {
 		UET_TSS_ERR("no security header present\n");
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	/* get the sdi */
@@ -237,14 +237,14 @@ int uet_sec_update_hdr_tsc(uint8_t *pkt)
 
 	if (sdi >= UET_SEC_MAX_SD) {
 		UET_TSS_ERR("invalid SDI %u\n", sdi);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	/* get the SD to pull the latest epoch */
 	sd = &sdkdb[sdi];
 	if (!sd->enabled) {
 		UET_TSS_ERR("SDI %u is not enabled\n", sdi);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	uet_gettime((time_t *)&tsc);
@@ -263,7 +263,7 @@ int uet_sec_update_hdr_tsc(uint8_t *pkt)
 		sec->epoch_tsc = htonll(sec->epoch_tsc);
 	}
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 int uet_sec_enc_pkt(struct uet_instance *uet,
@@ -310,7 +310,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 	if (((tfs & UET_SEC_TYPE_MASK) >> UET_SEC_TYPE_SHIFT) !=
 	     UET_PDS_TYPE_SECURITY) {
 		UET_TSS_ERR("no security header present\n");
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	/* get the sdi/an */
@@ -319,19 +319,19 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 
 	if (sdi >= UET_SEC_MAX_SD) {
 		UET_TSS_ERR("invalid SDI %u\n", sdi);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	sd = &sdkdb[sdi];
 	if (!sd->enabled) {
 		UET_TSS_ERR("SDI %u is not enabled\n", sdi);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	/* if the SSI is being used, verify it's there in the header */
 	if (sd->use_ssi && !(tfs & UET_SEC_SP_MASK)) {
 		UET_TSS_ERR("security header is missing the SSI\n");
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	/* get the epoch/tsc */
@@ -347,7 +347,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 	if ((enc_out < (pkt + pkt_len)) ||
 	    ((enc_out + pkt_len) > (pkt_buf + pkt_buf_len))) {
 		UET_TSS_ERR("pkt buffer not large enough for crypto out\n");
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	/* generate the key needed for encrypting the packet */
@@ -409,7 +409,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 
 	default:
 		UET_TSS_ERR("unknown mode\n");
-		return -FI_EINVAL;
+		return -EINVAL;
 		break;
 	}
 
@@ -448,7 +448,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 			       tag);
 	if (rc != 0) {
 		UET_TSS_ERR("failed to encrypt packet\n");
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	memcpy((enc_out + pkt_len - UET_SEC_TAG_LEN), tag, UET_SEC_TAG_LEN);
@@ -456,7 +456,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 	*enc_pkt = enc_out;
 	*enc_pkt_len = pkt_len;
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 int uet_sec_dec_pkt(struct uet_instance *uet,
@@ -495,7 +495,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	    (ipv4->ihl != UET_IPV4_IHL_NO_OPTIONS) ||
 	    (ipv4->protocol != uet->uet_ipproto)) {
 		*tag_len = 0;
-		return FI_SUCCESS;
+		return 0;
 	}
 
 	sec_hdr = (pkt +
@@ -509,7 +509,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	if (((tfs & UET_SEC_TYPE_MASK) >> UET_SEC_TYPE_SHIFT) !=
 	     UET_PDS_TYPE_SECURITY) {
 		*tag_len = 0;
-		return FI_SUCCESS;
+		return 0;
 	}
 
 	/* get the sdi/an */
@@ -518,19 +518,19 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 
 	if (sdi >= UET_SEC_MAX_SD) {
 		UET_TSS_ERR("invalid SDI %u\n", sdi);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	sd = &sdkdb[sdi];
 	if (!sd->enabled) {
 		UET_TSS_ERR("SDI %u is not enabled\n", sdi);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	/* if the SSI is being used, verify it's there in the header */
 	if (sd->use_ssi && !(tfs & UET_SEC_SP_MASK)) {
 		UET_TSS_ERR("security header is missing the SSI\n");
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	/* get the epoch/tsc */
@@ -598,7 +598,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 
 	default:
 		UET_TSS_ERR("unknown mode\n");
-		return -FI_EINVAL;
+		return -EINVAL;
 		break;
 	}
 
@@ -635,12 +635,12 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 			      (pkt + clrtxt_len));
 	if (rc != 0) {
 		UET_TSS_ERR("failed to decrypt packet\n");
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	*tag_len = UET_SEC_TAG_LEN;
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 static int uet_sec_init_sd(uint32_t sdi,
@@ -657,7 +657,7 @@ static int uet_sec_init_sd(uint32_t sdi,
 
 	if (sdi >= UET_SEC_MAX_SD) {
 		UET_TSS_ERR("invalid SDI %u\n", sdi);
-		return -FI_EINVAL;
+		return -EINVAL;
 	}
 
 	sd = &sdkdb[sdi];
@@ -683,7 +683,7 @@ static int uet_sec_init_sd(uint32_t sdi,
 		if (!getenv(UET_SEC_SSI)) {
 			UET_TSS_ERR("server mode requires SSI\n");
 			memset(sd, 0, sizeof(*sd));
-			return -FI_EINVAL;
+			return -EINVAL;
 		}
 
 		/* TODO: support IPv6 w/ large_context (requires SSI) */
@@ -718,7 +718,7 @@ static int uet_sec_init_sd(uint32_t sdi,
 		memcpy(sd->key[1], derived_key, UET_SEC_KDF_GEN_SIZE);
 	}
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 int uet_sec_init(void)
@@ -735,7 +735,7 @@ int uet_sec_init(void)
 	sec_ssi  = getenv(UET_SEC_SSI);
 
 	if (sec_mode == NULL)
-		return FI_SUCCESS;
+		return 0;
 
 	/* FIXME: Only using SDI=0x1 AN=0x0 for now... */
 
@@ -753,13 +753,13 @@ int uet_sec_init(void)
 
 		if (sec_ssi == NULL) {
 			UET_TSS_ERR("UET_SEC_SSI required for server mode");
-			return -FI_EINVAL;
+			return -EINVAL;
 		}
 
 		if (getenv(UET_SEC_SERVER) && !getenv(UET_SEC_CLIENT_SSI)) {
 			UET_TSS_ERR("UET_SEC_CLIENT_SSI required on server "
 				    "for server mode");
-			return -FI_EINVAL;
+			return -EINVAL;
 		}
 
 		rc = uet_sec_init_sd(DEF_SDI, UET_SEC_MODE_SERVER,
@@ -768,7 +768,7 @@ int uet_sec_init(void)
 	} else {
 
 		UET_TSS_ERR("invalid UET_SEC_MODE environment variable");
-		return -FI_EINVAL;
+		return -EINVAL;
 
 	}
 

--- a/uet_sec.c
+++ b/uet_sec.c
@@ -266,7 +266,8 @@ int uet_sec_update_hdr_tsc(uint8_t *pkt)
 	return FI_SUCCESS;
 }
 
-int uet_sec_enc_pkt(uint8_t *pkt_buf,
+int uet_sec_enc_pkt(struct uet_instance *uet,
+		    uint8_t *pkt_buf,
 		    int pkt_buf_len,
 		    uint8_t *pkt,
 		    int pkt_len,
@@ -280,7 +281,7 @@ int uet_sec_enc_pkt(uint8_t *pkt_buf,
 	uint8_t tag[UET_SEC_TAG_LEN];
 	struct gcm_context gcm;
 	struct uet_sec_sd *sd;
-	struct iphdr *ip;
+	struct iphdr *ipv4;
 	uint8_t *sec_hdr, *aad;
 	struct uet_sec *sec;
 	struct uet_sec_ssi *sec_ssi;
@@ -297,7 +298,7 @@ int uet_sec_enc_pkt(uint8_t *pkt_buf,
 	int i, rc, clrtxt_len;
 
 	/* TODO: IPv6 support (requires SSI) and UDP support */
-	ip = (struct iphdr *)(pkt + sizeof(struct ethhdr));
+	ipv4 = (struct iphdr *)(pkt + sizeof(struct ethhdr));
 	sec_hdr = (pkt +
 		   sizeof(struct ethhdr) +
 		   sizeof(struct iphdr) +
@@ -369,7 +370,7 @@ int uet_sec_enc_pkt(uint8_t *pkt_buf,
 		memset(small_context, 0, sizeof(small_context));
 		memcpy(small_context, (uint8_t *)&epoch, 2);
 		memcpy((small_context + 2), (uint8_t *)&rekey, 4);
-		tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ip->saddr;
+		tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
 		memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
 
 		kdf_ctr_cmac_aes(sd->key[an],
@@ -392,7 +393,7 @@ int uet_sec_enc_pkt(uint8_t *pkt_buf,
 		/* TODO: support IPv6 w/ large_context (requires SSI) */
 		memset(small_context, 0, sizeof(small_context));
 		memcpy(small_context, (uint8_t *)&epoch, 2);
-		tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ip->saddr;
+		tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
 		memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
 
 		kdf_ctr_cmac_aes(sd->key[sd->an],
@@ -418,7 +419,7 @@ int uet_sec_enc_pkt(uint8_t *pkt_buf,
 	aad = (sec_hdr + sd->aoff); /* likely negative and moves backwards */
 
 	/* TODO: support IPv6 (requires SSI) */
-	tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ip->saddr;
+	tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
 	memcpy(iv, (uint8_t *)&tmp_val, 4);
 	tmp_lval = htonll(tsc);
 	memcpy((iv + 4), (uint8_t *)&tmp_lval, 8);
@@ -458,7 +459,8 @@ int uet_sec_enc_pkt(uint8_t *pkt_buf,
 	return FI_SUCCESS;
 }
 
-int uet_sec_dec_pkt(uint8_t *pkt,
+int uet_sec_dec_pkt(struct uet_instance *uet,
+		    uint8_t *pkt,
 		    int pkt_len,
 		    int *tag_len)
 {
@@ -470,7 +472,8 @@ int uet_sec_dec_pkt(uint8_t *pkt,
 	struct uet_sec_sd *sd;
 	struct uet_sec *sec;
 	struct uet_sec_ssi *sec_ssi;
-	struct iphdr *ip;
+	struct ethhdr *eth;
+	struct iphdr *ipv4;
 	uint8_t *sec_hdr, *aad;
 	uint32_t rekey;
 	uint32_t tmp_val;
@@ -483,7 +486,18 @@ int uet_sec_dec_pkt(uint8_t *pkt,
 	int i, rc, clrtxt_len;
 
 	/* TODO: IPv6 support (requires SSI) and UDP support */
-	ip = (struct iphdr *)(pkt + sizeof(struct ethhdr));
+	eth = (struct ethhdr *)pkt;
+	ipv4 = (struct iphdr *)(pkt + sizeof(struct ethhdr));
+
+	/* do some preliminary sanity checks */
+	if ((eth->h_proto != htons(ETH_P_IP)) ||
+	    (ipv4->version != IPVERSION) ||
+	    (ipv4->ihl != UET_IPV4_IHL_NO_OPTIONS) ||
+	    (ipv4->protocol != uet->uet_ipproto)) {
+		*tag_len = 0;
+		return FI_SUCCESS;
+	}
+
 	sec_hdr = (pkt +
 		   sizeof(struct ethhdr) +
 		   sizeof(struct iphdr) +
@@ -545,7 +559,7 @@ int uet_sec_dec_pkt(uint8_t *pkt,
 		memset(small_context, 0, sizeof(small_context));
 		memcpy(small_context, (uint8_t *)&epoch, 2);
 		memcpy((small_context + 2), (uint8_t *)&rekey, 4);
-		tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ip->saddr;
+		tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
 		memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
 
 		kdf_ctr_cmac_aes(sd->key[an],
@@ -568,7 +582,7 @@ int uet_sec_dec_pkt(uint8_t *pkt,
 		/* TODO: support IPv6 w/ large_context (requires SSI) */
 		memset(small_context, 0, sizeof(small_context));
 		memcpy(small_context, (uint8_t *)&epoch, 2);
-		tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ip->saddr;
+		tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
 		memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
 
 		kdf_ctr_cmac_aes(sd->key[sd->an],
@@ -594,7 +608,7 @@ int uet_sec_dec_pkt(uint8_t *pkt,
 	aad = (sec_hdr + sd->aoff); /* likely negative and moves backwards */
 
 	/* TODO: support IPv6 (requires SSI) */
-	tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ip->saddr;
+	tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
 	memcpy(iv, (uint8_t *)&tmp_val, 4);
 	tmp_lval = htonll(tsc);
 	memcpy((iv + 4), (uint8_t *)&tmp_lval, 8);

--- a/uet_sec.h
+++ b/uet_sec.h
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 
+#include "uet_api_private.h"
 #include "uet_util.h"
 
 #define UET_SEC_MODE       "UET_SEC_MODE"
@@ -57,7 +58,8 @@ int uet_sec_update_hdr_tsc(uint8_t *pkt);
  * The pkt_len field is expected to include the length of the auth tag.
  * The encrypted pkt pointer and length are returned in enc_pkt/enc_pkt_len.
  */
-int uet_sec_enc_pkt(uint8_t *pkt_buf,
+int uet_sec_enc_pkt(struct uet_instance *uet,
+		    uint8_t *pkt_buf,
 		    int pkt_buf_len,
 		    uint8_t *pkt,
 		    int pkt_len,
@@ -68,7 +70,8 @@ int uet_sec_enc_pkt(uint8_t *pkt_buf,
  * Decryption occurs inplace. The length of the tag is returned so the
  * payload length can be determined from the total packet length.
  */
-int uet_sec_dec_pkt(uint8_t *pkt,
+int uet_sec_dec_pkt(struct uet_instance *uet,
+		    uint8_t *pkt,
 		    int pkt_len,
 		    int *tag_len);
 

--- a/util/bitmap.c
+++ b/util/bitmap.c
@@ -253,17 +253,19 @@ void bm_print_idx(const struct bitmap *b)
 	printf("\n}\n");
 }
 
-void bm_print_bits(const struct bitmap *b)
+void bm_print_bits(const struct bitmap *b, char (*bit_char)(void *))
 {
 	int i, idx, bit, word_size;
+	void *data;
 
 	word_size = (sizeof(uint64_t) * 8);
 	for (idx = (b->bit_arr_len - 1); idx >= 0; idx--) {
 		for (i = (word_size - 1); i >= 0; i--) {
 			bit = (i + (idx * word_size));
-			printf("%d", (bm_get(b, bit, NULL) ? 1 : 0));
+			bm_get(b, bit, &data);
+			printf("%c", bit_char(data));
 			if ((i != 0) && ((i % 8) == 0))
-				printf(".");
+				printf(" ");
 		}
 		printf(" (%d..%d)\n",
 		       (((idx + 1) * word_size) - 1),

--- a/util/bitmap.h
+++ b/util/bitmap.h
@@ -37,6 +37,6 @@ void bm_shift_right(struct bitmap *bm, int s);
 bool bm_next_set_bit_iter(const struct bitmap *bm, int *i);
 
 void bm_print_idx(const struct bitmap *b);
-void bm_print_bits(const struct bitmap *b);
+void bm_print_bits(const struct bitmap *b, char (*bit_char)(void *));
 
 #endif /* _BITMAP_H_ */

--- a/util/uet_log.h
+++ b/util/uet_log.h
@@ -25,6 +25,8 @@
  * Colors can be disabled by undefining UET_LOG_EN_CLR.
  */
 
+#include <stdio.h>
+
 #define UET_LOG_EN_CLR /* comment out to disable log colors */
 
 #define UET_LOG_SES /* comment out to disable all SES logs */
@@ -70,37 +72,52 @@
 #define UET_WARN_CLR UET_CLR_RED
 #define UET_ERR_CLR  UET_CLR_RED
 
-#define UET_LOG(fmt, clr, ...)  \
-	printf("%s" fmt "%s\n", \
-	       (clr),           \
-	       ##__VA_ARGS__,   \
-	       UET_CLR_NORMAL)
+#define UET_LOG(fmt, clr, ...)          \
+	do {                            \
+		printf("%s" fmt "%s\n", \
+		       (clr),           \
+		       ##__VA_ARGS__,   \
+		       UET_CLR_NORMAL); \
+		fflush(stdout);         \
+	} while (0)
 
-#define UET_DBG(fmt, clr, ...)       \
-	printf("%sDBG: " fmt "%s\n", \
-	       (clr),                \
-	       ##__VA_ARGS__,        \
-	       UET_CLR_NORMAL)
+#define UET_DBG(fmt, clr, ...)               \
+	do {                                 \
+		printf("%sDBG: " fmt "%s\n", \
+		       (clr),                \
+		       ##__VA_ARGS__,        \
+		       UET_CLR_NORMAL);      \
+		fflush(stdout);              \
+	} while (0)
 
-#define UET_INFO(fmt, clr, ...)       \
-	printf("%sINFO: " fmt "%s\n", \
-	       (clr),                 \
-	       ##__VA_ARGS__,         \
-	       UET_CLR_NORMAL)
+#define UET_INFO(fmt, clr, ...)               \
+	do {                                  \
+		printf("%sINFO: " fmt "%s\n", \
+		       (clr),                 \
+		       ##__VA_ARGS__,         \
+		       UET_CLR_NORMAL);       \
+		fflush(stdout);               \
+	} while (0)
 
-#define UET_WARN(fmt, ...)                    \
-	printf("%s[%s:%d] WARN: " fmt "%s\n", \
-	       UET_WARN_CLR,                  \
-	       __FILE__, __LINE__,            \
-	       ##__VA_ARGS__,                 \
-	       UET_CLR_NORMAL)
+#define UET_WARN(fmt, ...)                            \
+	do {                                          \
+		printf("%s[%s:%d] WARN: " fmt "%s\n", \
+		       UET_WARN_CLR,                  \
+		       __FILE__, __LINE__,            \
+		       ##__VA_ARGS__,                 \
+		       UET_CLR_NORMAL);               \
+		fflush(stdout);                       \
+	} while (0)
 
-#define UET_ERR(fmt, ...)                      \
-	printf("%s[%s:%d] ERROR: " fmt "%s\n", \
-	       UET_ERR_CLR,                    \
-	       __FILE__, __LINE__,             \
-	       ##__VA_ARGS__,                  \
-	       UET_CLR_NORMAL)
+#define UET_ERR(fmt, ...)                              \
+	do {                                           \
+		printf("%s[%s:%d] ERROR: " fmt "%s\n", \
+		       UET_ERR_CLR,                    \
+		       __FILE__, __LINE__,             \
+		       ##__VA_ARGS__,                  \
+		       UET_CLR_NORMAL);                \
+		fflush(stdout);                        \
+	} while (0)
 
 #if UET_LOG_LVL >= UET_LOG_DBG
 # ifdef UET_LOG_SES

--- a/util/uet_pkt_chk.c
+++ b/util/uet_pkt_chk.c
@@ -7,11 +7,14 @@
 #include <linux/ip.h>
 
 #include "uet_pkt_chk.h"
+#include "uet_log.h"
 
 /* determine if uet packet type is valid */
 static bool uet_pds_pkt_type_valid(uint8_t *pkt,
+				   size_t pkt_size,
 				   bool *pkt_is_ack,
-				   bool *pkt_is_rd_rsp)
+				   bool *pkt_is_rd_rsp,
+				   bool *pkt_is_ctrl)
 {
 	struct uet_sec *sec_hdr;
 	struct uet_pds_req *pds_hdr;
@@ -20,6 +23,7 @@ static bool uet_pds_pkt_type_valid(uint8_t *pkt,
 
 	*pkt_is_ack = false;
 	*pkt_is_rd_rsp = false;
+	*pkt_is_ctrl = false;
 
 	/* TODO: IPv6 support and UDP support */
 	pds_hdr = (struct uet_pds_req *)(pkt +
@@ -55,10 +59,31 @@ static bool uet_pds_pkt_type_valid(uint8_t *pkt,
 	case UET_PDS_TYPE_RUD_REQ:
 		pds_req = true;
 		break;
+	case UET_PDS_TYPE_UUD_REQ:
+		/* TODO: unsupported */
+		UET_PDS_WARN("UUD_REQ packets not supported");
+		return false;
 	case UET_PDS_TYPE_ACK:
 		pds_req = false;
 		next_hdr = UET_HDR_RSP;
 		break;
+	case UET_PDS_TYPE_ACK_CC:
+	case UET_PDS_TYPE_ACK_CCX:
+		/* TODO: unsupported */
+		UET_PDS_WARN("ACK_CC packets not supported");
+		return false;
+	case UET_PDS_TYPE_NACK:
+		/* TODO: unsupported */
+		UET_PDS_WARN("NACK packets not supported");
+		return false;
+	case UET_PDS_TYPE_CTRL:
+		*pkt_is_ctrl = true;
+		return true;
+	case UET_PDS_TYPE_RUDI_REQ:
+	case UET_PDS_TYPE_RUDI_RESP:
+		/* TODO: unsupported */
+		UET_PDS_WARN("RUDI packets not supported");
+		return false;
 	default:
 		return false;
 	}
@@ -95,24 +120,60 @@ bool uet_pds_rx_pkt_chk(struct uet_instance *uet,
 			uint8_t *pkt,
 			size_t pkt_size,
 			bool *pkt_is_ack,
-			bool *pkt_is_rd_rsp)
+			bool *pkt_is_rd_rsp,
+			bool *pkt_is_ctrl)
 {
 	struct ethhdr *eth = (struct ethhdr *)pkt;
 	struct iphdr *ipv4 = (struct iphdr *)(eth + 1);
 
 	/* TODO: IPv6 support */
-	if (!memcmp(eth->h_dest, uet->nic.mac_addr, ETH_ALEN) &&
-	    (eth->h_proto == htons(ETH_P_IP)) &&
-	    (ipv4->version == IPVERSION) &&
-	    (ipv4->ihl == UET_IPV4_IHL_NO_OPTIONS) &&
-	    (ipv4->protocol == uet->uet_ipproto) &&
-	    (ipv4->tot_len >= htons(uet->nic.min_ip_pkt_size)) &&
-	    (ipv4->tot_len <=
-	     htons((pkt_size - uet->nic.l2_hdr_size))) &&
-	    (uet_ipv4_csum(ipv4) == 0) &&
-	    (uet_pds_pkt_type_valid(pkt, pkt_is_ack, pkt_is_rd_rsp)))
-		return true;
 
-	return false;
+	if (memcmp(eth->h_dest, uet->nic.mac_addr, ETH_ALEN) != 0) {
+		UET_PDS_WARN("dest MAC mismatch");
+		return false;
+	}
+
+	if (eth->h_proto != htons(ETH_P_IP)) {
+		UET_PDS_WARN("not an IPv4 packet");
+		return false;
+	}
+
+	if (ipv4->version != IPVERSION) {
+		UET_PDS_WARN("invalid IPv4 header version");
+		return false;
+	}
+
+	if (ipv4->ihl != UET_IPV4_IHL_NO_OPTIONS) {
+		UET_PDS_WARN("IPv4 header options not supported");
+		return false;
+	}
+
+	if (ipv4->protocol != uet->uet_ipproto) {
+		UET_PDS_WARN("unsupported IP protocol");
+		return false;
+	}
+
+	if (ipv4->tot_len < htons(uet->nic.min_ip_pkt_size)) {
+		UET_PDS_WARN("IPv4 total length too small");
+		return false;
+	}
+
+	if (ipv4->tot_len > htons((pkt_size - uet->nic.l2_hdr_size))) {
+		UET_PDS_WARN("IPv4 total length too large");
+		return false;
+	}
+
+	if (uet_ipv4_csum(ipv4) != 0) {
+		UET_PDS_WARN("IPv4 header checksum invalid");
+		return false;
+	}
+
+	if (!uet_pds_pkt_type_valid(pkt, pkt_size, pkt_is_ack,
+				    pkt_is_rd_rsp, pkt_is_ctrl)) {
+		UET_PDS_WARN("invalid UET PDS packet type");
+		return false;
+	}
+
+	return true;
 }
 

--- a/util/uet_pkt_chk.h
+++ b/util/uet_pkt_chk.h
@@ -19,15 +19,12 @@
  *   - validate uet packet type
  *
  * parms:
- *      uet        - ptr to uet instance struct
- *      pkt        - ptr to received packet
- *      pkt_size   - size of received packet in bytes
- *      pkt_is_ack - ptr to location where indication of packet type
- *                   is returned, true => packet is an ack packet,
- *                   only valid when function returns true
- *      pkt_is_rd_rsp - ptr to location where indication of packet type
- *                      is returned, true => packet is a read response in
- *                      a pds request, only valid when function returns true
+ *      uet           - ptr to uet instance struct
+ *      pkt           - ptr to received packet
+ *      pkt_size      - size of received packet in bytes
+ *      pkt_is_ack    - set to true when packet is an ack packet
+ *      pkt_is_rd_rsp - set to true when packet is a read response packet
+ *      pkt_is_ctrl   - set to true when packet is a control packet
  *
  * returns:
  *      true  => packet passed validation checks
@@ -37,5 +34,6 @@ bool uet_pds_rx_pkt_chk(struct uet_instance *uet,
 			uint8_t *pkt,
 			size_t pkt_size,
 			bool *pkt_is_ack,
-			bool *pkt_is_rd_rsp);
+			bool *pkt_is_rd_rsp,
+			bool *pkt_is_ctrl);
 

--- a/util/uet_util.c
+++ b/util/uet_util.c
@@ -758,15 +758,15 @@ void uet_rw_unlock(struct uet_rw_lock *lock, uet_rw_lock_access_t access)
  *      field_len    - length of the packet field to be checked in bytes
  *
  * returns:
- *	 FI_SUCCESS: field is within packet bounds
- *	-FI_EFAULT:  packet is malformed
+ *	 0: field is within packet bounds
+ *	-EFAULT: packet is malformed
  */
 static int uet_parse_chk_next_field(struct uet_parsed_pkt *pp,
 				    uint16_t field_offset, uint16_t field_len)
 {
 	if ((field_offset + field_len) > pp->pkt_len)
-		return -FI_EFAULT;
-	return FI_SUCCESS;
+		return -EFAULT;
+	return 0;
 }
 
 /* determine if ip protocol is associated with a supported ipv6 ext hdr */
@@ -800,9 +800,9 @@ static bool uet_is_valid_ipv6_ext_hdr(uint8_t ipproto)
  *              - ip_protocol
  *
  * returns:
- *	 FI_SUCCESS: packet successfully parsed
- *	-FI_EINVAL:  packet is not a properly encapsulated UET packet
- *	-FI_EFAULT:  malformed packet
+ *	 0: packet successfully parsed
+ *	-EINVAL: packet is not a properly encapsulated UET packet
+ *	-EFAULT: malformed packet
  */
 static int uet_get_ipv6_nexthdr(struct uet_instance *uet,
 				struct uet_parsed_pkt *pp)
@@ -821,18 +821,18 @@ static int uet_get_ipv6_nexthdr(struct uet_instance *uet,
 		    (pp->ip_protocol == IPPROTO_UDP))
 			break;
 		if (!uet_is_valid_ipv6_ext_hdr(pp->ip_protocol))
-			return -FI_EINVAL;
+			return -EINVAL;
 		opt_hdr = (struct ipv6_opt_hdr *)
 			(((uint8_t *) pp->ip) + pp->ip_len);
 		rc = uet_parse_chk_next_field(pp, pp->eth_len + pp->ip_len,
 				sizeof(struct ipv6_opt_hdr));
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 		pp->ip_protocol = opt_hdr->nexthdr;
 		pp->ip_len += ((opt_hdr->hdrlen + 1) << 3);
 	}
 
-	return FI_SUCCESS;
+	return 0;
 }
 
 /*
@@ -888,9 +888,9 @@ uint16_t uet_get_ses_req_payload_len(struct uet_parsed_pkt *pp,
  *      pp      - ptr to struct where packet parsing results are returned
  *
  * returns:
- *	 FI_SUCCESS: packet successfully parsed
- *	-FI_EINVAL:  packet is not a properly encapsulated UET packet
- *	-FI_EFAULT:  malformed packet
+ *	 0: packet successfully parsed
+ *	-EINVAL: packet is not a properly encapsulated UET packet
+ *	-EFAULT: malformed packet
  */
 int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 		  struct uet_parsed_pkt *pp)
@@ -979,7 +979,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 		break;
 	case ETH_P_IPV6:
 		rc = uet_get_ipv6_nexthdr(uet, pp);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 		break;
 	default:
@@ -1003,7 +1003,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 			udp = (struct udphdr *) p;
 			rc = uet_parse_chk_next_field(
 				pp, cur_len, sizeof(struct udphdr));
-			if (rc != FI_SUCCESS)
+			if (rc != 0)
 				return rc;
 			if (ntohs(udp->dest) != uet->uet_udp_port)
 				goto err_exit;
@@ -1021,7 +1021,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 	/* parse security header */
 	pds_prlg = (struct uet_pds_prlg *)p;
 	rc = uet_parse_chk_next_field(pp, cur_len, sizeof(struct uet_pds_prlg));
-	if (rc != FI_SUCCESS)
+	if (rc != 0)
 		return rc;
 	pds_type_next_flags = ntohs(pds_prlg->type_next_flags);
 	pp->pds_type = ((pds_type_next_flags & UET_PDS_TYPE_MASK) >>
@@ -1053,7 +1053,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 		pds_prlg = (struct uet_pds_prlg *) p;
 		rc = uet_parse_chk_next_field(
 				pp, cur_len, sizeof(struct uet_pds_prlg));
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 		pds_type_next_flags = ntohs(pds_prlg->type_next_flags);
 		pp->pds_type = (pds_type_next_flags & UET_PDS_TYPE_MASK) >>
@@ -1089,7 +1089,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 		break;
 	case UET_PDS_TYPE_UUD_REQ:
 		/* TODO: support for parsing UUD */
-		return -FI_EINVAL;
+		return -EINVAL;
 	case UET_PDS_TYPE_ACK:
 	case UET_PDS_TYPE_ACK_CC:
 	case UET_PDS_TYPE_ACK_CCX:
@@ -1109,7 +1109,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 		pp->pds_spdcid = ntohs(pds_nack->spdcid);
 		pp->pds_dpdcid = ntohs(pds_nack->dpdcid);
 		pp->pds_nack_code = pds_nack->nack_code;
-		return FI_SUCCESS;
+		return 0;
 	case UET_PDS_TYPE_CTRL:
 		pds_ctrl = (struct uet_pds_ctrl *)pp->pds;
 		pp->pds_len = sizeof(struct uet_pds_ctrl);
@@ -1131,11 +1131,11 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 			pp->pds_dpdcid = ntohs(pds_ctrl->dpdcid);
 		}
 		pp->pds_ctrl_payload = ntohl(pds_ctrl->payload);
-		return FI_SUCCESS;
+		return 0;
 	case UET_PDS_TYPE_RUDI_REQ:
 	case UET_PDS_TYPE_RUDI_RESP:
 		/* TODO: support for parsing RUDI */
-		return -FI_EINVAL;
+		return -EINVAL;
 	default:
 		goto err_exit;
 	}
@@ -1153,7 +1153,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 	case UET_HDR_REQ_STD:
 		rc = uet_parse_chk_next_field(
 			pp, cur_len, sizeof(struct uet_ses_req_std));
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 		pp->ses_len = sizeof(struct uet_ses_req_std);
 		ses_req = (struct uet_ses_req_std *) pp->ses;
@@ -1188,7 +1188,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 		if (pp->ses_opcode != UET_READ) {
 			rc = uet_parse_chk_next_field(
 					pp, cur_len, pp->ses_payload_len);
-			if (rc != FI_SUCCESS)
+			if (rc != 0)
 				return rc;
 			cur_len += pp->ses_payload_len;
 		}
@@ -1203,14 +1203,14 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 			rc = uet_parse_chk_next_field(
 					pp, cur_len,
 					sizeof(struct uet_pds_def_rsp));
-			if (rc != FI_SUCCESS)
+			if (rc != 0)
 				return rc;
 			pp->ses_len = sizeof(struct uet_pds_def_rsp);
 		} else {
 			rc = uet_parse_chk_next_field(
 					pp, cur_len,
 					sizeof(struct uet_ses_rsp));
-			if (rc != FI_SUCCESS)
+			if (rc != 0)
 				return rc;
 			pp->ses_len = sizeof(struct uet_ses_rsp);
 		}
@@ -1221,7 +1221,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 	case UET_HDR_RSP_DATA:
 		rc = uet_parse_chk_next_field(
 				pp, cur_len, sizeof(struct uet_ses_rsp_d));
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 		pp->ses_len = sizeof(struct uet_ses_rsp_d);
 		cur_len += pp->ses_len;
@@ -1237,7 +1237,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 			 UET_SES_RSP_D_PAYLOAD_LEN_MASK) >>
 			UET_SES_RSP_D_PAYLOAD_LEN_SHIFT;
 		rc = uet_parse_chk_next_field(pp, cur_len, pp->ses_payload_len);
-		if (rc != FI_SUCCESS)
+		if (rc != 0)
 			return rc;
 		cur_len += pp->ses_payload_len;
 		break;
@@ -1248,9 +1248,9 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 		goto err_exit;
 	}
 
-	return FI_SUCCESS;
+	return 0;
 
 err_exit:
-	return -FI_EINVAL;
+	return -EINVAL;
 }
 

--- a/util/uet_util.c
+++ b/util/uet_util.c
@@ -813,6 +813,7 @@ static int uet_get_ipv6_nexthdr(struct uet_instance *uet,
 
 	ipv6 = (struct ipv6hdr *) pp->ip;
 	pp->ip_len = sizeof(struct ipv6hdr);
+	pp->ip_payload_len = ntohs(ipv6->payload_len);
 	pp->ip_protocol = ipv6->nexthdr;
 
 	while (1) {
@@ -965,13 +966,16 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 		default:
 			goto err_exit;
 		}
-	} else
+	} else {
 		ethertype = pp->ethertype;
+	}
 	switch (ethertype) {
 	case ETH_P_IP:
 		ipv4 = (struct iphdr *) p;
 		pp->ip_protocol = ipv4->protocol;
-		pp->ip_len = ipv4->ihl << 2;
+		pp->ip_len = (ipv4->ihl << 2);
+		pp->ip_payload_len = (ntohs(ipv4->tot_len) -
+				      sizeof(struct iphdr));
 		break;
 	case ETH_P_IPV6:
 		rc = uet_get_ipv6_nexthdr(uet, pp);
@@ -1075,16 +1079,17 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 		pp->pds_spdcid = ntohs(pds_req->spdcid);
 		pp->pds_clear_psn = ((int16_t)ntohs(pds_req->clear_psn_offset) +
 				     pp->pds_psn);
-		if (pp->pds_flags & UET_PDS_REQ_FLAGS_SYN)
+		if (pp->pds_flags & UET_PDS_REQ_FLAGS_SYN) {
 			pp->pds_syn_off = ((ntohs(pds_req->pdc_info_psn_offset) &
 					    UET_PDS_REQ_PSN_OFFSET_MASK) >>
 					   UET_PDS_REQ_PSN_OFFSET_SHIFT);
-		else
+		} else {
 			pp->pds_dpdcid = ntohs(pds_req->dpdcid);
+		}
 		break;
 	case UET_PDS_TYPE_UUD_REQ:
-		pp->pds_len = sizeof(struct uet_pds_uud_req);
-		return FI_SUCCESS;
+		/* TODO: support for parsing UUD */
+		return -FI_EINVAL;
 	case UET_PDS_TYPE_ACK:
 	case UET_PDS_TYPE_ACK_CC:
 	case UET_PDS_TYPE_ACK_CCX:
@@ -1108,12 +1113,29 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 	case UET_PDS_TYPE_CTRL:
 		pds_ctrl = (struct uet_pds_ctrl *)pp->pds;
 		pp->pds_len = sizeof(struct uet_pds_ctrl);
+		pp->pds_ctrl_type = pp->next_hdr;
+		pp->pds_psn = ntohl(pds_ctrl->psn);
+		pp->pds_spdcid = ntohs(pds_ctrl->spdcid);
+		if (pp->pds_ctrl_type == UET_PDS_CTRL_TYPE_PROBE)
+			pp->pds_probe_opaque = ntohs(pds_ctrl->probe_opaque);
+		if (pp->pds_flags & UET_PDS_CTRL_FLAGS_SYN) {
+			pp->pds_pdc_info =
+				((ntohs(pds_ctrl->pdc_info_psn_offset) &
+				  UET_PDS_CTRL_PDC_INFO_MASK) >>
+				 UET_PDS_CTRL_PDC_INFO_SHIFT);
+			pp->pds_syn_off =
+				((ntohs(pds_ctrl->pdc_info_psn_offset) &
+				  UET_PDS_CTRL_PSN_OFFSET_MASK) >>
+				 UET_PDS_CTRL_PSN_OFFSET_SHIFT);
+		} else {
+			pp->pds_dpdcid = ntohs(pds_ctrl->dpdcid);
+		}
 		pp->pds_ctrl_payload = ntohl(pds_ctrl->payload);
-		/* TODO: support for parsing control messages */
 		return FI_SUCCESS;
 	case UET_PDS_TYPE_RUDI_REQ:
 	case UET_PDS_TYPE_RUDI_RESP:
 		/* TODO: support for parsing RUDI */
+		return -FI_EINVAL;
 	default:
 		goto err_exit;
 	}
@@ -1124,6 +1146,10 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 	/* parse ses header */
 	pp->ses = p;
 	switch (pp->next_hdr) {
+	case UET_HDR_NONE:
+		pp->ses_len = 0;
+		pp->ses_payload_len = 0;
+		break;
 	case UET_HDR_REQ_STD:
 		rc = uet_parse_chk_next_field(
 			pp, cur_len, sizeof(struct uet_ses_req_std));

--- a/util/uet_util.h
+++ b/util/uet_util.h
@@ -10,7 +10,6 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <rdma/fi_errno.h>
 
 #include "uet_addr.h"
 #include "uet_pkt_hdr.h"
@@ -113,22 +112,21 @@ struct uet_parsed_pkt {
 //#define UET_PDS_PKT_HDR_TRACE_ENABLED
 
 #ifdef UET_PDS_PKT_HDR_TRACE_ENABLED
-#define UET_PDS_PKT_HDR_TRACE(UET, PP, PKT, PKT_LEN, MSG)     \
-	do {                                                  \
-		struct uet_parsed_pkt _pp;                    \
-		if ((PP) == NULL) {                           \
-			if (uet_parse_pkt((UET), (PKT),       \
-					  (PKT_LEN), &_pp) == \
-			    FI_SUCCESS) {                     \
-				printf("\n%s\n\n", (MSG));    \
-				uet_print_pkt_hdrs((&_pp));   \
-				printf("\n");                 \
-			}                                     \
-		} else {                                      \
-			printf("\n%s\n\n", (MSG));            \
-			uet_print_pkt_hdrs((PP));             \
-			printf("\n");                         \
-		}                                             \
+#define UET_PDS_PKT_HDR_TRACE(UET, PP, PKT, PKT_LEN, MSG)          \
+	do {                                                       \
+		struct uet_parsed_pkt _pp;                         \
+		if ((PP) == NULL) {                                \
+			if (uet_parse_pkt((UET), (PKT),            \
+					  (PKT_LEN), &_pp) == 0) { \
+				printf("\n%s\n\n", (MSG));         \
+				uet_print_pkt_hdrs((&_pp));        \
+				printf("\n");                      \
+			}                                          \
+		} else {                                           \
+			printf("\n%s\n\n", (MSG));                 \
+			uet_print_pkt_hdrs((PP));                  \
+			printf("\n");                              \
+		}                                                  \
 	} while (0)
 #else
 #define UET_PDS_PKT_HDR_TRACE(...)

--- a/util/uet_util.h
+++ b/util/uet_util.h
@@ -67,6 +67,7 @@ struct uet_parsed_pkt {
 	uint16_t ethertype;
 	void *ip;                         /* can point to ipv4 or ipv6 header */
 	uint16_t ip_len;
+	uint16_t ip_payload_len;
 	uint8_t ip_protocol;                        /* next protocol after ip */
 	void *udp;
 	uint16_t udp_len;
@@ -92,7 +93,10 @@ struct uet_parsed_pkt {
 	uint8_t pds_syn_off;
 	uint32_t pds_clear_psn;
 	uint8_t pds_nack_code;
-	uint8_t pds_ctrl_payload;
+	uint16_t pds_probe_opaque;
+	uint8_t pds_pdc_info;
+	uint32_t pds_ctrl_payload;
+	uint8_t pds_ctrl_type;
 	uint8_t next_hdr;        /* identifies format of header following pds */
 	void *ses;
 	uint16_t ses_len;


### PR DESCRIPTION
- all logs go to stdout so serialized in the terminal (no stderr)
- fixed bug in SES where multiple packets had SOM set within a msg_id
- fixed CRC32 checks for very small packets containing zero padding (to 60B)
- added support for UET_HDR_NONE (PDS packets with no SES payload)
- PDS packet checks now identify all packet types (verifies control packets)
- PDS manager can randomly close PDCs after EOM seen for active msg_id
- updated initiator/target PDC lookup keys to include both src/dst IPs
- verify all calls to uet_pds_tx_pkt() are the same msg_id between SOM/EOM
- if PDC not found in uet_pds_tx_pkt(), FI_EAGAIN is returned and SES retries
- added support for parsing and processing PDC control packets
- added support for sending PDC close command control packets
- store the uet_ep and av_entry in the initiator PDC state