### PR TITLE
added resiliency to PDC close flows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ CC=gcc
 CLANG=clang
 
 # Auto-discover libfabric directory by searching up parent directories
+# Use LIBFABRIC environment variable if set, otherwise auto-discover
 ifneq ($(MAKECMDGOALS),clean)
+ifndef LIBFABRIC
 LIBFABRIC := $(shell \
 	current_dir=$(CURDIR); \
 	while [ "$$current_dir" != "/" ]; do \
@@ -16,12 +18,13 @@ LIBFABRIC := $(shell \
 		current_dir=$$(dirname $$current_dir); \
 	done; \
 )
-
 ifeq ($(LIBFABRIC),)
 $(error a libfabric directory was not found)
 endif
-
 $(info Found libfabric directory: $(LIBFABRIC))
+else
+$(info Using libfabric directory from environment: $(LIBFABRIC))
+endif
 endif
 
 LF_HDRS=-I$(LIBFABRIC) -I$(LIBFABRIC)/include

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 created: 2025-11-10T19:46
-updated: 2025-11-10T19:48
+updated: 2025-11-17T13:33
 ---
 
 # UEC Reference Provider (libfabric)
@@ -181,6 +181,8 @@ Replace `2` with the desired number of senders.
 - **UET_SEC_MODE** - [ `direct` | `cluster` | `server` ]
 - **UET_SEC_SSI** - The SSI to be used for crypto operations. This value must be unique for all instances of `uet`. If not set the source IP address will be used instead as the source identifier.
 - **UET_SEC_CLIENT_SSI** - If set, the client SSI to be used by the server side of the session. This is only valid for the `UET_SEC_MODE=server` configuration.
+- **UET_PDC_CLOSE_THRESH** - Randomly close a PDC after message Tx EOM (100=1% chance to close, default=0).
+- **UET_PKT_DROP_THRESH** - Randomly drop a Tx packet before sending (100=1% chance to drop, default=0).
 
 ## Security
 

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -31,8 +31,13 @@
 
 #define UET_PDC_MAX 64
 
-#define UET_RANDOM_PDC_CLOSE
-#define UET_RANDOM_PDC_CLOSE_THRESH 10 /* percent */
+/*
+ * These random thresholds can be overridden with the UET_PDC_CLOSE_THRESH
+ * and the UET_PKT_DROP_THRESH environment variables. The values are
+ * represented in hundredths of a percent (1=0.01%, 100=1%, etc).
+ */
+#define UET_PDC_CLOSE_THRESH 0
+#define UET_PKT_DROP_THRESH  0
 
 typedef enum {
 	PDC_STATE_UNALLOC,
@@ -152,6 +157,19 @@ struct uet_pds_state {
 };
 
 static struct uet_pds_state pds_state;
+
+static int pds_pdc_close_thresh = UET_PDC_CLOSE_THRESH;
+static int pds_pkt_drop_thresh = UET_PKT_DROP_THRESH;
+
+/*
+ * Test if a random event should occur based on a threshold. Threshold is in
+ * hundredths of a percent (0.01% granularity). Returns true if event should
+ * occur.
+ */
+static inline bool uet_pds_random_check(int thresh)
+{
+	return ((rand() % 10000) < thresh);
+}
 
 #define PDS_GO()                                          \
 	do {                                              \
@@ -338,6 +356,15 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 		if (tx_pkt)
 			uet_gettime(&pdc_pkt->tx_time);
 
+		/* randomly drop packets for testing retransmit logic */
+		if (pds_pkt_drop_thresh &&
+		    uet_pds_random_check(pds_pkt_drop_thresh)) {
+			UET_PDS_ERR("PDC %u PSN %u random drop %s packet!",
+				    pdc->pdc_id, pp->pds_psn,
+				    (tx_pkt) ? "Tx" : "ACK");
+			return 0;
+		}
+
 		/* TODO: IPv6 support */
 		return uet_nic_tx_pkt(UET_NIC(uet), *pkt, pp->ip, new_pkt_len);
 	}
@@ -396,6 +423,15 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 
 	if (tx_pkt)
 		uet_gettime(&pdc_pkt->tx_time);
+
+	/* randomly drop packets for testing retransmit logic */
+	if (pds_pkt_drop_thresh &&
+	    uet_pds_random_check(pds_pkt_drop_thresh)) {
+		UET_PDS_ERR("PDC %u PSN %u random drop %s packet!",
+			    pdc->pdc_id, pp->pds_psn,
+			    (tx_pkt) ? "Tx" : "ACK");
+		return 0;
+	}
 
 	/* TODO: IPv6 support */
 	return uet_nic_tx_pkt(UET_NIC(uet), new_pkt, pp->ip, new_pkt_len);
@@ -573,6 +609,13 @@ static struct uet_pdc *uet_pdsm_assign_ini_pdc(struct uet_ep *uet_ep,
 	HASH_FIND(pdc_ini_hh, pds_state.pdc_ini_ht, &pdc_key,
 		  sizeof(pdc_key), pdc);
 	if (pdc) {
+		/* if the PDC is in the error state, don't use it */
+		if (pdc->state == PDC_STATE_ERROR) {
+			UET_PDS_DBG("initiator lookup found an errored PDC %u",
+				    pdc->pdc_id);
+			return NULL;
+		}
+
 		/* if the PDC is closing, don't use it for new messages */
 		if (pdc->close_requested) {
 			UET_PDS_DBG("initiator lookup found a closing PDC %u",
@@ -712,6 +755,11 @@ static struct uet_pdc *uet_pdsm_get_pdc(uint16_t pdc_id,
 
 	if (pdc->state == PDC_STATE_UNALLOC) {
 		UET_PDS_ERR("invalid PDC %u (unalloc)", pdc_id);
+		return NULL;
+	}
+
+	if (pdc->state == PDC_STATE_ERROR) {
+		UET_PDS_ERR("invalid PDC %u (error)", pdc_id);
 		return NULL;
 	}
 
@@ -971,7 +1019,18 @@ static int uet_pds_initiate_pdc_close(struct uet_instance *uet,
 		return -EAGAIN;
 	}
 
-	/* the previous active message has drained, send the close command */
+	/*
+	 * Check if all outstanding packets have been ACK'ed. The initiator
+	 * MUST wait for all PDS ACKs to arrive before sending a close
+	 * command on a PDC.
+	 */
+	if (!dlist_empty(&pdc->tx_pkt_list_head)) {
+		UET_PDS_DBG("PDC %u has un-ACK'ed packets (cannot close)",
+			    pdc->pdc_id);
+		return -EAGAIN;
+	}
+
+	/* all messages and packets have drained, send the close command */
 	rc = uet_pds_send_close_cmd(uet, pdc);
 	if (rc != 0) {
 		UET_PDS_ERR("PDC %u failed to send close command",
@@ -1003,8 +1062,20 @@ int uet_pds_initialize(struct uet_instance *uet)
 	struct uet_pdc *pdc;
 	int i;
 
-	/* seed random number generator for PDC close decisions */
+	/* seed random number generator for PDC close and packet drop */
 	srand(time(NULL));
+
+	/* configure random PDC close threshold */
+	if (getenv("UET_PDC_CLOSE_THRESH")) {
+		pds_pdc_close_thresh =
+			strtoul(getenv("UET_PDC_CLOSE_THRESH"), NULL, 10);
+	}
+
+	/* configure random packet drop threshold */
+	if (getenv("UET_PKT_DROP_THRESH")) {
+		pds_pkt_drop_thresh =
+			strtoul(getenv("UET_PKT_DROP_THRESH"), NULL, 10);
+	}
 
 	uet->pds.tx_timeout     = UET_DEFAULT_TX_TIMEOUT;
 	uet->pds.max_tx_retries = UET_DEFAULT_MAX_TX_RETRIES;
@@ -1265,15 +1336,14 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 			if (rc != 0)
 				return rc;
 
-#ifdef UET_RANDOM_PDC_CLOSE
-			if (pdc->is_initiator && !pdc->close_requested &&
-			    ((rand() % 100) < UET_RANDOM_PDC_CLOSE_THRESH)) {
-				/* randomly mark PDC for close */
-				UET_PDS_DBG("PDC %u randomly marked for close!",
+			/* randomly mark the PDC for close */
+			if (pds_pdc_close_thresh &&
+			    pdc->is_initiator && !pdc->close_requested &&
+			    uet_pds_random_check(pds_pdc_close_thresh)) {
+				UET_PDS_ERR("PDC %u random marked for close!",
 					    pdc->pdc_id);
 				pdc->close_requested = true;
 			}
-#endif /* UET_RANDOM_PDC_CLOSE */
 		}
 	}
 
@@ -1461,6 +1531,7 @@ static int uet_pds_rtx_pkt(struct uet_instance *uet,
 	return 0;
 }
 
+/* returns 0, -EIO, or -EAGAIN */
 static int uet_pds_check_rtx_pkt(struct uet_instance *uet,
 				 struct uet_pdc *pdc,
 				 struct uet_pdc_pkt *pdc_pkt)
@@ -1491,6 +1562,57 @@ static int uet_pds_check_rtx_pkt(struct uet_instance *uet,
 	return -EAGAIN; /* pkt retransmitted, could be more */
 }
 
+int uet_pds_progress_tx_pkt(struct uet_instance *uet,
+			    uet_pkt_handle_t *err_pkt_handle,
+			    struct uet_pdc *pdc,
+			    struct uet_pdc_pkt *pdc_pkt)
+{
+	int rc;
+
+	rc = uet_pds_check_rtx_pkt(uet, pdc, pdc_pkt);
+	if (rc == 0)
+		return 0; /* no retransmit, done with this PDC */
+
+	if (rc == -EIO) {
+		/*
+		 * Max retries exceeded - transition this PDC to the error
+		 * state and notify the SES layer.
+		 */
+		UET_PDS_ERR("PDC %u transitioning to ERROR state "
+			    "(max retries exceeded)",
+			    pdc->pdc_id);
+		pdc->state = PDC_STATE_ERROR;
+
+		/* notify the SES layer of the failed packet */
+		if (err_pkt_handle)
+			*err_pkt_handle = pdc_pkt->tx_pkt_handle;
+
+		dlist_remove(&pdc_pkt->node);
+
+		/* free the packet buffers and structure */
+		if (pdc_pkt->ack_buf)
+			free(pdc_pkt->ack_buf);
+		if (pdc_pkt->pkt_buf)
+			free(pdc_pkt->pkt_buf);
+		free(pdc_pkt);
+
+		/*
+		 * Will return immediately to give the SES layer a chance to
+		 * handle this error before checking other PDCs.
+		 */
+		return -EPROTO;
+	}
+
+	/* (rc == -EAGAIN)
+	 * This packet was retransmitted so it's moved to the end of
+	 * the pending list. Continue to the next packet.
+	 */
+	dlist_remove(&pdc_pkt->node);
+	dlist_insert_tail(&pdc_pkt->node,
+			  &pdc->tx_pkt_list_head);
+	return -EAGAIN;
+}
+
 int uet_pds_progress_tx(struct uet_ep *uet_ep,
 			uet_pkt_handle_t *err_pkt_handle)
 {
@@ -1498,7 +1620,6 @@ int uet_pds_progress_tx(struct uet_ep *uet_ep,
 	struct uet_pdc *pdc;
 	struct dlist_entry *tmp1, *tmp2;
 	struct uet_pdc_pkt *pdc_pkt;
-	time_t now, delta;
 	int rc;
 
 	PDS_GO();
@@ -1513,7 +1634,7 @@ int uet_pds_progress_tx(struct uet_ep *uet_ep,
 	 *         [x] increment the retry count
 	 *         [x] if the retry count has exceeeded the max
 	 *             [x] set the error handle to the tx_handle
-	 *             [ ] change PDC state(?)
+	 *             [x] change PDC state to ERROR
 	 *         [x] update the tx time
 	 *         [x] move the packet to the end of the tx_pkt_list
 	 *         [x] retransmit the pkt
@@ -1524,22 +1645,20 @@ int uet_pds_progress_tx(struct uet_ep *uet_ep,
 		dlist_foreach_container_safe(&pdc->tx_pkt_list_head,
 					     struct uet_pdc_pkt, pdc_pkt,
 					     node, tmp2) {
-			rc = uet_pds_check_rtx_pkt(uet, pdc, pdc_pkt);
-			if (rc == 0) {
-				break; /* no retransmit, done with this PDC */
-			} else if (rc == -EIO) {
-				/* TODO: Need to destroy this PDC... */
-				dlist_remove(&pdc_pkt->node);
-				break; /* done with this PDC */
-			} else if (rc == -EAGAIN) {
-				/*
-				 * This packet was retransmitted, move this
-				 * packet to the end of the list and continue.
-				 */
-				dlist_remove(&pdc_pkt->node);
-				dlist_insert_tail(&pdc_pkt->node,
-						  &pdc->tx_pkt_list_head);
-			}
+			rc = uet_pds_progress_tx_pkt(uet, err_pkt_handle,
+						     pdc, pdc_pkt);
+
+			/* no retransmit, done with this PDC */
+			if (rc == 0)
+				break;
+
+			/* max retransmits were exceeded for the packet */
+			if (rc == -EPROTO)
+				return -EPROTO;
+
+			/* paket was retransmitted, check the next packet */
+			if (rc == -EAGAIN)
+				continue;
 		}
 	}
 
@@ -2297,9 +2416,11 @@ static int uet_pds_process_control(struct uet_instance *uet,
 			return -EINVAL;
 		}
 
-		/* verify the PDC is in correct state */
-		if (pdc->state != PDC_STATE_ESTABLISHED) {
-			UET_PDS_WARN("PDC %u not ESTABLISHED (state=%d)",
+		/* verify the PDC is in the correct state */
+		if (pdc->state != PDC_STATE_ESTABLISHED &&
+		    pdc->state != PDC_STATE_CLOSING) {
+			UET_PDS_WARN("PDC %u not in ESTABLISHED or CLOSING "
+				     "(state=%d)",
 				     pdc->pdc_id, pdc->state);
 			return -EINVAL;
 		}
@@ -2309,6 +2430,51 @@ static int uet_pds_process_control(struct uet_instance *uet,
 			UET_PDS_WARN("PDC %u dpdcid mismatch (%u != %u)",
 				     pdc->pdc_id, pdc->dpdcid, pp->pds_spdcid);
 			return -EINVAL;
+		}
+
+		/*
+		 * If a close command was already received (PDC is in CLOSING
+		 * state), this is a duplicate/retransmit.
+		 */
+		if (pdc->state == PDC_STATE_CLOSING) {
+			UET_PDS_DBG("PDC %u already CLOSING, duplicate CLOSE "
+				    "command",
+				    pdc->pdc_id);
+
+			/* FIXME Need to send a NACK with UET_CLOSING. */
+
+			/* send ACK if requested */
+			if (send_ack) {
+				struct uet_pdc_pkt temp_pkt;
+
+				UET_PDS_DBG("PDC %u Tx ACK for duplicate CLOSE",
+					    pdc->pdc_id);
+
+				memset(&temp_pkt, 0, sizeof(temp_pkt));
+				memcpy(&temp_pkt.pkt_pp, pp, sizeof(*pp));
+
+				rc = uet_pds_tx_ack_pkt(uet, pdc, &temp_pkt,
+							UET_HDR_NONE, 0,
+							NULL, false);
+				if (rc != 0) {
+					UET_PDS_ERR("failed to send ACK for "
+						    "duplicate CLOSE");
+					return rc;
+				}
+			}
+
+			break;
+		}
+
+		/*
+		 * Verify the PDC is idle with no outstanding TX packets.
+		 * There should be no active PSNs in the return direction
+		 * when a close command is received.
+		 */
+		if (bm_count(pdc->tx_bm) > 0) {
+			UET_PDS_WARN("PDC %u PDC_CLOSE_IN_ERR: received CLOSE "
+				     "with %d outstanding TX packets",
+				     pdc->pdc_id, bm_count(pdc->tx_bm));
 		}
 
 		/* send ACK if requested */
@@ -2334,8 +2500,13 @@ static int uet_pds_process_control(struct uet_instance *uet,
 			/* FIXME Is the control packet freed here? */
 		}
 
-		/* free the PDC */
-		uet_pdsm_free_pdc(pdc);
+		/*
+		 * Transition to CLOSING state and save the close command PSN.
+		 * Note: The PDC is not immediately freed to allow detection
+		 * of late-arriving packets.
+		 */
+		pdc->state = PDC_STATE_CLOSING;
+		pdc->close_cmd_psn = pp->pds_psn;
 
 		break;
 
@@ -2430,6 +2601,24 @@ static int uet_pds_process_request(struct uet_instance *uet,
 			     pdc->dpdcid);
 		rc = -EINVAL;
 		goto exit_err;
+	}
+
+	/*
+	 * If a close command was already received and a packet with a higher
+	 * PSN is received, transmit a NACK with UET_CLOSING.
+	 */
+	if (pdc->state == PDC_STATE_CLOSING) {
+		if ((int32_t)(pdc_pkt->pkt_pp.pds_psn -
+			      pdc->close_cmd_psn) > 0) {
+			UET_PDS_WARN("PDC %u is CLOSING, received PSN %u "
+				     "after CLOSE (close_cmd_psn=%u)",
+				     pdc->pdc_id, pdc_pkt->pkt_pp.pds_psn,
+				     pdc->close_cmd_psn);
+
+			/* FIXME Need to send a NACK with UET_CLOSING. */
+			rc = -EINVAL;
+			goto exit_err;
+		}
 	}
 
 	/* check if this packet is a duplicate */

--- a/util/uet_log.h
+++ b/util/uet_log.h
@@ -69,7 +69,7 @@
 #define UET_PDS_CLR UET_CLR_MAGENTA
 #define UET_TSS_CLR UET_CLR_GREEN
 
-#define UET_WARN_CLR UET_CLR_RED
+#define UET_WARN_CLR UET_CLR_YELLOW
 #define UET_ERR_CLR  UET_CLR_RED
 
 #define UET_LOG(fmt, clr, ...)          \


### PR DESCRIPTION
- New UET_PDC_CLOSE_THRESH env var to randomly close a PDC (100=1% chance)
- New UET_PKT_DROP_THRESH env var to randomly drop a Tx packet (100=1% chance)
- With new msg PDC lookup, don't use PDCs in the ERROR or CLOSING state
- Don't send a PDC close command until all outstanding packets are ACK'ed
- Support for Tx max retransmits to ERROR the PDC and notify SES layer
- Only process control packets with PDC is in ESTABLISHED or CLOSING state
- Support duplicate PDC close command events (Note, NACK not yet sent)
- Verify there are no pending packets in reverse direction before CLOSING
- Check that new requests on a closing PDC are not a higher PSN