### PR TITLE
added support for IPv6

### DIFF
--- a/nic_shim/nic_rawsock.c
+++ b/nic_shim/nic_rawsock.c
@@ -49,118 +49,18 @@ int nic_rawsock_getinfo(struct uet_nic *nic,
 	return 0;
 }
 
-/* get next-hop info for ipv4 destination address */
-int nic_rawsock_get_ipv4_nh(struct uet_nic *nic,
-			    uint32_t dst_ip,
-			    uint8_t *mac)
-{
-	struct rawsock_data *rdata =
-		(struct rawsock_data *)nic->nic_priv_data;
-	char sys_cmd[UET_MAX_SYS_CMD_OCTETS];
-	int i, rc;
-	uint32_t net_order;
-	FILE *cmd_stream;
-	struct in_addr nh_ipv4;
-	struct arpreq areq;
-	struct sockaddr_in *sin;
-	uint8_t invalid_mac[ETH_ALEN];
-
-	/* convert ipv4 addr to string */
-	net_order = htonl(dst_ip);
-	inet_ntop(AF_INET, (char *) &net_order, nic->dst_ip_addr_str,
-		  INET_ADDRSTRLEN);
-
-	/* find next-hop ipv4 address */
-	strcpy(sys_cmd, "ip route get to ");
-	strcat(sys_cmd, nic->dst_ip_addr_str);
-	strcat(sys_cmd, " oif ");
-	strcat(sys_cmd, nic->ifname);
-	cmd_stream = popen(sys_cmd, "r");
-	if (cmd_stream == NULL) {
-		UET_API_PRINT_ERRNO("popen");
-		UET_API_ERR("Error getting next-hop IP address");
-		pclose(cmd_stream);
-		return -EIO;
-	}
-	for (i = 0; i < INET_ADDRSTRLEN; i++) {
-		nic->nh_ip_addr_str[i] = getc(cmd_stream);
-		if (isspace((int) nic->nh_ip_addr_str[i])) {
-			nic->nh_ip_addr_str[i] = '\0';
-			break;
-		}
-	}
-	if (i == INET_ADDRSTRLEN) {
-		UET_API_ERR("Error parsing next-hop IP address");
-		pclose(cmd_stream);
-		return -EIO;
-	}
-	inet_pton(AF_INET, nic->nh_ip_addr_str, &nh_ipv4);
-	pclose(cmd_stream);
-
-	/* delete any entry for next-hop already in arp cache */
-	/*  - to handle case where the entry is associated    */
-	/*    with a different interface                      */
-	strcpy(sys_cmd, "arp -d ");
-	strcat(sys_cmd, nic->nh_ip_addr_str);
-	strcat(sys_cmd, " 2> /dev/null 1> /dev/null");
-	system(sys_cmd);
-
-	/* ping next hop to load arp cache using our interface */
-	strcpy(sys_cmd, "ping -c 1 -I ");
-	strcat(sys_cmd, nic->ifname);
-	strcat(sys_cmd, " ");
-	strcat(sys_cmd, nic->nh_ip_addr_str);
-	strcat(sys_cmd, " 2> /dev/null 1> /dev/null");
-	system(sys_cmd);
-
-	/* read next-hop mac address from arp cache */
-	memset(&areq, 0, sizeof(areq));
-	sin = (struct sockaddr_in *) &areq.arp_pa;
-	sin->sin_family = AF_INET;
-	sin->sin_port = nic->uet_ipproto;
-	sin->sin_addr = nh_ipv4;
-	sin = (struct sockaddr_in *) &areq.arp_ha;
-	sin->sin_family = ARPHRD_ETHER;
-	strcpy(areq.arp_dev, nic->ifname);
-	if (ioctl(rdata->sock_fd.fd, SIOCGARP, (caddr_t) &areq) < 0) {
-		UET_API_PRINT_ERRNO("socket ioctl");
-		UET_API_ERR("Error getting ARP entry");
-		return -EIO;
-	}
-	memcpy(mac, areq.arp_ha.sa_data, ETH_ALEN);
-
-	rc = 0;
-	memset(invalid_mac, 0, ETH_ALEN);
-	if (memcmp(mac, invalid_mac, ETH_ALEN) == 0) {
-		UET_API_ERR("Unable to resolve next-hop MAC addr");
-		rc = -ENETUNREACH;
-	}
-
-	printf("Next-Hop Address Resolution\n");
-	printf("  Destination IPv4 Addr: %s\n", nic->dst_ip_addr_str);
-	printf("  Next-Hop IPv4 Addr:    %s\n", nic->nh_ip_addr_str);
-	printf("  Next-Hop MAC Addr:     ");
-	uet_print_mac_addr(mac);
-
-	return rc;
-}
-
 /* transmit a packet */
 int nic_rawsock_tx_pkt(struct uet_nic *nic,
 		       void *pkt,
 		       void *iphdr,
 		       size_t pkt_size)
 {
-	struct ethhdr *eth = (struct ethhdr *) pkt;
-	struct iphdr *ipv4 = (struct iphdr *) iphdr;
+	struct ethhdr *eth = (struct ethhdr *)pkt;
 	struct rawsock_data *rdata =
 		(struct rawsock_data *)nic->nic_priv_data;
 	size_t len;
 
 	memcpy(rdata->sadr.sll_addr, eth->h_dest, ETH_ALEN);
-
-	ipv4->check = 0;
-	ipv4->check = uet_ipv4_csum(ipv4);
 
 #ifdef UET_NIC_DEBUG_HEXDUMP
 	uet_pkt_hex_dump(pkt, pkt_size, 0, true);
@@ -264,7 +164,7 @@ int nic_rawsock_initialize(struct uet_nic *nic)
 {
 	struct rawsock_data *rdata = NULL;
 	int rc;
-	char *ifname, *ip;
+	char *ifname;
 
 	nic->min_pkt_size = UET_MIN_PKT_SIZE;
 	nic->l2_hdr_size = sizeof(struct ethhdr);
@@ -292,14 +192,16 @@ int nic_rawsock_initialize(struct uet_nic *nic)
 
 	strncpy(nic->ifname, ifname, IFNAMSIZ);
 
-	/* open transport raw socket */
-	rdata->sock_fd.fd = socket(AF_PACKET, SOCK_RAW, ETH_P_IP);
+	/* open transport raw socket - use ETH_P_ALL to receive both v4/v6 */
+	rdata->sock_fd.fd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
 	if (rdata->sock_fd.fd == -1) {
 		UET_API_PRINT_ERRNO("socket");
 		rc = -EIO;
 		goto err_return;
 	}
+
 	rdata->sock_fd.events = POLLIN;
+	nic->sock_fd = rdata->sock_fd.fd;
 
 	/* get index of interface */
 	strcpy(rdata->ifr.ifr_name, nic->ifname);
@@ -314,7 +216,7 @@ int nic_rawsock_initialize(struct uet_nic *nic)
 	rdata->sadr.sll_family   = AF_PACKET;
 	rdata->sadr.sll_ifindex  = rdata->ifr.ifr_ifindex;
 	rdata->sadr.sll_halen    = ETH_ALEN;
-	rdata->sadr.sll_protocol = htons(ETH_P_IP);
+	rdata->sadr.sll_protocol = htons(ETH_P_ALL);
 
 	if (bind(rdata->sock_fd.fd, (struct sockaddr *) &rdata->sadr,
 		 sizeof(struct sockaddr_ll)) < 0) {
@@ -323,16 +225,36 @@ int nic_rawsock_initialize(struct uet_nic *nic)
 		goto err_return;
 	}
 
-	/* get ipv4 address of interface */
-	if ((ioctl(rdata->sock_fd.fd, SIOCGIFADDR, &rdata->ifr)) < 0) {
-		UET_API_PRINT_ERRNO("socket ioctl");
-		UET_API_ERR("Error getting IP address of local device");
-		rc = -EIO;
-		goto err_return;
+	/* get IPv4 address of interface (optional) */
+	nic->has_ipv4 = (uet_nic_get_ipv4_addr(rdata->sock_fd.fd,
+					       &rdata->ifr,
+					       &nic->ipv4_addr,
+					       nic->ipv4_addr_str) == 0);
+
+	/* get IPv6 address of interface (optional) */
+	nic->has_ipv6 = (uet_nic_get_ipv6_addr(nic->ifname,
+					       nic->ipv6_addr,
+					       nic->ipv6_addr_str) == 0);
+
+	if (nic->is_ipv6) {
+		if (!nic->has_ipv6) {
+			UET_API_ERR("Error: IPv6 requested but no IPv6 address");
+			rc = -ENODEV;
+			goto err_return;
+		}
+
+		memcpy(nic->ip_addr.v6, nic->ipv6_addr, 16);
+		strncpy(nic->ip_addr_str, nic->ipv6_addr_str, INET6_ADDRSTRLEN);
+	} else {
+		if (!nic->has_ipv4) {
+			UET_API_ERR("Error: IPv4 requested but no IPv4 address");
+			rc = -ENODEV;
+			goto err_return;
+		}
+
+		nic->ip_addr.v4 = nic->ipv4_addr;
+		strncpy(nic->ip_addr_str, nic->ipv4_addr_str, INET_ADDRSTRLEN);
 	}
-	ip = &rdata->ifr.ifr_hwaddr.sa_data[2];
-	nic->ipv4_addr = ntohl(*((uint32_t *) ip));
-	inet_ntop(AF_INET, ip, nic->ip_addr_str, INET_ADDRSTRLEN);
 
 	/* get mac address of interface */
 	if ((ioctl(rdata->sock_fd.fd, SIOCGIFHWADDR, &rdata->ifr)) < 0) {

--- a/nic_shim/nic_xdp.c
+++ b/nic_shim/nic_xdp.c
@@ -125,102 +125,6 @@ int nic_xdp_getinfo(struct uet_nic *nic,
 	return 0;
 }
 
-/* get next-hop info for ipv4 destination address */
-int nic_xdp_get_ipv4_nh(struct uet_nic *nic,
-			uint32_t dst_ip,
-			uint8_t *mac)
-{
-	struct xdp_data *xdata = (struct xdp_data *)nic->nic_priv_data;
-	char sys_cmd[UET_MAX_SYS_CMD_OCTETS];
-	int i, rc;
-	uint32_t net_order;
-	FILE *cmd_stream;
-	struct in_addr nh_ipv4;
-	struct arpreq areq;
-	struct sockaddr_in *sin;
-	uint8_t invalid_mac[ETH_ALEN];
-
-	/* convert IP addr to a string */
-	net_order = htonl(dst_ip);
-	inet_ntop(AF_INET, (char *) &net_order, nic->dst_ip_addr_str,
-		  INET_ADDRSTRLEN);
-
-	/* find next-hop ipv4 address */
-	strcpy(sys_cmd, "ip route get to ");
-	strcat(sys_cmd, nic->dst_ip_addr_str);
-	strcat(sys_cmd, " oif ");
-	strcat(sys_cmd, nic->ifname);
-	cmd_stream = popen(sys_cmd, "r");
-	if (cmd_stream == NULL) {
-		UET_API_ERR("ERROR: Failed to get next-hop IP address");
-		pclose(cmd_stream);
-		return -EIO;
-	}
-
-	for (i = 0; i < INET_ADDRSTRLEN; i++) {
-		nic->nh_ip_addr_str[i] = getc(cmd_stream);
-		if (isspace((int)nic->nh_ip_addr_str[i])) {
-			nic->nh_ip_addr_str[i] = '\0';
-			break;
-		}
-	}
-
-	if (i == INET_ADDRSTRLEN) {
-		UET_API_ERR("ERROR: Failed to parse next-hop IP address");
-		pclose(cmd_stream);
-		return -EIO;
-	}
-
-	inet_pton(AF_INET, nic->nh_ip_addr_str, &nh_ipv4);
-	pclose(cmd_stream);
-
-	/* delete any entry for next-hop already in arp cache */
-	/*  - to handle case where the entry is associated    */
-	/*    with a different interface                      */
-	strcpy(sys_cmd, "arp -d ");
-	strcat(sys_cmd, nic->nh_ip_addr_str);
-	strcat(sys_cmd, " 2> /dev/null 1> /dev/null");
-	system(sys_cmd);
-
-	/* ping next hop to load arp cache using our interface */
-	strcpy(sys_cmd, "ping -c 1 -I ");
-	strcat(sys_cmd, nic->ifname);
-	strcat(sys_cmd, " ");
-	strcat(sys_cmd, nic->nh_ip_addr_str);
-	strcat(sys_cmd, " 2> /dev/null 1> /dev/null");
-	system(sys_cmd);
-
-	/* read next-hop mac address from arp cache */
-	memset(&areq, 0, sizeof(areq));
-	sin = (struct sockaddr_in *)&areq.arp_pa;
-	sin->sin_family = AF_INET;
-	sin->sin_port = nic->uet_ipproto;
-	sin->sin_addr = nh_ipv4;
-	sin = (struct sockaddr_in *)&areq.arp_ha;
-	sin->sin_family = ARPHRD_ETHER;
-	strcpy(areq.arp_dev, nic->ifname);
-	if (ioctl(xdata->sock_fd, SIOCGARP, (caddr_t)&areq) < 0) {
-		UET_API_ERR("ERROR: Failed getting ARP entry");
-		return -EIO;
-	}
-	memcpy(mac, areq.arp_ha.sa_data, ETH_ALEN);
-
-	rc = 0;
-	memset(invalid_mac, 0, ETH_ALEN);
-	if (memcmp(mac, invalid_mac, ETH_ALEN) == 0) {
-		UET_API_ERR("ERROR: Failed to resolve next-hop MAC addr");
-		rc = -ENETUNREACH;
-	}
-
-	printf("Next-Hop Address Resolution\n");
-	printf("  Destination IPv4 Addr: %s\n", nic->dst_ip_addr_str);
-	printf("  Next-Hop IPv4 Addr:    %s\n", nic->nh_ip_addr_str);
-	printf("  Next-Hop MAC Addr:     ");
-	uet_print_mac_addr(mac);
-
-	return rc;
-}
-
 static inline void nic_xdp_tx_complete(struct xsk_socket_info *xsk,
 				       int batch_size)
 {
@@ -297,7 +201,9 @@ int nic_xdp_tx_pkt(struct uet_nic *nic,
 	uet_pkt_hex_dump(xdp_pkt_data, tx_desc->len, tx_desc->addr, true);
 #endif
 
-	xdata->next_frame[0] = ((xdata->next_frame[0] + 1) % NUM_FRAMES);
+	xdata->next_frame[0] = (MAX_FILL_SIZE +
+				((xdata->next_frame[0] - MAX_FILL_SIZE + 1) %
+				 MAX_TX_SIZE));
 
 	/* Submit the newly added packet into the Tx ring. */
 	xsk_ring_prod__submit(&xsk->tx, 1);
@@ -656,7 +562,6 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	struct ifreq ifr;	  /* socket interface request struct */
 	int i, rc, mem_size;
 	char *ifname;
-	char *ip;
 
 	/* Make sure we can abuse memory usage! */
 	if (setrlimit(RLIMIT_MEMLOCK, &r)) {
@@ -680,11 +585,12 @@ int nic_xdp_initialize(struct uet_nic *nic)
 	}
 
 	nic->nic_priv_data = (void *)xdata;
-	xdata->num_socks    = 1;
-	xdata->xdp_rx_queue = 0;
-	xdata->xdp_prog     = NULL;
-	xdata->xdp_ifindex  = -1;
-	xdata->sock_fd      = -1;
+	xdata->num_socks     = 1;
+	xdata->next_frame[0] = MAX_FILL_SIZE; /* Tx frames start after Rx */
+	xdata->xdp_rx_queue  = 0;
+	xdata->xdp_prog      = NULL;
+	xdata->xdp_ifindex   = -1;
+	xdata->sock_fd       = -1;
 
 	/* get interface name from environment variable */
 	ifname = getenv(UET_IFNAME);
@@ -789,18 +695,39 @@ int nic_xdp_initialize(struct uet_nic *nic)
 		goto exit_err;
 	}
 
+	nic->sock_fd = xdata->sock_fd;
+
 	strcpy(ifr.ifr_name, nic->ifname);
 
-	/* get the IPv4 address of the interface */
-	ifr.ifr_addr.sa_family = AF_INET;
-	if ((ioctl(xdata->sock_fd, SIOCGIFADDR, &ifr)) < 0) {
-		UET_API_ERR("ERROR: Failed to get local IPv4 address");
-		rc = -ENODEV;
-		goto exit_err;
+	/* get IPv4 address of interface (optional) */
+	nic->has_ipv4 = (uet_nic_get_ipv4_addr(xdata->sock_fd, &ifr,
+					       &nic->ipv4_addr,
+					       nic->ipv4_addr_str) == 0);
+
+	/* get IPv6 address of interface (optional) */
+	nic->has_ipv6 = (uet_nic_get_ipv6_addr(nic->ifname,
+					       nic->ipv6_addr,
+					       nic->ipv6_addr_str) == 0);
+
+	if (nic->is_ipv6) {
+		if (!nic->has_ipv6) {
+			UET_API_ERR("ERROR: IPv6 requested but no IPv6 address");
+			rc = -ENODEV;
+			goto exit_err;
+		}
+
+		memcpy(nic->ip_addr.v6, nic->ipv6_addr, 16);
+		strncpy(nic->ip_addr_str, nic->ipv6_addr_str, INET6_ADDRSTRLEN);
+	} else {
+		if (!nic->has_ipv4) {
+			UET_API_ERR("ERROR: IPv4 requested but no IPv4 address");
+			rc = -ENODEV;
+			goto exit_err;
+		}
+
+		nic->ip_addr.v4 = nic->ipv4_addr;
+		strncpy(nic->ip_addr_str, nic->ipv4_addr_str, INET_ADDRSTRLEN);
 	}
-	ip = &ifr.ifr_addr.sa_data[2];
-	nic->ipv4_addr = ntohl(*((uint32_t *)ip));
-	inet_ntop(AF_INET, ip, nic->ip_addr_str, INET_ADDRSTRLEN);
 
 	/* get the MAC address of the interface */
 	if ((ioctl(xdata->sock_fd, SIOCGIFHWADDR, &ifr)) < 0) {

--- a/nic_shim/uet_nic.c
+++ b/nic_shim/uet_nic.c
@@ -3,13 +3,308 @@
  * Broadcom refers to Broadcom Limited and/or its subsidiaries.
  */
 
-/* Raw Socket NIC Interface for UET API's */
+/* NIC Interface common functions */
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <net/if_arp.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 
 #include "uet_api_private.h"
 #include "uet_nic.h"
+
+/* helper to get IPv4 address of interface */
+int uet_nic_get_ipv4_addr(int sock_fd,
+			  struct ifreq *ifr,
+			  uint32_t *ipv4_addr,
+			  char *ipv4_addr_str)
+{
+	char *ip;
+
+	ifr->ifr_addr.sa_family = AF_INET;
+	if ((ioctl(sock_fd, SIOCGIFADDR, ifr)) < 0)
+		return -ENOENT;
+
+	ip = &ifr->ifr_addr.sa_data[2];
+	*ipv4_addr = ntohl(*((uint32_t *)ip));
+	inet_ntop(AF_INET, ip, ipv4_addr_str, INET_ADDRSTRLEN);
+	return 0;
+}
+
+/* helper to get IPv6 address of interface from /proc/net/if_inet6 */
+int uet_nic_get_ipv6_addr(const char *ifname,
+			  uint8_t *ipv6_addr,
+			  char *ipv6_addr_str)
+{
+	FILE *f;
+	char line[128];
+	char addr_hex[33];
+	char if_name[IFNAMSIZ];
+	int scope, prefix, flags, if_idx;
+	unsigned int addr_bytes[16];
+	int i;
+	bool found_link_local = false;
+	uint8_t link_local_addr[16];
+	char link_local_str[INET6_ADDRSTRLEN];
+
+	f = fopen("/proc/net/if_inet6", "r");
+	if (!f)
+		return -ENOENT;
+
+	while (fgets(line, sizeof(line), f)) {
+		if (sscanf(line, "%32s %x %x %x %x %s",
+			   addr_hex, &if_idx, &prefix, &scope, &flags,
+			   if_name) != 6)
+			continue;
+
+		if (strcmp(if_name, ifname) != 0)
+			continue;
+
+		/* skip loopback (scope 0x10) */
+		if (scope == 0x10)
+			continue;
+
+		/* parse hex address */
+		for (i = 0; i < 16; i++) {
+			if (sscanf(&addr_hex[i * 2], "%2x", &addr_bytes[i]) != 1) {
+				fclose(f);
+				return -EINVAL;
+			}
+		}
+
+		/* save link-local (scope 0x20) as fallback */
+		if (scope == 0x20) {
+			if (!found_link_local) {
+				for (i = 0; i < 16; i++)
+					link_local_addr[i] = (uint8_t)addr_bytes[i];
+				inet_ntop(AF_INET6, link_local_addr,
+					  link_local_str, INET6_ADDRSTRLEN);
+				found_link_local = true;
+			}
+			continue;
+		}
+
+		/* found non-link-local address - use it */
+		for (i = 0; i < 16; i++)
+			ipv6_addr[i] = (uint8_t)addr_bytes[i];
+		inet_ntop(AF_INET6, ipv6_addr, ipv6_addr_str, INET6_ADDRSTRLEN);
+		fclose(f);
+		return 0;
+	}
+
+	fclose(f);
+
+	/* fallback to link-local if no global/site-local found */
+	if (found_link_local) {
+		memcpy(ipv6_addr, link_local_addr, 16);
+		strncpy(ipv6_addr_str, link_local_str, INET6_ADDRSTRLEN);
+		return 0;
+	}
+
+	return -ENOENT;
+}
+
+/* resolve next-hop info for ipv4 destination address */
+int uet_nic_resolve_ipv4_nh(struct uet_nic *nic,
+			    int sock_fd,
+			    uint32_t dst_ip,
+			    uint8_t *mac)
+{
+	char sys_cmd[UET_MAX_SYS_CMD_OCTETS];
+	int i, rc;
+	uint32_t net_order;
+	FILE *cmd_stream;
+	struct in_addr nh_ipv4;
+	struct arpreq areq;
+	struct sockaddr_in *sin;
+	uint8_t invalid_mac[ETH_ALEN];
+
+	/* convert ipv4 addr to string */
+	net_order = htonl(dst_ip);
+	inet_ntop(AF_INET, (char *)&net_order, nic->dst_ip_addr_str,
+		  INET_ADDRSTRLEN);
+
+	/* find next-hop ipv4 address */
+	strcpy(sys_cmd, "ip route get to ");
+	strcat(sys_cmd, nic->dst_ip_addr_str);
+	strcat(sys_cmd, " oif ");
+	strcat(sys_cmd, nic->ifname);
+	cmd_stream = popen(sys_cmd, "r");
+	if (cmd_stream == NULL) {
+		UET_API_PRINT_ERRNO("popen");
+		UET_API_ERR("Error getting next-hop IP address");
+		return -EIO;
+	}
+	for (i = 0; i < INET_ADDRSTRLEN; i++) {
+		nic->nh_ip_addr_str[i] = getc(cmd_stream);
+		if (isspace((int)nic->nh_ip_addr_str[i])) {
+			nic->nh_ip_addr_str[i] = '\0';
+			break;
+		}
+	}
+	if (i == INET_ADDRSTRLEN) {
+		UET_API_ERR("Error parsing next-hop IP address");
+		pclose(cmd_stream);
+		return -EIO;
+	}
+	inet_pton(AF_INET, nic->nh_ip_addr_str, &nh_ipv4);
+	pclose(cmd_stream);
+
+	/* delete any entry for next-hop already in arp cache */
+	strcpy(sys_cmd, "arp -d ");
+	strcat(sys_cmd, nic->nh_ip_addr_str);
+	strcat(sys_cmd, " 2> /dev/null 1> /dev/null");
+	system(sys_cmd);
+
+	/* ping next hop to load arp cache using our interface */
+	strcpy(sys_cmd, "ping -c 1 -I ");
+	strcat(sys_cmd, nic->ifname);
+	strcat(sys_cmd, " ");
+	strcat(sys_cmd, nic->nh_ip_addr_str);
+	strcat(sys_cmd, " 2> /dev/null 1> /dev/null");
+	system(sys_cmd);
+
+	/* read next-hop mac address from arp cache */
+	memset(&areq, 0, sizeof(areq));
+	sin = (struct sockaddr_in *)&areq.arp_pa;
+	sin->sin_family = AF_INET;
+	sin->sin_port = nic->uet_ipproto;
+	sin->sin_addr = nh_ipv4;
+	sin = (struct sockaddr_in *)&areq.arp_ha;
+	sin->sin_family = ARPHRD_ETHER;
+	strcpy(areq.arp_dev, nic->ifname);
+	if (ioctl(sock_fd, SIOCGARP, (caddr_t)&areq) < 0) {
+		UET_API_PRINT_ERRNO("socket ioctl");
+		UET_API_ERR("Error getting ARP entry");
+		return -EIO;
+	}
+	memcpy(mac, areq.arp_ha.sa_data, ETH_ALEN);
+
+	rc = 0;
+	memset(invalid_mac, 0, ETH_ALEN);
+	if (memcmp(mac, invalid_mac, ETH_ALEN) == 0) {
+		UET_API_ERR("Unable to resolve next-hop MAC addr");
+		rc = -ENETUNREACH;
+	}
+
+	printf("Next-Hop Address Resolution\n");
+	printf("  Destination IPv4 Addr: %s\n", nic->dst_ip_addr_str);
+	printf("  Next-Hop IPv4 Addr:    %s\n", nic->nh_ip_addr_str);
+	printf("  Next-Hop MAC Addr:     ");
+	uet_print_mac_addr(mac);
+
+	return rc;
+}
+
+/* resolve next-hop info for ipv6 destination address */
+int uet_nic_resolve_ipv6_nh(struct uet_nic *nic,
+			    const uint8_t *dst_ip6,
+			    uint8_t *mac)
+{
+	char sys_cmd[UET_MAX_SYS_CMD_OCTETS];
+	char line[256];
+	int i, rc;
+	FILE *cmd_stream;
+	uint8_t invalid_mac[ETH_ALEN];
+
+	/* convert ipv6 addr to string */
+	inet_ntop(AF_INET6, dst_ip6, nic->dst_ip_addr_str, INET6_ADDRSTRLEN);
+
+	/* find next-hop ipv6 address using ip -6 route get */
+	snprintf(sys_cmd, sizeof(sys_cmd),
+		 "ip -6 route get %s oif %s 2>/dev/null | head -1",
+		 nic->dst_ip_addr_str, nic->ifname);
+	cmd_stream = popen(sys_cmd, "r");
+	if (cmd_stream == NULL) {
+		UET_API_PRINT_ERRNO("popen");
+		UET_API_ERR("Error getting next-hop IPv6 address");
+		return -EIO;
+	}
+
+	/* parse: "<dst> from <src> via <nexthop> ..." or "<dst> from <src> dev ..." */
+	memset(line, 0, sizeof(line));
+	if (fgets(line, sizeof(line), cmd_stream) == NULL) {
+		UET_API_ERR("Error reading route output");
+		pclose(cmd_stream);
+		return -EIO;
+	}
+	pclose(cmd_stream);
+
+	/* look for "via <nexthop>" in output, otherwise use dst as nexthop */
+	char *via = strstr(line, " via ");
+	if (via) {
+		via += 5; /* skip " via " */
+		for (i = 0; i < INET6_ADDRSTRLEN - 1 && via[i] && !isspace(via[i]); i++)
+			nic->nh_ip_addr_str[i] = via[i];
+		nic->nh_ip_addr_str[i] = '\0';
+	} else {
+		/* on-link destination, next-hop is the destination itself */
+		strncpy(nic->nh_ip_addr_str, nic->dst_ip_addr_str,
+			INET6_ADDRSTRLEN);
+	}
+
+	/* delete any entry for next-hop already in neighbor cache */
+	snprintf(sys_cmd, sizeof(sys_cmd),
+		 "ip -6 neigh del %s dev %s 2>/dev/null 1>/dev/null",
+		 nic->nh_ip_addr_str, nic->ifname);
+	system(sys_cmd);
+
+	/* ping6 next hop to trigger NDP */
+	snprintf(sys_cmd, sizeof(sys_cmd),
+		 "ping -6 -c 1 -I %s %s 2>/dev/null 1>/dev/null",
+		 nic->ifname, nic->nh_ip_addr_str);
+	system(sys_cmd);
+
+	/* read next-hop mac address from neighbor cache */
+	snprintf(sys_cmd, sizeof(sys_cmd),
+		 "ip -6 neigh show %s dev %s 2>/dev/null",
+		 nic->nh_ip_addr_str, nic->ifname);
+	cmd_stream = popen(sys_cmd, "r");
+	if (cmd_stream == NULL) {
+		UET_API_PRINT_ERRNO("popen");
+		UET_API_ERR("Error reading neighbor cache");
+		return -EIO;
+	}
+
+	/* parse: "<addr> dev <if> lladdr <mac> ..." */
+	memset(line, 0, sizeof(line));
+	memset(mac, 0, ETH_ALEN);
+	if (fgets(line, sizeof(line), cmd_stream) != NULL) {
+		char *lladdr = strstr(line, "lladdr ");
+		if (lladdr) {
+			lladdr += 7; /* skip "lladdr " */
+			/* parse MAC address aa:bb:cc:dd:ee:ff */
+			unsigned int m[6];
+			if (sscanf(lladdr, "%x:%x:%x:%x:%x:%x",
+				   &m[0], &m[1], &m[2], &m[3], &m[4], &m[5]) == 6) {
+				for (i = 0; i < 6; i++)
+					mac[i] = (uint8_t)m[i];
+			}
+		}
+	}
+	pclose(cmd_stream);
+
+	rc = 0;
+	memset(invalid_mac, 0, ETH_ALEN);
+	if (memcmp(mac, invalid_mac, ETH_ALEN) == 0) {
+		UET_API_ERR("Unable to resolve next-hop MAC addr for IPv6");
+		rc = -ENETUNREACH;
+	}
+
+	printf("Next-Hop Address Resolution\n");
+	printf("  Destination IPv6 Addr: %s\n", nic->dst_ip_addr_str);
+	printf("  Next-Hop IPv6 Addr:    %s\n", nic->nh_ip_addr_str);
+	printf("  Next-Hop MAC Addr:     ");
+	uet_print_mac_addr(mac);
+
+	return rc;
+}
 
 int uet_nic_getinfo(struct uet_nic *nic,
 		    struct uet_nic_info *nic_info)
@@ -25,9 +320,6 @@ int uet_nic_getinfo(struct uet_nic *nic,
 /* Raw Socket NIC protocol callbacks */
 extern int nic_rawsock_getinfo(struct uet_nic *nic,
 			       struct uet_nic_info *nic_info);
-extern int nic_rawsock_get_ipv4_nh(struct uet_nic *nic,
-				   uint32_t dst_ip,
-				   uint8_t *mac);
 extern int nic_rawsock_tx_pkt(struct uet_nic *nic,
 			      void *pkt,
 			      void *iphdr,
@@ -44,9 +336,6 @@ extern int nic_rawsock_initialize(struct uet_nic *nic);
 /* XDP NIC protocol callbacks */
 extern int nic_xdp_getinfo(struct uet_nic *nic,
 			   struct uet_nic_info *nic_info);
-extern int nic_xdp_get_ipv4_nh(struct uet_nic *nic,
-			       uint32_t dst_ip,
-			       uint8_t *mac);
 extern int nic_xdp_tx_pkt(struct uet_nic *nic,
 			  void *pkt,
 			  void *iphdr,
@@ -61,9 +350,13 @@ extern int nic_xdp_initialize(struct uet_nic *nic);
 #endif
 
 /* init nic resources */
-int uet_nic_initialize(struct uet_nic *nic)
+int uet_nic_initialize(struct uet_nic *nic,
+		       bool is_ipv6)
 {
 	char *nic_shim;
+
+	/* set IP version before calling shim-specific initializer */
+	nic->is_ipv6 = is_ipv6;
 
 	/* get interface name from environment variable */
 	nic_shim = getenv(UET_NIC_SHIM);
@@ -76,7 +369,6 @@ int uet_nic_initialize(struct uet_nic *nic)
 
 	if ((nic_shim == NULL) || (strcmp(nic_shim, "rawsock") == 0)) {
 		nic->nic_getinfo     = nic_rawsock_getinfo;
-		nic->nic_get_ipv4_nh = nic_rawsock_get_ipv4_nh;
 		nic->nic_tx_pkt      = nic_rawsock_tx_pkt;
 		nic->nic_rx_pkt      = nic_rawsock_rx_pkt;
 		nic->nic_rx_poll     = nic_rawsock_rx_poll;
@@ -85,7 +377,6 @@ int uet_nic_initialize(struct uet_nic *nic)
 #if ENABLE_XDP
 	} else if (strcmp(nic_shim, "xdp") == 0) {
 		nic->nic_getinfo     = nic_xdp_getinfo;
-		nic->nic_get_ipv4_nh = nic_xdp_get_ipv4_nh;
 		nic->nic_tx_pkt      = nic_xdp_tx_pkt;
 		nic->nic_rx_pkt      = nic_xdp_rx_pkt;
 		nic->nic_rx_poll     = nic_xdp_rx_poll;

--- a/nic_shim/uet_nic.h
+++ b/nic_shim/uet_nic.h
@@ -9,10 +9,14 @@
 #define _UET_NIC_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <assert.h>
+#include <errno.h>
 #include <net/if.h>
 #include <netinet/in.h>
 #include <linux/if_ether.h>
+
+#include "uet_addr.h"
 
 //#define UET_NIC_DEBUG_HEXDUMP
 
@@ -44,13 +48,23 @@ struct uet_nic_info {
 
 /* nic control block structure - field of struct uet_instance */
 struct uet_nic {
-	char ifname[IFNAMSIZ];                              /* interface name */
+	char ifname[IFNAMSIZ];
 	char network_type[UET_NET_TYPE_SIZE];
 
 	uint8_t mac_addr[ETH_ALEN];
 	char mac_addr_str[ETH_ALEN*3];
 
-	uint32_t ipv4_addr;                            /* host order */
+	/* v4/v6 local addresses - both populated at init if available */
+	uint32_t ipv4_addr;
+	char ipv4_addr_str[INET_ADDRSTRLEN];
+	bool has_ipv4;
+	uint8_t ipv6_addr[16];
+	char ipv6_addr_str[INET6_ADDRSTRLEN];
+	bool has_ipv6;
+
+	/* active address for this session (set by upper layer) */
+	struct uet_fa ip_addr;                         /* host order */
+	bool is_ipv6;                          /* true if using IPv6 */
 	char ip_addr_str[INET6_ADDRSTRLEN];            /* local addr */
 	char dst_ip_addr_str[INET6_ADDRSTRLEN];  /* destination addr */
 	char nh_ip_addr_str[INET6_ADDRSTRLEN];      /* next hop addr */
@@ -63,14 +77,12 @@ struct uet_nic {
 
 	uint8_t uet_ipproto;           /* ip protocol number for uet */
 
+	int sock_fd;                    /* socket fd for ioctl calls */
 	void *nic_priv_data;
 
 	/* function pointers supporting different NIC interfaces */
 	int (*nic_getinfo)(struct uet_nic *nic,
 			   struct uet_nic_info *nic_info);
-	int (*nic_get_ipv4_nh)(struct uet_nic *nic,
-			       uint32_t dst_ip,
-			       uint8_t *mac);
 	int (*nic_tx_pkt)(struct uet_nic *nic,
 			  void *pkt,
 			  void *iphdr,
@@ -89,16 +101,86 @@ struct uet_nic {
  *********************************************************************/
 
 /*
- * initialize nic resources
+ * helper to get IPv4 address of interface
  *
  * parms:
- *      uet - ptr to uet nic struct
+ *      sock_fd       - socket file descriptor for ioctl
+ *      ifr           - ptr to ifreq struct (ifr_name must be set)
+ *      ipv4_addr     - ptr to location where IPv4 addr is returned
+ *      ipv4_addr_str - ptr to buffer for IPv4 addr string
  *
  * returns:
  *      0 on success
  *      negative value corresponding to errno on error
  */
-int uet_nic_initialize(struct uet_nic *nic);
+int uet_nic_get_ipv4_addr(int sock_fd,
+			  struct ifreq *ifr,
+			  uint32_t *ipv4_addr,
+			  char *ipv4_addr_str);
+
+/*
+ * helper to get IPv6 address of interface from /proc/net/if_inet6
+ *
+ * parms:
+ *      ifname        - interface name
+ *      ipv6_addr     - ptr to 16-byte buffer for IPv6 addr
+ *      ipv6_addr_str - ptr to buffer for IPv6 addr string
+ *
+ * returns:
+ *      0 on success
+ *      negative value corresponding to errno on error
+ */
+int uet_nic_get_ipv6_addr(const char *ifname,
+			  uint8_t *ipv6_addr,
+			  char *ipv6_addr_str);
+
+/*
+ * helper to resolve IPv4 next-hop MAC address
+ *
+ * parms:
+ *      nic     - ptr to uet nic struct
+ *      sock_fd - socket file descriptor for ioctl
+ *      dst_ip  - destination IPv4 address
+ *      mac     - ptr to location where MAC address is returned
+ *
+ * returns:
+ *      0 on success
+ *      negative value corresponding to errno on error
+ */
+int uet_nic_resolve_ipv4_nh(struct uet_nic *nic,
+			    int sock_fd,
+			    uint32_t dst_ip,
+			    uint8_t *mac);
+
+/*
+ * helper to resolve IPv6 next-hop MAC address
+ *
+ * parms:
+ *      nic      - ptr to uet nic struct
+ *      dst_ip6  - destination IPv6 address
+ *      mac      - ptr to location where MAC address is returned
+ *
+ * returns:
+ *      0 on success
+ *      negative value corresponding to errno on error
+ */
+int uet_nic_resolve_ipv6_nh(struct uet_nic *nic,
+			    const uint8_t *dst_ip6,
+			    uint8_t *mac);
+
+/*
+ * initialize nic resources
+ *
+ * parms:
+ *      uet - ptr to uet nic struct
+ *      is_ipv6 - initialize for IPv6
+ *
+ * returns:
+ *      0 on success
+ *      negative value corresponding to errno on error
+ */
+int uet_nic_initialize(struct uet_nic *nic,
+		       bool is_ipv6);
 
 /*
  * free nic resources
@@ -147,7 +229,56 @@ static inline int uet_nic_get_ipv4_nh(struct uet_nic *nic,
 	if (!nic || !mac)
 		assert(0);
 
-	return nic->nic_get_ipv4_nh(nic, dst_ip, mac);
+	return uet_nic_resolve_ipv4_nh(nic, nic->sock_fd, dst_ip, mac);
+}
+
+/*
+ * get next-hop info for ipv6 destination address
+ *
+ * parms:
+ *      nic     - ptr to uet nic struct
+ *      dst_ip6 - destination IPv6 address for which info is requested
+ *      mac     - ptr to location where mac address is to be returned
+ *
+ * returns:
+ *      0 on success
+ *      negative value corresponding to errno on error
+ */
+static inline int uet_nic_get_ipv6_nh(struct uet_nic *nic,
+				      const uint8_t *dst_ip6,
+				      uint8_t *mac)
+{
+	if (!nic || !dst_ip6 || !mac)
+		assert(0);
+
+	return uet_nic_resolve_ipv6_nh(nic, dst_ip6, mac);
+}
+
+/*
+ * get next-hop info for destination address (v4 or v6)
+ *
+ * parms:
+ *      nic     - ptr to uet nic struct
+ *      fa      - ptr to fabric address (contains v4 or v6 address)
+ *      is_ipv6 - true if fa contains an IPv6 address
+ *      mac     - ptr to location where mac address is to be returned
+ *
+ * returns:
+ *      0 on success
+ *      negative value corresponding to errno on error
+ */
+static inline int uet_nic_get_nh(struct uet_nic *nic,
+				 const struct uet_fa *fa,
+				 bool is_ipv6,
+				 uint8_t *mac)
+{
+	if (!nic || !fa || !mac)
+		assert(0);
+
+	if (is_ipv6)
+		return uet_nic_get_ipv6_nh(nic, fa->v6, mac);
+	else
+		return uet_nic_get_ipv4_nh(nic, fa->v4, mac);
 }
 
 /*

--- a/scripts/uet_test.sh
+++ b/scripts/uet_test.sh
@@ -23,13 +23,14 @@ if [ -z "$LIBFABRIC" ]; then
     exit 1
 fi
 
-# Valid "test" and "pds" names
+# Valid "test", "pds", and "shim" names
 test_names=(all rma tag tag_any_src unexp_untag unexp_tag defer_send defer_tag defer_tag_any_src)
 pds_names=(all sng pds pds_direct pds_cluster pds_cluster_ssi pds_server_ssi)
+shim_names=(rawsock xdp)
 
 function usage()
 {
-    echo "Usage: $0 <client|server> <ifname> <peer_ip> <test> <pds>"
+    echo "Usage: $0 <client|server> <ifname> <peer_ip> <test> <pds> [ <shim> ]"
     echo ""
     echo -e "\t<client|server>: role to run as"
     echo -e "\t<ifname>: local network interface name"
@@ -43,6 +44,11 @@ function usage()
     echo -e "\t<pds>:"
     for p in "${pds_names[@]}"; do
         echo -e "\t\t$p"
+    done
+    echo ""
+    echo -e "\t<shim>: (optional, default: rawsock)"
+    for s in "${shim_names[@]}"; do
+        echo -e "\t\t$s"
     done
     echo ""
     exit 1
@@ -75,6 +81,12 @@ if [ -z "$peer_ip" ]; then
     usage
 fi
 
+# Detect IPv6 (contains colon)
+is_ipv6=0
+if [[ "$peer_ip" == *:* ]]; then
+    is_ipv6=1
+fi
+
 # Validate test name
 valid_test=0
 for t in "${test_names[@]}"; do
@@ -101,6 +113,22 @@ if [ $valid_pds -eq 0 ]; then
     usage
 fi
 
+# Parse optional shim argument (default: rawsock)
+shim=${6:-rawsock}
+
+# Validate shim name
+valid_shim=0
+for s in "${shim_names[@]}"; do
+    if [ "$shim" = "$s" ]; then
+        valid_shim=1
+        break
+    fi
+done
+if [ $valid_shim -eq 0 ]; then
+    echo "ERROR: Invalid shim name"
+    usage
+fi
+
 banner()
 {
     echo ""
@@ -110,7 +138,14 @@ banner()
     echo ""
 }
 
-CMD_BASE="LD_LIBRARY_PATH=${LIBFABRIC}:. UET_IFNAME=${iface} ./uet"
+# Set application name based on shim
+if [ "$shim" = "xdp" ]; then
+    app_name="uet_xdp"
+else
+    app_name="uet"
+fi
+
+CMD_BASE="LD_LIBRARY_PATH=${LIBFABRIC}:. UET_IFNAME=${iface} UET_NIC_SHIM=${shim} ./${app_name}"
 
 function run_test()
 {
@@ -135,6 +170,10 @@ function pds()
 function pds_direct()
 {
     UET_DEFS="UET_PDS=pds UET_SEC_MODE=direct"
+    # IPv6 direct mode requires SSI
+    if [ $is_ipv6 -eq 1 ]; then
+        UET_DEFS="$UET_DEFS UET_SEC_SSI=$ssi"
+    fi
     banner "PDS w/ SEC=direct $test"
     run_test "$UET_DEFS $CMD_BASE $actor $test $peer_ip"
 }

--- a/uet.c
+++ b/uet.c
@@ -1517,7 +1517,7 @@ static int uet_run(int argc, char *argv[], struct uet_context *ctx)
 	 * and likely return ICMP unreachable errors (possibly messing up
 	 * the desired UET flow).
 	 */
-	sleep(1);
+	//sleep(1);
 
 	for (use_iov = 0; use_iov <= 1; use_iov++) {
 		printf("Starting in %s\n",

--- a/uet.c
+++ b/uet.c
@@ -129,7 +129,8 @@ struct uet_cfg {
 	int num_iterations;                 /* number of messages to exchange */
 	size_t msg_size;                         /* size of messages in bytes */
 	char *peer_ip_addr_string;             /* peer ip addr in string form */
-	uint32_t peer_ipv4_addr;                                /* host order */
+	struct uet_fa peer_ip_addr;                             /* host order */
+	bool is_ipv6;
 	struct uet_addr peer_uet_addr;                    /* peer uet address */
 	uint32_t job_id;                                    /* id of this job */
 };
@@ -153,7 +154,7 @@ struct uet_context {
 	uet_cq_handle_t tx_cq_handle;
 	uet_cq_handle_t rx_cq_handle;
 	uet_addr_handle_t peer_addr_handle;
-	uint32_t local_ipv4_addr;                          /* host byte order */
+	struct uet_fa local_ip_addr;                       /* host byte order */
 	struct fid_fabric fabric;
 	struct fid_domain domain;
 	struct fid_ep ep;
@@ -295,6 +296,7 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 			     struct uet_context *ctx)
 {
 	struct in_addr peer_in_addr;
+	struct in6_addr peer_in6_addr;
 	struct uet_addr *addr;
 
 	ctx->cfg.job_id = UET_DEF_JOB_ID;
@@ -331,25 +333,33 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 		ctx->cfg.peer_ip_addr_string = argv[2];
 	}
 
-	if (inet_pton(AF_INET, ctx->cfg.peer_ip_addr_string,
-		      &peer_in_addr) != 1) {
-		UET_PRINT_ERRNO("Invalid usage: bad IPv4 address");
+	memset(&ctx->cfg.peer_ip_addr, 0, sizeof(struct uet_fa));
+
+	if (inet_pton(AF_INET6, ctx->cfg.peer_ip_addr_string,
+		      &peer_in6_addr) == 1) {
+		memcpy(ctx->cfg.peer_ip_addr.v6, &peer_in6_addr, 16);
+		ctx->cfg.is_ipv6 = true;
+	} else if (inet_pton(AF_INET, ctx->cfg.peer_ip_addr_string,
+			     &peer_in_addr) == 1) {
+		ctx->cfg.peer_ip_addr.v4 = ntohl(peer_in_addr.s_addr);
+		ctx->cfg.is_ipv6 = false;
+	} else {
+		UET_PRINT_ERRNO("Invalid usage: bad IP address");
 		return UET_ERR_RC;
 	}
-	ctx->cfg.peer_ipv4_addr = ntohl(peer_in_addr.s_addr);
 
 	addr = &ctx->cfg.peer_uet_addr;
 	addr->ver = UET_ADDR_VERSION;
-	addr->flags = UET_ADDR_FEP_CAP_V     |
-		      UET_ADDR_FA_V          |
-		      UET_ADDR_PID_ON_FEP_V  |
-		      UET_ADDR_INDEX_V       |
-		      UET_ADDR_INITIATOR_V   |
-		      UET_ADDR_RELATIVE_MODE |
-		      UET_ADDR_IPV4          |
-		      UET_ADDR_BIG_MSG_SIZE;
+	addr->flags = (UET_ADDR_FEP_CAP_V     |
+		       UET_ADDR_FA_V          |
+		       UET_ADDR_PID_ON_FEP_V  |
+		       UET_ADDR_INDEX_V       |
+		       UET_ADDR_INITIATOR_V   |
+		       UET_ADDR_RELATIVE_MODE |
+		       (ctx->cfg.is_ipv6 ? UET_ADDR_IPV6 : UET_ADDR_IPV4) |
+		       UET_ADDR_BIG_MSG_SIZE);
 	addr->fep_cap = UET_FEP_CAP_AI_FULL;
-	addr->fa.v4 = ctx->cfg.peer_ipv4_addr;
+	memcpy(&addr->fa, &ctx->cfg.peer_ip_addr, sizeof(struct uet_fa));
 	addr->pid_on_fep = UET_ADDR_DEF_PID_ON_FEP;
 	addr->num_indices = 1;
 	addr->start_index = UET_ADDR_DEF_INDEX;
@@ -436,7 +446,7 @@ static uet_rc_t uet_validate_iov_msg(struct uet_context *ctx)
 static uet_rc_t uet_init_transport(struct uet_context *ctx)
 {
 	int ret;
-	char ip_addr_str[INET_ADDRSTRLEN];
+	char ip_addr_str[INET6_ADDRSTRLEN];
 	void *context = NULL;
 	struct fi_info *hints = NULL, *info;
 	struct uet_addr *uet_addr;
@@ -447,7 +457,7 @@ static uet_rc_t uet_init_transport(struct uet_context *ctx)
 	if (!ctx->cfg.client)
 		setenv(UET_SEC_SERVER, "1", 1);
 
-	ret = uet_initialize(&ctx->uet_handle);
+	ret = uet_initialize(&ctx->uet_handle, ctx->cfg.is_ipv6);
 	if (ret) {
 		UET_ERR("uet_initialize: %s", fi_strerror(-ret));
 		goto exit;
@@ -489,7 +499,9 @@ static uet_rc_t uet_init_transport(struct uet_context *ctx)
 		else
 			printf("UNKNOWN\n");
 		uet_addr = (struct uet_addr *) info->src_addr;
-		uet_ipv4_addr_to_str(uet_addr->fa.v4, ip_addr_str);
+		uet_ip_addr_to_str(&uet_addr->fa,
+				   uet_addr_is_ipv6(uet_addr),
+				   ip_addr_str);
 		printf("  IP Address:      %s\n", ip_addr_str);
 	}
 

--- a/uet_addr.h
+++ b/uet_addr.h
@@ -58,4 +58,6 @@ struct uet_addr {
 	uint32_t initiator_id;
 };
 
+#define uet_addr_is_ipv6(addr) ((addr)->flags & UET_ADDR_IPV6)
+
 #endif /* _UET_ADDR_H_ */

--- a/uet_api.c
+++ b/uet_api.c
@@ -20,7 +20,7 @@
  *   - support for synchronous control operations
  *   - support for 1 send completion queue and 1 receive completion
  *     queue per endpoint
- *   - no support for ipv6
+ *   - support for ipv4 and ipv6
  *   - no support for selective completion
  *   - manual progress required
  *   - FI_TRANSMIT_COMPLETE and FI_DELIVERY_COMPLETE are the only transmit
@@ -73,18 +73,25 @@ static uint32_t uet_job_key_to_id(uint32_t job_key)
 }
 #endif
 
-/* init portions of uet address with ipv4 fabric address */
-static void uet_init_uet_addr_ipv4(struct uet_addr *uet_addr,
-				   uint32_t ipv4_addr)
+/* init portions of uet address with fabric address */
+static void uet_init_uet_addr(struct uet_addr *uet_addr,
+			      const struct uet_fa *ip_addr,
+			      bool is_ipv6)
 {
 	uet_addr->ver = UET_ADDR_VERSION;
 	uet_addr->flags = (UET_ADDR_FEP_CAP_V     |
 			   UET_ADDR_FA_V          |
 			   UET_ADDR_RELATIVE_MODE |
-			   UET_ADDR_IPV4          |
 			   UET_ADDR_BIG_MSG_SIZE);
+
+	if (is_ipv6)
+		uet_addr->flags |= UET_ADDR_IPV6;
+	else
+		uet_addr->flags |= UET_ADDR_IPV4;
+
 	uet_addr->fep_cap = UET_FEP_CAP_AI_FULL;
-	uet_addr->fa.v4 = ipv4_addr;
+
+	memcpy(&uet_addr->fa, ip_addr, sizeof(struct uet_fa));
 }
 
 /* get pds mode for an endpoint */
@@ -493,18 +500,24 @@ static void uet_set_av_msg_tx_seq_num(struct uet_av_entry *av_entry,
 	}
 }
 
-/* init key for ipv4 endpoint lookup from packet contents */
-static void uet_ipv4_ep_key_init(struct uet_ipv4_ep_key *key,
-				 struct uet_parsed_pkt *pp)
+/* init key for endpoint lookup from packet contents */
+static void uet_ep_key_init(struct uet_ep_key *key,
+			    struct uet_parsed_pkt *pp)
 {
-	struct iphdr *ipv4;
 	struct uet_ses_req_std *ses;
 
-	ipv4 = (struct iphdr *) pp->ip;
 	ses = (struct uet_ses_req_std *) pp->ses;
 
-	memset(key, 0, sizeof(struct uet_ipv4_ep_key));
-	key->ipv4_addr = ntohl(ipv4->daddr);
+	memset(key, 0, sizeof(struct uet_ep_key));
+
+	if (pp->is_ipv6) {
+		struct ipv6hdr *ipv6 = (struct ipv6hdr *)pp->ip;
+		memcpy(key->ip_addr.v6, &ipv6->daddr, 16);
+	} else {
+		struct iphdr *ipv4 = (struct iphdr *)pp->ip;
+		key->ip_addr.v4 = ntohl(ipv4->daddr);
+	}
+
 	key->pid_on_fep =
 		(ntohs(ses->cmn.rsvd_pid_on_fep) & UET_SES_REQ_PID_ON_FEP_MASK)
 		>> UET_SES_REQ_PID_ON_FEP_SHIFT;
@@ -514,48 +527,48 @@ static void uet_ipv4_ep_key_init(struct uet_ipv4_ep_key *key,
 }
 
 /* insert entry into ipv4 endpoint hash table */
-static void uet_ipv4_ep_hash_insert(struct uet_ep *uet_ep)
+static void uet_ep_hash_insert(struct uet_ep *uet_ep)
 {
 	struct uet_instance *uet;
 
 	uet = uet_ep->uet_domain->uet;
 
-	uet_rw_lock(&uet->ipv4_ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
-	HASH_ADD(ipv4_ep_hh, uet->ipv4_ep_hash_table, ipv4_ep_key,
-		 sizeof(struct uet_ipv4_ep_key), uet_ep);
-	uet_rw_unlock(&uet->ipv4_ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
+	uet_rw_lock(&uet->ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
+	HASH_ADD(ep_hh, uet->ep_hash_table, ep_key,
+		 sizeof(struct uet_ep_key), uet_ep);
+	uet_rw_unlock(&uet->ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
 }
 
 /* remove entry from ipv4 endpoint hash table */
-static void uet_ipv4_ep_hash_remove(struct uet_ep *uet_ep)
+static void uet_ep_hash_remove(struct uet_ep *uet_ep)
 {
 	struct uet_instance *uet;
 
 	uet = uet_ep->uet_domain->uet;
 
-	uet_rw_lock(&uet->ipv4_ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
-	HASH_DELETE(ipv4_ep_hh, uet->ipv4_ep_hash_table, uet_ep);
-	uet_rw_unlock(&uet->ipv4_ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
+	uet_rw_lock(&uet->ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
+	HASH_DELETE(ep_hh, uet->ep_hash_table, uet_ep);
+	uet_rw_unlock(&uet->ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
 }
 
 /* remove all entries from ipv4 endpoint hash table and free associated mem */
-static void uet_ipv4_ep_hash_finalize(struct uet_instance *uet)
+static void uet_ep_hash_finalize(struct uet_instance *uet)
 {
-	uet_rw_lock(&uet->ipv4_ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
-	HASH_CLEAR(ipv4_ep_hh, uet->ipv4_ep_hash_table);
-	uet_rw_unlock(&uet->ipv4_ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
+	uet_rw_lock(&uet->ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
+	HASH_CLEAR(ep_hh, uet->ep_hash_table);
+	uet_rw_unlock(&uet->ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
 }
 
 /* ipv4 endpoint hash table lookup */
-static struct uet_ep *uet_ipv4_ep_hash_lookup(struct uet_instance *uet,
-					      struct uet_ipv4_ep_key *key)
+static struct uet_ep *uet_ep_hash_lookup(struct uet_instance *uet,
+					      struct uet_ep_key *key)
 {
 	struct uet_ep *uet_ep;
 
-	uet_rw_lock(&uet->ipv4_ep_lkup_lock, UET_RW_LOCK_RD_ACCESS);
-	HASH_FIND(ipv4_ep_hh, uet->ipv4_ep_hash_table, key,
-		  sizeof(struct uet_ipv4_ep_key), uet_ep);
-	uet_rw_unlock(&uet->ipv4_ep_lkup_lock, UET_RW_LOCK_RD_ACCESS);
+	uet_rw_lock(&uet->ep_lkup_lock, UET_RW_LOCK_RD_ACCESS);
+	HASH_FIND(ep_hh, uet->ep_hash_table, key,
+		  sizeof(struct uet_ep_key), uet_ep);
+	uet_rw_unlock(&uet->ep_lkup_lock, UET_RW_LOCK_RD_ACCESS);
 
 	return uet_ep;
 }
@@ -564,14 +577,20 @@ static struct uet_ep *uet_ipv4_ep_hash_lookup(struct uet_instance *uet,
 static void uet_rx_msg_key_init(struct uet_rx_msg_key *key,
 				struct uet_parsed_pkt *pp)
 {
-	struct iphdr *ipv4 = (struct iphdr *)pp->ip; /* TODO: IPv6 support */
 	struct uet_ses_req_std *ses;
 
 	ses = (struct uet_ses_req_std *) pp->ses;
 
 	memset(key, 0, sizeof(struct uet_rx_msg_key));
-	/* TODO: IPv6 support */
-	key->src_ip.v4 = ntohl(ipv4->saddr);
+
+	if (pp->is_ipv6) {
+		struct ipv6hdr *ipv6 = (struct ipv6hdr *)pp->ip;
+		memcpy(key->src_ip.v6, &ipv6->saddr, 16);
+	} else {
+		struct iphdr *ipv4 = (struct iphdr *)pp->ip;
+		key->src_ip.v4 = ntohl(ipv4->saddr);
+	}
+
 	key->spdcid = pp->pds_spdcid;
 	key->initiator = ses->initiator;
 	key->msg_id = ses->cmn.msg_id;
@@ -1514,7 +1533,7 @@ static void uet_domain_free_all(struct uet_instance *uet)
 /* free most resources associated with uet instance */
 static void uet_finalize_core(struct uet_instance *uet)
 {
-	uet_ipv4_ep_hash_finalize(uet);
+	uet_ep_hash_finalize(uet);
 	uet_nic_finalize(UET_NIC(uet));
 	uet_domain_free_all(uet);
 }
@@ -1752,14 +1771,24 @@ static void uet_init_tx_desc_ephemeral_av(struct uet_tx_desc *tx_desc,
 					  struct uet_parsed_pkt *pp)
 {
 	struct ethhdr *eth;
-	struct iphdr *ipv4;
 	struct uet_av_entry *av;
+	struct uet_fa src_ip;
 
 	eth = (struct ethhdr *) pp->eth;
-	ipv4 = (struct iphdr *) pp->ip;
 
-	uet_init_uet_addr_ipv4(&tx_desc->ephemeral_av.uet_addr,
-			       ntohl(ipv4->saddr));
+	memset(&src_ip, 0, sizeof(src_ip));
+
+	if (pp->is_ipv6) {
+		struct ipv6hdr *ipv6 = (struct ipv6hdr *) pp->ip;
+		memcpy(src_ip.v6, &ipv6->saddr, 16);
+	} else {
+		struct iphdr *ipv4 = (struct iphdr *) pp->ip;
+		src_ip.v4 = ntohl(ipv4->saddr);
+	}
+
+	uet_init_uet_addr(&tx_desc->ephemeral_av.uet_addr,
+			  &src_ip, pp->is_ipv6);
+
 	av = &tx_desc->ephemeral_av.av;
 	av->addr = &tx_desc->ephemeral_av.uet_addr;
 	av->flags = UET_NH_MAC_ADDR_V;
@@ -2562,7 +2591,7 @@ static int uet_pds_to_ses_rx_req(uet_pkt_handle_t rx_pkt_handle,
 	struct uet_ses_req_std *ses_std_req;
 	struct uet_ses_rsp *ses_rsp;
 	struct uet_ses_rsp_d *rx_ses_rsp_d, *ses_rsp_d;
-	struct uet_ipv4_ep_key ipv4_ep_key;
+	struct uet_ep_key ep_key;
 	struct uet_rx_msg_key msg_key;
 	struct uet_rx_desc *rx_desc;
 	struct uet_ack_d_info ack_d_info;
@@ -2585,8 +2614,8 @@ static int uet_pds_to_ses_rx_req(uet_pkt_handle_t rx_pkt_handle,
 		ses_rsp->mod_len = ses_std_req->req_len;
 		job_id = uet_get_std_req_job_id(ses_std_req);
 		if (pp->ses_opcode != UET_DEFER_RTR) {
-			uet_ipv4_ep_key_init(&ipv4_ep_key, pp);
-			uet_ep = uet_ipv4_ep_hash_lookup(uet, &ipv4_ep_key);
+			uet_ep_key_init(&ep_key, pp);
+			uet_ep = uet_ep_hash_lookup(uet, &ep_key);
 			if (uet_ep == NULL) {
 				UET_API_ERR("RX: Unknown Endpoint");
 				ses_rc = UET_RC_UNDELIVERABLE;
@@ -2981,7 +3010,6 @@ static int uet_pds_to_ses_rx_rsp(uet_pkt_handle_t tx_pkt_handle,
 	struct uet_ep *ep;
 	struct uet_tx_desc *tx_desc;
 	struct uet_av_entry *av_entry;
-	union uet_pkt *pkt;
 
 	tx_desc = (struct uet_tx_desc *) tx_pkt_handle;
 	ses_rsp = (struct uet_ses_rsp *) rsp_pp->ses;
@@ -4192,7 +4220,7 @@ err:
  * Below functions implement UET APIs
  *********************************************************************/
 
-int uet_initialize(uet_handle_t *handle)
+int uet_initialize(uet_handle_t *handle, bool is_ipv6)
 {
 	int rc;
 	time_t seed;
@@ -4225,18 +4253,18 @@ int uet_initialize(uet_handle_t *handle)
 	uet->pds.upcall.rx_rsp = uet_pds_to_ses_rx_rsp;
 	uet->pds.upcall.pds_err = uet_pds_to_ses_pds_err;
 
-	uet_rw_lock_init(&uet->ipv4_ep_lkup_lock);
-
-	rc = uet_sec_init();
-	if (rc != FI_SUCCESS)
-		goto err_return;
+	uet_rw_lock_init(&uet->ep_lkup_lock);
 
 	rc = uet_pds_init(uet);
 	if (rc != FI_SUCCESS)
 		goto err_return;
 
 	UET_NIC(uet)->uet_ipproto = uet->uet_ipproto;
-	rc = uet_nic_initialize(UET_NIC(uet));
+	rc = uet_nic_initialize(UET_NIC(uet), is_ipv6);
+	if (rc != FI_SUCCESS)
+		goto err_return;
+
+	rc = uet_sec_init(&uet->nic.ip_addr, is_ipv6);
 	if (rc != FI_SUCCESS)
 		goto err_return;
 
@@ -4378,7 +4406,7 @@ int uet_getinfo(uet_handle_t handle, struct uet_addr *node,
 		rc = -FI_ENOMEM;
 		goto err_return;
 	}
-	uet_init_uet_addr_ipv4(src_addr, uet->nic.ipv4_addr);
+	uet_init_uet_addr(src_addr, &uet->nic.ip_addr, uet->nic.is_ipv6);
 
 	new_info->dest_addrlen = 0;
 	new_info->src_addrlen = sizeof(struct uet_addr);
@@ -4566,7 +4594,7 @@ int uet_endpoint(uet_domain_handle_t domain_handle,
 		goto err_exit;
 	}
 #endif
-	uet_ep->ipv4_addr = uet_ep->uet_addr.fa.v4;
+	memcpy(&uet_ep->ip_addr, &uet_ep->uet_addr.fa, sizeof(struct uet_fa));
 
 	uet_ep->num_rx_desc = info->rx_attr->size;
 	uet_ep->rx_desc = calloc(uet_ep->num_rx_desc,
@@ -4628,10 +4656,11 @@ int uet_endpoint(uet_domain_handle_t domain_handle,
 	uet_ep->send_cq.cq_state = UET_CQ_DOWN;
 	uet_ep->recv_cq.cq_state = UET_CQ_DOWN;
 
-	uet_ep->ipv4_ep_key.ipv4_addr = uet_ep->ipv4_addr;
-	uet_ep->ipv4_ep_key.pid_on_fep = uet_ep->uet_addr.pid_on_fep;
-	uet_ep->ipv4_ep_key.index = uet_ep->uet_addr.start_index;
-	uet_ipv4_ep_hash_insert(uet_ep);
+	memcpy(&uet_ep->ep_key.ip_addr, &uet_ep->ip_addr,
+	       sizeof(struct uet_fa));
+	uet_ep->ep_key.pid_on_fep = uet_ep->uet_addr.pid_on_fep;
+	uet_ep->ep_key.index = uet_ep->uet_addr.start_index;
+	uet_ep_hash_insert(uet_ep);
 
 	switch (info->tx_attr->tclass) {
 	case FI_TC_BEST_EFFORT:
@@ -4804,7 +4833,7 @@ int uet_ep_close(uet_ep_handle_t ep_handle)
 
 	pds->downcall.ep_close_wait(uet_ep);
 
-	uet_ipv4_ep_hash_remove(uet_ep);
+	uet_ep_hash_remove(uet_ep);
 
 	uet_ep_free(uet_ep);
 
@@ -4939,12 +4968,6 @@ int uet_av_insert(uet_domain_handle_t domain_handle,
 	uet_dom = (struct uet_domain *) domain_handle;
 	uet = uet_dom->uet;
 
-	/* TODO: only support ipv4 addresses for now */
-	if (uet_addr->flags & UET_ADDR_IPV6) {
-		UET_API_ERR("IPv6 not supported");
-		return -FI_ENOSYS;
-	}
-
 	/* allocate memory for av object */
 	av_entry = calloc(1, sizeof(struct uet_av_entry));
 	if (av_entry == NULL) {
@@ -4954,8 +4977,9 @@ int uet_av_insert(uet_domain_handle_t domain_handle,
 
 	/* initialize av entry */
 	av_entry->addr = uet_addr;
-	rc = uet_nic_get_ipv4_nh(UET_NIC(uet), uet_addr->fa.v4,
-				 av_entry->nh_mac_addr);
+	rc = uet_nic_get_nh(UET_NIC(uet), &uet_addr->fa,
+			    uet_addr_is_ipv6(uet_addr),
+			    av_entry->nh_mac_addr);
 	if (rc == FI_SUCCESS)
 		av_entry->flags |= UET_NH_MAC_ADDR_V;
 
@@ -5707,3 +5731,4 @@ int uet_query_atomic(uet_domain_handle_t domain_handle,
 {
 	return -FI_ENOSYS;
 }
+

--- a/uet_api.h
+++ b/uet_api.h
@@ -77,12 +77,13 @@ typedef void (*uet_eq_err_callback_t)(uet_handle_t handle,
  *
  * parms:
  *   handle - ptr to location where uet instance handle is returned
+ *   is_ipv6 - initialize for IPv6
  *
  * returns:
  *   0 on success,
  *   negative value corresponding to fabric errno on error
  */
-int uet_initialize(uet_handle_t *handle);
+int uet_initialize(uet_handle_t *handle, bool is_ipv6);
 
 /*
  * free resources of uet instance

--- a/uet_api_private.h
+++ b/uet_api_private.h
@@ -383,9 +383,9 @@ struct uet_tx_rtr_token_cb {
 	uint32_t initiator_id[UET_MAX_RTR_TOKEN+1];    /* remote initiator id */
 };
 
-/* key for ipv4 endpoint lookup */
-struct uet_ipv4_ep_key {
-	uint32_t ipv4_addr;
+/* key for endpoint lookup */
+struct uet_ep_key {
+	struct uet_fa ip_addr;
 	uint16_t pid_on_fep;
 	uint32_t index;
 };
@@ -411,8 +411,8 @@ struct uet_instance {
 	struct uet_msg_id_cb msg_id_cb;        /* used for assigning msg id's */
 				      /* used for assigning tx restart tokens */
 	struct uet_tx_rtr_token_cb tx_rtr_token_cb;
-	struct uet_rw_lock ipv4_ep_lkup_lock;  /* lock for ipv4 ep lookup tbl */
-	struct uet_ep *ipv4_ep_hash_table;        /* ipv4 endpoint hash table */
+	struct uet_rw_lock ep_lkup_lock;           /* lock for ep lookup tbl */
+	struct uet_ep *ep_hash_table;                 /* endpoint hash table */
 };
 
 /* memory region descriptor allocation control block struct */
@@ -484,14 +484,14 @@ struct uet_ep {
 	pthread_mutex_t data_lock;        /* lock for data path thread safety */
 	uet_ep_state_t ep_state;                         /* state of endpoint */
 	struct dlist_entry ep_list_entry;              /* endpoint list entry */
-	UT_hash_handle ipv4_ep_hh;  /* handle for ipv4 endpoint hash function */
+	UT_hash_handle ep_hh;            /* handle for endpoint hash function */
 	struct uet_domain *uet_domain;                /* ptr to domain struct */
 	struct fi_info *info;                 /* ptr to libfabric info struct */
 	struct fid_ep *ep;                /* ptr to libfabric endpoint struct */
 	void *context;               /* user context associated with endpoint */
 	struct uet_addr uet_addr;               /* uet addr of ep, host order */
-	uint32_t ipv4_addr;                    /* ipv4 addr of ep, host order */
-	struct uet_ipv4_ep_key ipv4_ep_key;   /* key for ipv4 endpoint lookup */
+	struct uet_fa ip_addr;                   /* ip addr of ep, host order */
+	struct uet_ep_key ep_key;                  /* key for endpoint lookup */
 	uint8_t msg_ip_tos;                            /* ip tos for messages */
 	struct uet_cq send_cq;                       /* send completion queue */
 	struct uet_cq recv_cq;                    /* receive completion queue */

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -125,6 +125,7 @@ struct uet_pdc {
 	uint8_t              dst_mac_addr[ETH_ALEN];
 	struct uet_fa        src_addr;
 	struct uet_fa        dst_addr;
+	bool                 is_ipv6;
 	uint16_t             syn_offset; /* initiator SYN offset until ACK */
 	uint32_t             next_psn; /* next Tx pkt seq number */
 	struct bitmap       *tx_bm;
@@ -305,7 +306,7 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 	struct uet_pds_req *pds_hdr;
 	uint32_t crc;
 	uint8_t *crc_start;
-	bool update_ipv4_tl = false;
+	bool update_ip_len = false;
 	int rc;
 
 	if (tx_pkt) {
@@ -343,8 +344,9 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 		}
 
 		/* calculate the CRC (include src/dst IP and UDP) */
-		/* TODO: IPv6 support */
-		crc_start = ((uint8_t *)pp->ip + 12);
+		crc_start = (pp->is_ipv6) ?
+			    ((uint8_t *)pp->ip + 8) : /* IPv6 src offset */
+			    ((uint8_t *)pp->ip + 12); /* IPv4 src offset */
 		crc = crc32c(crc_start,
 			     (pp->pkt_len -
 			      (crc_start - (uint8_t *)pp->eth)));
@@ -365,14 +367,13 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 			return 0;
 		}
 
-		/* TODO: IPv6 support */
 		return uet_nic_tx_pkt(UET_NIC(uet), *pkt, pp->ip, new_pkt_len);
 	}
 
 	/* inject/build the security header and encrypt the packet */
 
 	if (is_rtx) {
-		rc = uet_sec_update_hdr_tsc(*pkt);
+		rc = uet_sec_update_hdr_tsc(*pkt, pdc->is_ipv6);
 		if (rc != 0)
 			return rc;
 	} else {
@@ -383,16 +384,16 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 				       *pkt,
 				       *pkt_len,
 				       &new_pkt,
-				       &new_pkt_len);
+				       &new_pkt_len,
+				       pdc->is_ipv6);
 		if (rc != 0)
 			return rc;
 
 		*pkt     = new_pkt;
 		*pkt_len = (new_pkt_len + UET_SEC_TAG_LEN);
 
-		/* for IPv4 the total length and checksum needs fixing */
-		/* TODO: not with IPv6 */
-		update_ipv4_tl = true;
+		/* IP length fields need fixing after security header injection */
+		update_ip_len = true;
 	}
 
 	/* If the packet hasn't been parsed yet for debug then do it now. */
@@ -407,9 +408,15 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 		*pp_parsed = true;
 	}
 
-	/* TODO: IPv6 support (don't do this) */
-	if (update_ipv4_tl)
-		uet_update_ipv4_tl(pp->ip, (*pkt_len - uet->nic.l2_hdr_size));
+	if (update_ip_len) {
+		if (pp->is_ipv6)
+			uet_update_ipv6_pl(pp->ip,
+					   (*pkt_len - uet->nic.l2_hdr_size -
+					    sizeof(struct ipv6hdr)));
+		else
+			uet_update_ipv4_tl(pp->ip,
+					   (*pkt_len - uet->nic.l2_hdr_size));
+	}
 
 	rc = uet_sec_enc_pkt(uet,
 			     pkt_buf,
@@ -433,7 +440,6 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 		return 0;
 	}
 
-	/* TODO: IPv6 support */
 	return uet_nic_tx_pkt(UET_NIC(uet), new_pkt, pp->ip, new_pkt_len);
 }
 
@@ -602,8 +608,7 @@ static struct uet_pdc *uet_pdsm_assign_ini_pdc(struct uet_ep *uet_ep,
 						     PDC_TYPE_NONE);
 	pdc_key.job_id = uet_ep->job_id;
 	pdc_key.tc = UET_DEFAULT_TC;
-	/* TODO: IPv6 support */
-	memcpy(&pdc_key.src_ip, &uet_ep->ipv4_addr, sizeof(uet_ep->ipv4_addr));
+	memcpy(&pdc_key.src_ip, &uet_ep->ip_addr, sizeof(struct uet_fa));
 	memcpy(&pdc_key.dst_ip, &av_entry->addr->fa, sizeof(struct uet_fa));
 
 	HASH_FIND(pdc_ini_hh, pds_state.pdc_ini_ht, &pdc_key,
@@ -641,11 +646,9 @@ static struct uet_pdc *uet_pdsm_assign_ini_pdc(struct uet_ep *uet_ep,
 	memcpy(pdc->dst_mac_addr, av_entry->nh_mac_addr,
 	       ETH_ALEN);
 
-	/* TODO: IPv6 support */
-	memcpy(&pdc->src_addr, &uet_ep->ipv4_addr,
-	       sizeof(pdc->src_addr.v4));
-	memcpy(&pdc->dst_addr, &av_entry->addr->fa.v4,
-	       sizeof(pdc->dst_addr.v4));
+	memcpy(&pdc->src_addr, &uet_ep->ip_addr, sizeof(struct uet_fa));
+	memcpy(&pdc->dst_addr, &av_entry->addr->fa, sizeof(struct uet_fa));
+	pdc->is_ipv6 = uet_addr_is_ipv6(av_entry->addr);
 
 	pdc->next_psn       = UET_DEFAULT_START_PSN;
 	pdc->tx_bm_base_psn = UET_DEFAULT_START_PSN;
@@ -665,7 +668,6 @@ static struct uet_pdc *uet_pdsm_assign_tgt_pdc(struct uet_parsed_pkt *pp)
 {
 	struct uet_ses_req_cmn *ses_cmn = (struct uet_ses_req_cmn *)pp->ses;
 	struct ethhdr *eth = (struct ethhdr *)pp->eth;
-	struct iphdr *ipv4 = (struct iphdr *)pp->ip; /* TODO: IPv6 support */
 	struct uet_pdc_tgt_key pdc_key;
 	struct uet_pdc *pdc;
 
@@ -682,9 +684,15 @@ static struct uet_pdc *uet_pdsm_assign_tgt_pdc(struct uet_parsed_pkt *pp)
 		return NULL;
 
 	memset(&pdc_key, 0, sizeof(pdc_key));
-	/* TODO: IPv6 support */
-	pdc_key.src_ip.v4 = ntohl(ipv4->saddr);
-	pdc_key.dst_ip.v4 = ntohl(ipv4->daddr);
+	if (pp->is_ipv6) {
+		struct ipv6hdr *ipv6 = (struct ipv6hdr *)pp->ip;
+		memcpy(pdc_key.src_ip.v6, &ipv6->saddr, 16);
+		memcpy(pdc_key.dst_ip.v6, &ipv6->daddr, 16);
+	} else {
+		struct iphdr *ipv4 = (struct iphdr *)pp->ip;
+		pdc_key.src_ip.v4 = ntohl(ipv4->saddr);
+		pdc_key.dst_ip.v4 = ntohl(ipv4->daddr);
+	}
 	pdc_key.spdcid = pp->pds_spdcid; /* target side needs spdcid */
 
 	HASH_FIND(pdc_tgt_hh, pds_state.pdc_tgt_ht, &pdc_key,
@@ -721,10 +729,17 @@ static struct uet_pdc *uet_pdsm_assign_tgt_pdc(struct uet_parsed_pkt *pp)
 	memcpy(pdc->src_mac_addr, eth->h_dest, ETH_ALEN);
 	memcpy(pdc->dst_mac_addr, eth->h_source, ETH_ALEN);
 
-	/* TODO: IPv6 support */
-	pdc->src_addr.v4 = ntohl(ipv4->daddr);
-	pdc->dst_addr.v4 = ntohl(ipv4->saddr);
+	if (pp->is_ipv6) {
+		struct ipv6hdr *ipv6 = (struct ipv6hdr *)pp->ip;
+		memcpy(pdc->src_addr.v6, &ipv6->daddr, 16);
+		memcpy(pdc->dst_addr.v6, &ipv6->saddr, 16);
+	} else {
+		struct iphdr *ipv4 = (struct iphdr *)pp->ip;
+		pdc->src_addr.v4 = ntohl(ipv4->daddr);
+		pdc->dst_addr.v4 = ntohl(ipv4->saddr);
+	}
 
+	pdc->is_ipv6        = pp->is_ipv6;
 	pdc->dpdcid         = pp->pds_spdcid;
 	pdc->rx_bm_base_psn = (pp->pds_psn - pp->pds_syn_off);
 	pdc->tx_bm_base_psn = pdc->rx_bm_base_psn;
@@ -875,6 +890,7 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 	struct uet_pdc_pkt *pdc_pkt;
 	struct uet_pds_ctrl *ctrl_hdr;
 	struct uet_entropy *entropy_hdr;
+	size_t ip_hdr_size;
 	uint16_t ctrl_flags;
 	int rc;
 
@@ -900,21 +916,25 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 			? (pdc_pkt->pkt_buf + UET_SEC_MAX_HDR_LEN)
 			: pdc_pkt->pkt_buf;
 
+	ip_hdr_size = (pdc->is_ipv6) ? sizeof(struct ipv6hdr) :
+				       sizeof(struct iphdr);
+
 	/* build Ethernet header */
 	uet_build_eth_hdr((struct ethhdr *)pdc_pkt->pkt,
-			  pdc->dst_mac_addr, pdc->src_mac_addr);
+			  pdc->dst_mac_addr, pdc->src_mac_addr,
+			  pdc->is_ipv6);
 
 	/* set up pointers to headers */
 	entropy_hdr = (struct uet_entropy *)(pdc_pkt->pkt +
 					     sizeof(struct ethhdr) +
-					     sizeof(struct iphdr));
+					     ip_hdr_size);
 	ctrl_hdr = (struct uet_pds_ctrl *)(pdc_pkt->pkt +
 					   sizeof(struct ethhdr) +
-					   sizeof(struct iphdr) +
+					   ip_hdr_size +
 					   sizeof(struct uet_entropy));
 
 	pdc_pkt->pkt_len = (sizeof(struct ethhdr) +
-			    sizeof(struct iphdr) +
+			    ip_hdr_size +
 			    sizeof(struct uet_entropy) +
 			    sizeof(struct uet_pds_ctrl));
 
@@ -941,14 +961,26 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 	ctrl_hdr->payload = 0;
 
 	/* build the IP header */
-	uet_build_ipv4_hdr(uet,
-			   (struct iphdr *)(pdc_pkt->pkt +
-					    sizeof(struct ethhdr)),
-			   htonl(pdc->dst_addr.v4),
-			   htonl(pdc->src_addr.v4),
-			   (pdc_pkt->pkt_len - uet->nic.l2_hdr_size),
-			   uet->pds.ack_ip_tos,
-			   !pdc->sec_enabled);
+	if (pdc->is_ipv6) {
+		uet_build_ipv6_hdr(uet,
+				   (struct ipv6hdr *)(pdc_pkt->pkt +
+						      sizeof(struct ethhdr)),
+				   pdc->dst_addr.v6,
+				   pdc->src_addr.v6,
+				   (pdc_pkt->pkt_len - uet->nic.l2_hdr_size -
+				    ip_hdr_size),
+				   uet->pds.ack_ip_tos,
+				   !pdc->sec_enabled);
+	} else {
+		uet_build_ipv4_hdr(uet,
+				   (struct iphdr *)(pdc_pkt->pkt +
+						    sizeof(struct ethhdr)),
+				   htonl(pdc->dst_addr.v4),
+				   htonl(pdc->src_addr.v4),
+				   (pdc_pkt->pkt_len - uet->nic.l2_hdr_size),
+				   uet->pds.ack_ip_tos,
+				   !pdc->sec_enabled);
+	}
 
 	/* save packet params */
 	pdc_pkt->msg_id = 0; /* control packets have no msg_id */
@@ -1203,6 +1235,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	struct uet_pdc *pdc;
 	struct uet_entropy *entropy_hdr;
 	struct uet_pds_req *pds_hdr;
+	size_t ip_hdr_size;
 	void *ses_hdr, *payload;
 	uint16_t pds_flags;
 	int rc, hdr_len;
@@ -1298,9 +1331,8 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 		}
 	}
 
-	/* TODO: IPv6 support */
-	if (memcmp(&pdc->dst_addr.v4, &av_entry->addr->fa.v4,
-		   sizeof(pdc->dst_addr.v4)) != 0) {
+	if (memcmp(&pdc->dst_addr, &av_entry->addr->fa,
+		   sizeof(struct uet_fa)) != 0) {
 		UET_PDS_ERR("PDC %u dst_addr does not match AV for Tx pkt %p",
 			    pdc->pdc_id, tx_pkt_handle);
 		return -EINVAL;
@@ -1374,23 +1406,25 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 			? (pdc_pkt->pkt_buf + UET_SEC_MAX_HDR_LEN)
 			: pdc_pkt->pkt_buf;
 
-	uet_build_eth_hdr((struct ethhdr *)pdc_pkt->pkt,
-			  pdc->dst_mac_addr, pdc->src_mac_addr);
+	ip_hdr_size = (pdc->is_ipv6) ? sizeof(struct ipv6hdr) :
+				       sizeof(struct iphdr);
 
-	/* TODO: IPv6 support and UDP support */
+	uet_build_eth_hdr((struct ethhdr *)pdc_pkt->pkt,
+			  pdc->dst_mac_addr, pdc->src_mac_addr,
+			  pdc->is_ipv6);
+
 	entropy_hdr = (struct uet_entropy *)(pdc_pkt->pkt +
 					     sizeof(struct ethhdr) +
-					     sizeof(struct iphdr));
+					     ip_hdr_size);
 	pds_hdr = (struct uet_pds_req *)(pdc_pkt->pkt +
 					 sizeof(struct ethhdr) +
-					 sizeof(struct iphdr) +
+					 ip_hdr_size +
 					 sizeof(struct uet_entropy));
 	ses_hdr = (pds_hdr + 1);
 	payload = ((uint8_t *)ses_hdr + ses_len);
 
-	/* TODO: IPv6 support and UDP support */
 	hdr_len = (sizeof(struct ethhdr) +
-		   sizeof(struct iphdr) +
+		   ip_hdr_size +
 		   sizeof(struct uet_entropy) +
 		   sizeof(struct uet_pds_req) +
 		   ses_len);
@@ -1444,16 +1478,26 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	memcpy(payload, pkt, pkt_len);
 
 	/* build the IP header */
-
-	/* TODO: IPv6 support and UDP support */
-	uet_build_ipv4_hdr(uet,
-			   (struct iphdr *)(pdc_pkt->pkt +
-					    sizeof(struct ethhdr)),
-			   htonl(pdc->dst_addr.v4),
-			   htonl(pdc->src_addr.v4),
-			   (pdc_pkt->pkt_len - uet->nic.l2_hdr_size),
-			   uet_ep->msg_ip_tos,
-			   !pdc->sec_enabled);
+	if (pdc->is_ipv6) {
+		uet_build_ipv6_hdr(uet,
+				   (struct ipv6hdr *)(pdc_pkt->pkt +
+						      sizeof(struct ethhdr)),
+				   pdc->dst_addr.v6,
+				   pdc->src_addr.v6,
+				   (pdc_pkt->pkt_len - uet->nic.l2_hdr_size -
+				    ip_hdr_size),
+				   uet_ep->msg_ip_tos,
+				   !pdc->sec_enabled);
+	} else {
+		uet_build_ipv4_hdr(uet,
+				   (struct iphdr *)(pdc_pkt->pkt +
+						    sizeof(struct ethhdr)),
+				   htonl(pdc->dst_addr.v4),
+				   htonl(pdc->src_addr.v4),
+				   (pdc_pkt->pkt_len - uet->nic.l2_hdr_size),
+				   uet_ep->msg_ip_tos,
+				   !pdc->sec_enabled);
+	}
 
 	/* save some params specific for this packet */
 	pdc_pkt->msg_id        = msg_id;
@@ -1712,29 +1756,44 @@ static void uet_pds_build_ack_pkt(struct uet_instance *uet,
 	struct uet_entropy *entropy_hdr;
 	struct uet_pds_ack *ack_pds;
 	uint8_t *ack_ses;
+	size_t ip_hdr_size = (pdc->is_ipv6) ? sizeof(struct ipv6hdr) :
+					      sizeof(struct iphdr);
 
-	/* TODO: IPv6 support and UDP support */
 	entropy_hdr = (struct uet_entropy *)(pdc_pkt->ack +
 					     sizeof(struct ethhdr) +
-					     sizeof(struct iphdr));
+					     ip_hdr_size);
 	ack_pds = (struct uet_pds_ack *)(pdc_pkt->ack +
 					 sizeof(struct ethhdr) +
-					 sizeof(struct iphdr) +
+					 ip_hdr_size +
 					 sizeof(struct uet_entropy));
 
 	uet_build_eth_hdr((struct ethhdr *)pdc_pkt->ack,
 			  ((struct ethhdr *)pdc_pkt->pkt_pp.eth)->h_source,
-			  ((struct ethhdr *)pdc_pkt->pkt_pp.eth)->h_dest);
+			  ((struct ethhdr *)pdc_pkt->pkt_pp.eth)->h_dest,
+			  pdc->is_ipv6);
 
-	/* TODO: IPv6 support */
-	uet_build_ipv4_hdr(uet,
-			   (struct iphdr *)(pdc_pkt->ack +
-					    sizeof(struct ethhdr)),
-			   ((struct iphdr *)pdc_pkt->pkt_pp.ip)->saddr,
-			   ((struct iphdr *)pdc_pkt->pkt_pp.ip)->daddr,
-			   (pdc_pkt->ack_len - uet->nic.l2_hdr_size),
-			   uet->pds.ack_ip_tos,
-			   !pdc->sec_enabled);
+	if (pdc->is_ipv6) {
+		struct ipv6hdr *rx_ipv6 =
+			(struct ipv6hdr *)pdc_pkt->pkt_pp.ip;
+		uet_build_ipv6_hdr(uet,
+				   (struct ipv6hdr *)(pdc_pkt->ack +
+						      sizeof(struct ethhdr)),
+				   (const uint8_t *)&rx_ipv6->saddr,
+				   (const uint8_t *)&rx_ipv6->daddr,
+				   (pdc_pkt->ack_len - uet->nic.l2_hdr_size -
+				    ip_hdr_size),
+				   uet->pds.ack_ip_tos,
+				   !pdc->sec_enabled);
+	} else {
+		uet_build_ipv4_hdr(uet,
+				   (struct iphdr *)(pdc_pkt->ack +
+						    sizeof(struct ethhdr)),
+				   ((struct iphdr *)pdc_pkt->pkt_pp.ip)->saddr,
+				   ((struct iphdr *)pdc_pkt->pkt_pp.ip)->daddr,
+				   (pdc_pkt->ack_len - uet->nic.l2_hdr_size),
+				   uet->pds.ack_ip_tos,
+				   !pdc->sec_enabled);
+	}
 
 	/* TODO: UDP support */
 	entropy_hdr->entropy = htons(pdc_pkt->pkt_pp.entropy_val);
@@ -1772,24 +1831,24 @@ static int uet_pds_tx_ack_pkt(struct uet_instance *uet,
 	uint16_t ack_pkt_len;
 	uint16_t ack_data_len;
 	int rc;
-
-	/* TODO: IPv6 support and UDP support */
+	size_t ip_hdr_size = (pdc->is_ipv6) ? sizeof(struct ipv6hdr) :
+					      sizeof(struct iphdr);
 
 	if (next_hdr == UET_HDR_NONE) {
 		pdc_pkt->ack_len = (sizeof(struct ethhdr) +
-				    sizeof(struct iphdr) +
+				    ip_hdr_size +
 				    sizeof(struct uet_entropy) +
 				    sizeof(struct uet_pds_ack));
 	} else if (next_hdr == UET_HDR_RSP) {
 		pdc_pkt->ack_len = (sizeof(struct ethhdr) +
-				    sizeof(struct iphdr) +
+				    ip_hdr_size +
 				    sizeof(struct uet_entropy) +
 				    sizeof(struct uet_pds_ack) +
 				    sizeof(struct uet_ses_rsp));
 	} else { /* response w/ data */
 		ack_data_len = (ses_hdr_len - sizeof(struct uet_ses_rsp_d));
 		pdc_pkt->ack_len = (sizeof(struct ethhdr) +
-				    sizeof(struct iphdr) +
+				    ip_hdr_size +
 				    sizeof(struct uet_entropy) +
 				    sizeof(struct uet_pds_ack) +
 				    sizeof(struct uet_ses_rsp_d) +
@@ -1846,10 +1905,11 @@ static int uet_pds_tx_def_rsp_ack_pkt(struct uet_instance *uet,
 	struct uet_pds_ack *ack_pds;
 	struct uet_pds_def_rsp *ack_ses;
 	int rc;
+	size_t ip_hdr_size = (pdc->is_ipv6) ? sizeof(struct ipv6hdr) :
+					      sizeof(struct iphdr);
 
-	/* TODO: IPv6 support and UDP support */
 	def_rsp_len = (sizeof(struct ethhdr) +
-		       sizeof(struct iphdr) +
+		       ip_hdr_size +
 		       sizeof(struct uet_entropy) +
 		       sizeof(struct uet_pds_ack) +
 		       sizeof(struct uet_pds_def_rsp));
@@ -1878,13 +1938,12 @@ static int uet_pds_tx_def_rsp_ack_pkt(struct uet_instance *uet,
 	tmp_pdc_pkt.ack_len     = def_rsp_len;
 	tmp_pdc_pkt.ack_parsed  = false;
 
-	/* TODO: IPv6 support and UDP support */
 	entropy_hdr = (struct uet_entropy *)(def_rsp +
 					     sizeof(struct ethhdr) +
-					     sizeof(struct iphdr));
+					     ip_hdr_size);
 	ack_pds = (struct uet_pds_ack *)(def_rsp +
 					 sizeof(struct ethhdr) +
-					 sizeof(struct iphdr) +
+					 ip_hdr_size +
 					 sizeof(struct uet_entropy));
 	ack_ses = (struct uet_pds_def_rsp *)(ack_pds + 1);
 
@@ -1893,17 +1952,31 @@ static int uet_pds_tx_def_rsp_ack_pkt(struct uet_instance *uet,
 
 	uet_build_eth_hdr((struct ethhdr *)def_rsp,
 			  ((struct ethhdr *)pdc_pkt->pkt_pp.eth)->h_source,
-			  ((struct ethhdr *)pdc_pkt->pkt_pp.eth)->h_dest);
+			  ((struct ethhdr *)pdc_pkt->pkt_pp.eth)->h_dest,
+			  pdc->is_ipv6);
 
-	/* TODO: IPv6 support */
-	uet_build_ipv4_hdr(uet,
-			   (struct iphdr *)(def_rsp +
-					    sizeof(struct ethhdr)),
-			   ((struct iphdr *)pdc_pkt->pkt_pp.ip)->saddr,
-			   ((struct iphdr *)pdc_pkt->pkt_pp.ip)->daddr,
-			   (def_rsp_len - uet->nic.l2_hdr_size),
-			   uet->pds.ack_ip_tos,
-			   !pdc->sec_enabled);
+	if (pdc->is_ipv6) {
+		struct ipv6hdr *rx_ipv6 =
+			(struct ipv6hdr *)pdc_pkt->pkt_pp.ip;
+		uet_build_ipv6_hdr(uet,
+				   (struct ipv6hdr *)(def_rsp +
+						      sizeof(struct ethhdr)),
+				   (const uint8_t *)&rx_ipv6->saddr,
+				   (const uint8_t *)&rx_ipv6->daddr,
+				   (def_rsp_len - uet->nic.l2_hdr_size -
+				    ip_hdr_size),
+				   uet->pds.ack_ip_tos,
+				   !pdc->sec_enabled);
+	} else {
+		uet_build_ipv4_hdr(uet,
+				   (struct iphdr *)(def_rsp +
+						    sizeof(struct ethhdr)),
+				   ((struct iphdr *)pdc_pkt->pkt_pp.ip)->saddr,
+				   ((struct iphdr *)pdc_pkt->pkt_pp.ip)->daddr,
+				   (def_rsp_len - uet->nic.l2_hdr_size),
+				   uet->pds.ack_ip_tos,
+				   !pdc->sec_enabled);
+	}
 
 	/* TODO: add SACK header, UET_PDS_ACK_FLAGS_AX */
 	ack_pds->prlg.type_next_flags =
@@ -2705,9 +2778,15 @@ int uet_pds_progress_rx(struct uet_instance *uet)
 
 	if (!pp.sec) {
 		/* calculate the CRC (include src/dst IP and UDP) */
-		/* TODO: IPv6 support */
-		crc_start = ((uint8_t *)pp.ip + 12);
-		crc = crc32c(crc_start, (8 + pp.ip_payload_len - CRC_LEN));
+		if (pp.is_ipv6) {
+			crc_start = ((uint8_t *)pp.ip + 8);
+			crc = crc32c(crc_start,
+				     (32 + pp.ip_payload_len - CRC_LEN));
+		} else {
+			crc_start = ((uint8_t *)pp.ip + 12);
+			crc = crc32c(crc_start,
+				     (8 + pp.ip_payload_len - CRC_LEN));
+		}
 
 		/* verify the CRC */
 		if (memcmp(&crc,

--- a/uet_pds_sng.c
+++ b/uet_pds_sng.c
@@ -18,88 +18,6 @@
 #include "uet_nic.h"
 #include "crc32c.h"
 
-/****************************************************************************/
-/*                      FULL HEADER STACKS (UTILITY)                        */
-/****************************************************************************/
-
-/* uet standard request packet format */
-struct UET_PACKED uet_std_req_pkt {
-	struct ethhdr          eth;
-	struct iphdr           ipv4;
-	struct uet_entropy     entropy;
-	struct uet_pds_req     pds;
-	struct uet_ses_req_std ses;
-	uint8_t                payload[];
-};
-
-/* uet default response packet format */
-struct UET_PACKED uet_def_rsp_pkt {
-	struct ethhdr          eth;
-	struct iphdr           ipv4;
-	struct uet_entropy     entropy;
-	struct uet_pds_ack     pds;
-	struct uet_pds_def_rsp ses;
-};
-
-/* uet standard response packet format */
-struct UET_PACKED uet_std_rsp_pkt {
-	struct ethhdr      eth;
-	struct iphdr       ipv4;
-	struct uet_entropy entropy;
-	struct uet_pds_ack pds;
-	struct uet_ses_rsp ses;
-	uint8_t            payload[];
-};
-
-/* uet standard response with data ack packet format */
-struct UET_PACKED uet_std_rsp_d_ack_pkt {
-	struct ethhdr        eth;
-	struct iphdr         ipv4;
-	struct uet_entropy   entropy;
-	struct uet_pds_ack   pds;
-	struct uet_ses_rsp_d ses;
-	uint8_t              payload[];
-};
-
-/* uet standard response with data request packet format */
-struct UET_PACKED uet_std_rsp_d_req_pkt {
-	struct ethhdr        eth;
-	struct iphdr         ipv4;
-	struct uet_entropy   entropy;
-	struct uet_pds_req   pds;
-	struct uet_ses_rsp_d ses;
-	uint8_t              payload[];
-};
-
-/* uet packet (union used to represent any packet type) */
-union UET_PACKED uet_pkt {
-	struct UET_PACKED {
-		struct ethhdr eth;
-		struct iphdr  ipv4;
-		struct UET_PACKED {
-			struct uet_entropy  entropy;
-			struct uet_pds_prlg prlg;
-			union {
-				uint16_t clear_psn_offset;
-				uint16_t ack_psn_offset;
-				uint16_t rsv;
-			};
-			uint32_t            psn;
-			uint16_t            spdcid;
-			uint16_t            dpdcid;
-		} pds;
-	} common;
-
-	struct uet_std_req_pkt       std_req;
-	struct uet_def_rsp_pkt       def_rsp;
-	struct uet_std_rsp_pkt       std_rsp;
-	struct uet_std_rsp_d_req_pkt std_rsp_d;
-	struct uet_std_rsp_d_ack_pkt std_rsp_d_ack;
-};
-
-/****************************************************************************/
-
-/* determine if tx is active for an endpoint */
 /* pds transmit state */
 struct uet_pds_sng_tx_state {
 	bool tx_active;      /* transmit in progress */
@@ -160,6 +78,7 @@ struct uet_pds_ack_state {
 	uint8_t ack[];                 /* ack packet that was sent */
 };
 
+/* determine if tx is active for an endpoint */
 static bool uet_pds_ep_tx_active(struct uet_ep *uet_ep)
 {
 	struct uet_pds_sng_state *pds_state =
@@ -170,7 +89,7 @@ static bool uet_pds_ep_tx_active(struct uet_ep *uet_ep)
 
 /* determine if pkt is destined for endpoint */
 static bool uet_pds_ep_addr_match(
-	struct uet_ep *uet_ep, union uet_pkt *pkt, bool pkt_is_ack,
+	struct uet_ep *uet_ep, void *pkt, bool pkt_is_ack,
 	bool pkt_is_rd_rsp, struct uet_msg_match_info *match_info)
 {
 	uint16_t msg_id, pid_on_fep, index;
@@ -178,28 +97,59 @@ static bool uet_pds_ep_addr_match(
 	struct uet_pds_sng_state *pds_state =
 		(struct uet_pds_sng_state *)uet_ep->pds;
 	struct uet_rx_desc *rx_desc;
+	struct uet_instance *uet = uet_ep->uet_domain->uet;
+	bool is_ipv6 = uet->nic.is_ipv6;
+	size_t ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr) :
+					 sizeof(struct iphdr);
 
-	if (ntohl(pkt->common.ipv4.daddr) != uet_ep->ipv4_addr)
-		return false;
+	/* check destination IP address match */
+	if (is_ipv6) {
+		struct ipv6hdr *ipv6 =
+			(struct ipv6hdr *)((uint8_t *)pkt +
+					   sizeof(struct ethhdr));
+		if (memcmp(&ipv6->daddr, uet_ep->ip_addr.v6, 16) != 0)
+			return false;
+	} else {
+		struct iphdr *ipv4 =
+			(struct iphdr *)((uint8_t *)pkt +
+					 sizeof(struct ethhdr));
+		if (ntohl(ipv4->daddr) != uet_ep->ip_addr.v4)
+			return false;
+	}
+
 	match_info->ip_addr_match = true;
 
 	if (pkt_is_ack) {
+		struct uet_ses_rsp *ses_rsp =
+			(struct uet_ses_rsp *)((uint8_t *)pkt +
+					       sizeof(struct ethhdr) +
+					       ip_hdr_size +
+					       sizeof(struct uet_entropy) +
+					       sizeof(struct uet_pds_ack));
+
 		if (!pds_state->tx.tx_active)
 			return false;
 
-		job_id = ((ntohl(pkt->std_rsp.ses.cmn.ri_gen_job_id) &
+		job_id = ((ntohl(ses_rsp->cmn.ri_gen_job_id) &
 			   UET_SES_RSP_JOB_ID_MASK) >>
 			  UET_SES_RSP_JOB_ID_SHIFT);
 		if (job_id != uet_ep->job_id)
 			return false;
 		match_info->job_id_match = true;
 
-		msg_id = ntohs(pkt->std_rsp.ses.cmn.msg_id);
+		msg_id = ntohs(ses_rsp->cmn.msg_id);
 		if (msg_id != pds_state->tx.pkt_parms.msg_id)
 			return false;
 		match_info->msg_id_match = true;
 	} else if (pkt_is_rd_rsp) {
-		job_id = ((ntohl(pkt->std_rsp_d.ses.cmn.ri_gen_job_id) &
+		struct uet_ses_rsp_d *ses_rsp_d =
+			(struct uet_ses_rsp_d *)((uint8_t *)pkt +
+						 sizeof(struct ethhdr) +
+						 ip_hdr_size +
+						 sizeof(struct uet_entropy) +
+						 sizeof(struct uet_pds_ack));
+
+		job_id = ((ntohl(ses_rsp_d->cmn.ri_gen_job_id) &
 			   UET_SES_RSP_JOB_ID_MASK) >>
 			  UET_SES_RSP_JOB_ID_SHIFT);
 		if (job_id != uet_ep->job_id)
@@ -209,29 +159,36 @@ static bool uet_pds_ep_addr_match(
 		match_info->pid_on_fep_match = true;
 		match_info->index_match = true;
 
-		msg_id = ntohs(pkt->std_rsp_d.ses.cmn.msg_id);
-		rx_desc = uet_ep->uet_domain->uet->msg_id_cb.rx_desc[msg_id];
+		msg_id = ntohs(ses_rsp_d->cmn.msg_id);
+		rx_desc = uet->msg_id_cb.rx_desc[msg_id];
 		if (rx_desc == NULL)
 			return false;
 		if (rx_desc->uet_ep != uet_ep)
 			return false;
 		match_info->msg_id_match = true;
 	} else {
-		job_id = ((ntohl(pkt->std_req.ses.cmn.ri_gen_job_id) &
+		struct uet_ses_req_std *ses_req =
+			(struct uet_ses_req_std *)((uint8_t *)pkt +
+						   sizeof(struct ethhdr) +
+						   ip_hdr_size +
+						   sizeof(struct uet_entropy) +
+						   sizeof(struct uet_pds_req));
+
+		job_id = ((ntohl(ses_req->cmn.ri_gen_job_id) &
 			   UET_SES_REQ_JOB_ID_MASK) >>
 			  UET_SES_REQ_JOB_ID_SHIFT);
 		if (job_id != uet_ep->job_id)
 			return false;
 		match_info->job_id_match = true;
 
-		pid_on_fep = ((ntohs(pkt->std_req.ses.cmn.rsvd_pid_on_fep) &
+		pid_on_fep = ((ntohs(ses_req->cmn.rsvd_pid_on_fep) &
 			       UET_SES_REQ_PID_ON_FEP_MASK) >>
 			      UET_SES_REQ_PID_ON_FEP_SHIFT);
 		if (pid_on_fep != uet_ep->uet_addr.pid_on_fep)
 			return false;
 		match_info->pid_on_fep_match = true;
 
-		index = ((ntohs(pkt->std_req.ses.cmn.rsvd_res_index) &
+		index = ((ntohs(ses_req->cmn.rsvd_res_index) &
 			  UET_SES_REQ_RES_INDEX_MASK) >>
 			 UET_SES_REQ_RES_INDEX_SHIFT);
 		if (index != uet_ep->uet_addr.start_index)
@@ -244,7 +201,7 @@ static bool uet_pds_ep_addr_match(
 
 /* find endpoint that packet is destined for */
 static struct uet_ep *uet_pds_find_dst_ep(
-	struct uet_instance *uet, union uet_pkt *pkt, bool pkt_is_ack,
+	struct uet_instance *uet, void *pkt, bool pkt_is_ack,
 	bool pkt_is_rd_rsp, struct uet_msg_match_info *match_info)
 {
 	struct dlist_entry *dom_head, *dom_item, *ep_head, *ep_item;
@@ -274,7 +231,7 @@ static struct uet_ep *uet_pds_find_dst_ep(
 }
 
 /* determine if pds request is a duplicate that has already been received */
-static bool uet_pds_is_dup_req(struct uet_ep *uet_ep, union uet_pkt *pkt,
+static bool uet_pds_is_dup_req(struct uet_ep *uet_ep, void *pkt,
 			       struct uet_pds_ack_state **dup_ack_state)
 {
 	struct dlist_entry *head, *item, *prev_item;
@@ -283,24 +240,68 @@ static bool uet_pds_is_dup_req(struct uet_ep *uet_ep, union uet_pkt *pkt,
 	time_t now;
 	struct uet_pds_sng_state *pds_state =
 		(struct uet_pds_sng_state *) uet_ep->pds;
-	union uet_pkt *ack;
+	struct uet_instance *uet = uet_ep->uet_domain->uet;
+	bool is_ipv6 = uet->nic.is_ipv6;
+	size_t ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr) :
+					 sizeof(struct iphdr);
+	/* PDS spdcid offset from start of packet */
+	size_t pds_spdcid_off = (sizeof(struct ethhdr) +
+				 ip_hdr_size +
+				 sizeof(struct uet_entropy) +
+				 sizeof(struct uet_pds_prlg) +
+				 sizeof(uint16_t) + /* clear/ack_psn_offset */
+				 sizeof(uint32_t)); /* psn */
+	/* PDS psn offset from start of packet */
+	size_t pds_psn_off = (sizeof(struct ethhdr) +
+			      ip_hdr_size +
+			      sizeof(struct uet_entropy) +
+			      sizeof(struct uet_pds_prlg) +
+			      sizeof(uint16_t)); /* clear/ack_psn_offset */
+	uint8_t *ack;
 
 	*dup_ack_state = NULL;
 	uet_gettime(&now);
 
 	head = &pds_state->ack_state_list_head;
 	dlist_foreach(head, item) {
+		uint32_t *ack_psn, *pkt_psn;
+		bool ip_match;
+
 		ack_state = container_of(item, struct uet_pds_ack_state,
 					 list_entry);
-		ack = (union uet_pkt *) ack_state->ack;
-		ack_overlay = (struct uet_pds_hdr_overlay *)
-					&ack->common.pds.spdcid;
-		pkt_overlay = (struct uet_pds_hdr_overlay *)
-					&pkt->common.pds.spdcid;
-		if ((ack->common.ipv4.daddr == pkt->common.ipv4.saddr) &&
-		    (ack_overlay->pid_on_fep == pkt_overlay->pid_on_fep)  &&
+		ack = ack_state->ack;
+		ack_overlay =
+			(struct uet_pds_hdr_overlay *)((uint8_t *)ack +
+						       pds_spdcid_off);
+		pkt_overlay =
+			(struct uet_pds_hdr_overlay *)((uint8_t *)pkt +
+						       pds_spdcid_off);
+		ack_psn = (uint32_t *)((uint8_t *)ack + pds_psn_off);
+		pkt_psn = (uint32_t *)((uint8_t *)pkt + pds_psn_off);
+
+		if (is_ipv6) {
+			struct ipv6hdr *ack_ip =
+				(struct ipv6hdr *)((uint8_t *)ack +
+						   sizeof(struct ethhdr));
+			struct ipv6hdr *pkt_ip =
+				(struct ipv6hdr *)((uint8_t *)pkt +
+						   sizeof(struct ethhdr));
+			ip_match = (memcmp(&ack_ip->daddr,
+					   &pkt_ip->saddr, 16) == 0);
+		} else {
+			struct iphdr *ack_ipv4 =
+				(struct iphdr *)(ack +
+						 sizeof(struct ethhdr));
+			struct iphdr *pkt_ipv4 =
+				(struct iphdr *)((uint8_t *)pkt +
+						 sizeof(struct ethhdr));
+			ip_match = (ack_ipv4->daddr == pkt_ipv4->saddr);
+		}
+
+		if (ip_match &&
+		    (ack_overlay->pid_on_fep == pkt_overlay->pid_on_fep) &&
 		    (ack_overlay->index == pkt_overlay->index)) {
-			if (ack->common.pds.psn == pkt->common.pds.psn) {
+			if (*ack_psn == *pkt_psn) {
 				*dup_ack_state = ack_state;
 				return true;
 			}
@@ -335,37 +336,73 @@ static bool uet_pds_is_dup_req(struct uet_ep *uet_ep, union uet_pkt *pkt,
  *      ses_hdr_len - length of ses header in bytes
  *      ses_hdr     - ptr to ses header
  */
-static void uet_pds_build_ack_pkt(struct uet_instance *uet, union uet_pkt *pkt,
-				  union uet_pkt *ack, uint16_t ack_pkt_len,
+static void uet_pds_build_ack_pkt(struct uet_instance *uet, void *pkt,
+				  void *ack, uint16_t ack_pkt_len,
 				  uet_pds_next_hdr_t next_hdr,
 				  size_t ses_hdr_len, void *ses_hdr)
 {
-	uint16_t tot_len;
-	void *ack_ses;
-	struct uet_std_rsp_pkt *ack_rsp;
-	struct uet_std_rsp_d_ack_pkt *ack_rsp_d;
+	bool is_ipv6 = uet->nic.is_ipv6;
+	size_t ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr) :
+					 sizeof(struct iphdr);
+	void *ack_ip = (uint8_t *)ack + sizeof(struct ethhdr);
+	struct uet_pds_ack *ack_pds =
+		(struct uet_pds_ack *)((uint8_t *)ack +
+				       sizeof(struct ethhdr) +
+				       ip_hdr_size +
+				       sizeof(struct uet_entropy));
+	struct uet_pds_req *pkt_pds =
+		(struct uet_pds_req *)((uint8_t *)pkt +
+				       sizeof(struct ethhdr) +
+				       ip_hdr_size +
+				       sizeof(struct uet_entropy));
 	struct uet_pds_hdr_overlay *pkt_overlay, *ack_overlay;
+	void *ack_ses = (uint8_t *)(ack_pds + 1);
+	struct uet_entropy *ack_entropy =
+		(struct uet_entropy *)((uint8_t *)ack +
+				       sizeof(struct ethhdr) +
+				       ip_hdr_size);
 
-	if (next_hdr == UET_HDR_RSP)
-		ack_ses = &ack->std_rsp.ses;
-	else
-		ack_ses = &ack->std_rsp_d_ack.ses;
+	/* copy entropy from request */
+	ack_entropy->entropy =
+		((struct uet_entropy *)((uint8_t *)pkt +
+					sizeof(struct ethhdr) +
+					ip_hdr_size))->entropy;
 
-	uet_build_eth_hdr(&ack->common.eth, pkt->common.eth.h_source,
-			  pkt->common.eth.h_dest);
+	uet_build_eth_hdr((struct ethhdr *)ack,
+			  ((struct ethhdr *)pkt)->h_source,
+			  ((struct ethhdr *)pkt)->h_dest, is_ipv6);
 
-	tot_len = ack_pkt_len - ((uint16_t) uet->nic.l2_hdr_size);
-	uet_build_ipv4_hdr(uet, &ack->common.ipv4, pkt->common.ipv4.saddr,
-			   pkt->common.ipv4.daddr, tot_len,
-			   uet->pds.ack_ip_tos, true);
+	if (is_ipv6) {
+		struct ipv6hdr *pkt_ipv6 =
+			(struct ipv6hdr *)((uint8_t *)pkt +
+					   sizeof(struct ethhdr));
+		uet_build_ipv6_hdr(uet,
+				   (struct ipv6hdr *)ack_ip,
+				   (const uint8_t *)&pkt_ipv6->saddr,
+				   (const uint8_t *)&pkt_ipv6->daddr,
+				   (ack_pkt_len - uet->nic.l2_hdr_size -
+				    ip_hdr_size),
+				   uet->pds.ack_ip_tos, true);
+	} else {
+		struct iphdr *pkt_ipv4 =
+			(struct iphdr *)((uint8_t *)pkt +
+					 sizeof(struct ethhdr));
+		uet_build_ipv4_hdr(uet,
+				   (struct iphdr *)ack_ip,
+				   pkt_ipv4->saddr,
+				   pkt_ipv4->daddr,
+				   (ack_pkt_len -
+				    (uint16_t)uet->nic.l2_hdr_size),
+				   uet->pds.ack_ip_tos, true);
+	}
 
-	ack->common.pds.prlg.type_next_flags = htons(
-		(UET_PDS_TYPE_ACK << UET_PDS_TYPE_SHIFT) |
-		(next_hdr << UET_PDS_NEXT_HDR_SHIFT) |
-		(UET_PDS_ACK_FLAGS_NONE << UET_PDS_FLAGS_SHIFT));
-	ack->common.pds.psn = pkt->common.pds.psn;
-	pkt_overlay = (struct uet_pds_hdr_overlay *) &pkt->common.pds.spdcid;
-	ack_overlay = (struct uet_pds_hdr_overlay *) &ack->common.pds.spdcid;
+	ack_pds->prlg.type_next_flags =
+		htons((UET_PDS_TYPE_ACK << UET_PDS_TYPE_SHIFT) |
+		      (next_hdr << UET_PDS_NEXT_HDR_SHIFT) |
+		      (UET_PDS_ACK_FLAGS_NONE << UET_PDS_FLAGS_SHIFT));
+	ack_pds->cack_psn = pkt_pds->psn;
+	pkt_overlay = (struct uet_pds_hdr_overlay *)&pkt_pds->spdcid;
+	ack_overlay = (struct uet_pds_hdr_overlay *)&ack_pds->spdcid;
 	ack_overlay->pid_on_fep = pkt_overlay->pid_on_fep;
 	ack_overlay->index = pkt_overlay->index;
 
@@ -386,7 +423,7 @@ static void uet_pds_build_ack_pkt(struct uet_instance *uet, union uet_pkt *pkt,
  *      0 on success,
  *      negative value corresponding to errno on error
  */
-static int uet_pds_tx_ack_pkt(struct uet_ep *uet_ep, union uet_pkt *pkt,
+static int uet_pds_tx_ack_pkt(struct uet_ep *uet_ep, void *pkt,
 			      uet_pds_next_hdr_t next_hdr, size_t ses_hdr_len,
 			      void *ses_hdr)
 {
@@ -397,18 +434,31 @@ static int uet_pds_tx_ack_pkt(struct uet_ep *uet_ep, union uet_pkt *pkt,
 	struct uet_pds_ack_state *ack_state;
 	struct uet_pds_sng_state *pds_state =
 		(struct uet_pds_sng_state *)uet_ep->pds;
-	union uet_pkt *ack;
+	uint8_t *ack;
 	uint32_t crc;
 	uint8_t *crc_start;
+	bool is_ipv6;
+	size_t ip_hdr_size;
 
 	uet = uet_ep->uet_domain->uet;
+	is_ipv6 = uet->nic.is_ipv6;
+	ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr) :
+				  sizeof(struct iphdr);
 
 	if (next_hdr == UET_HDR_RSP)
-		ack_pkt_len = sizeof(struct uet_std_rsp_pkt);
+		ack_pkt_len = (sizeof(struct ethhdr) +
+			       ip_hdr_size +
+			       sizeof(struct uet_entropy) +
+			       sizeof(struct uet_pds_ack) +
+			       sizeof(struct uet_ses_rsp));
 	else {
-		ack_data_len = ses_hdr_len - sizeof(struct uet_ses_rsp_d);
-		ack_pkt_len = sizeof(struct uet_std_rsp_d_ack_pkt) +
-			      ack_data_len;
+		ack_data_len = (ses_hdr_len - sizeof(struct uet_ses_rsp_d));
+		ack_pkt_len = (sizeof(struct ethhdr) +
+			       ip_hdr_size +
+			       sizeof(struct uet_entropy) +
+			       sizeof(struct uet_pds_ack) +
+			       sizeof(struct uet_ses_rsp_d) +
+			       ack_data_len);
 	}
 
 	/* allocate buffer for ack packet */
@@ -417,27 +467,28 @@ static int uet_pds_tx_ack_pkt(struct uet_ep *uet_ep, union uet_pkt *pkt,
 		UET_API_PRINT_ERRNO("calloc");
 		return -ENOMEM;
 	}
-	ack = (union uet_pkt *) ack_state->ack;
+	ack = ack_state->ack;
 	ack_state->ack_len = ack_pkt_len;
 
 	/* build ack packet */
 	uet_pds_build_ack_pkt(uet, pkt, ack, ack_pkt_len, next_hdr,
 			      ses_hdr_len, ses_hdr);
 
-	/* calculate the CRC (include src/dst IP and UDP) */
-	/* TODO: IPv6 support */
-	crc_start = ((uint8_t *)&ack->common.ipv4 + 12);
-	crc = crc32c(crc_start,
-		     (ack_pkt_len -
-		      (crc_start - (uint8_t *)&ack->common.eth)));
+	/* calculate the CRC (include src/dst IP) */
+	if (is_ipv6)
+		crc_start = (ack + sizeof(struct ethhdr) + 8);
+	else
+		crc_start = (ack + sizeof(struct ethhdr) + 12);
+	crc = crc32c(crc_start, (ack_pkt_len - (crc_start - ack)));
 
 	/* append the CRC and adjust the transmit length */
-	memcpy(((uint8_t *)ack + ack_pkt_len), &crc, CRC_LEN);
+	memcpy((ack + ack_pkt_len), &crc, CRC_LEN);
 	ack_pkt_len += CRC_LEN;
 
 	/* send ack packet */
 	UET_PDS_PKT_HDR_TRACE(uet, NULL, ack, ack_pkt_len, "TX ACK PACKET");
-	rc = uet_nic_tx_pkt(UET_NIC(uet), ack, &ack->common.ipv4,
+	rc = uet_nic_tx_pkt(UET_NIC(uet), ack,
+			    (ack + sizeof(struct ethhdr)),
 			    (size_t) ack_pkt_len);
 	if (rc == 0) {
 		uet_gettime(&now);
@@ -465,52 +516,63 @@ static int uet_pds_tx_ack_pkt(struct uet_ep *uet_ep, union uet_pkt *pkt,
  *      negative value corresponding to errno on error
  */
 static int uet_pds_tx_err_ack_pkt(struct uet_instance *uet,
-				  union uet_pkt *pkt, uet_ses_rc_t ses_rc)
+				  void *pkt, struct uet_parsed_pkt *pp,
+				  uet_ses_rc_t ses_rc)
 {
 	int rc;
 	uint16_t ack_pkt_len;
-	struct uet_std_rsp_pkt *ack;
+	uint8_t *ack;
 	struct uet_ses_rsp ses;
+	struct uet_ses_req_std *pkt_ses;
 	uint32_t crc;
 	uint8_t *crc_start;
+	bool is_ipv6 = uet->nic.is_ipv6;
+	size_t ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr) :
+					 sizeof(struct iphdr);
 
-	ack_pkt_len = sizeof(struct uet_std_rsp_pkt);
+	ack_pkt_len = (sizeof(struct ethhdr) +
+		       ip_hdr_size +
+		       sizeof(struct uet_entropy) +
+		       sizeof(struct uet_pds_ack) +
+		       sizeof(struct uet_ses_rsp));
 
 	/* allocate buffer for ack packet */
-	ack = calloc(1, sizeof(struct uet_std_rsp_pkt));
+	ack = calloc(1, ack_pkt_len + CRC_LEN);
 	if (ack == NULL) {
 		UET_API_PRINT_ERRNO("calloc");
 		return -ENOMEM;
 	}
 
 	/* build ses header */
+	pkt_ses = (struct uet_ses_req_std *)pp->ses;
 	ses.cmn.list_opcode = ((UET_EXPECTED << UET_SES_RSP_LIST_SHIFT) |
 			       (UET_RESPONSE << UET_SES_OPCODE_SHIFT));
 	ses.cmn.ver_ret_code = ((UET_SES_VER << UET_SES_VER_SHIFT) |
 				(ses_rc << UET_SES_RSP_RET_CODE_SHIFT));
-	ses.cmn.msg_id = pkt->std_req.ses.cmn.msg_id;
+	ses.cmn.msg_id = pkt_ses->cmn.msg_id;
 	ses.mod_len = 0;
-	ses.cmn.ri_gen_job_id = pkt->std_req.ses.cmn.ri_gen_job_id;
+	ses.cmn.ri_gen_job_id = pkt_ses->cmn.ri_gen_job_id;
 
 	/* build ack packet */
-	uet_pds_build_ack_pkt(uet, pkt, (union uet_pkt *) ack, ack_pkt_len,
+	uet_pds_build_ack_pkt(uet, pkt, ack, ack_pkt_len,
 			      UET_HDR_RSP, sizeof(struct uet_ses_rsp), &ses);
 
-	/* calculate the CRC (include src/dst IP and UDP) */
-	/* TODO: IPv6 support */
-	crc_start = ((uint8_t *)&ack->ipv4 + 12);
-	crc = crc32c(crc_start,
-		     (ack_pkt_len -
-		      (crc_start - (uint8_t *)&ack->eth)));
+	/* calculate the CRC (include src/dst IP) */
+	if (is_ipv6)
+		crc_start = (ack + sizeof(struct ethhdr) + 8);
+	else
+		crc_start = (ack + sizeof(struct ethhdr) + 12);
+	crc = crc32c(crc_start, (ack_pkt_len - (crc_start - ack)));
 
 	/* append the CRC and adjust the transmit length */
-	memcpy(((uint8_t *)ack + ack_pkt_len), &crc, CRC_LEN);
+	memcpy((ack + ack_pkt_len), &crc, CRC_LEN);
 	ack_pkt_len += CRC_LEN;
 
 	/* send ack packet */
-	UET_PDS_PKT_HDR_TRACE(uet, NULL, (union uet_pkt *) ack, ack_pkt_len,
-			      "TX ACK PACKET");
-	rc = uet_nic_tx_pkt(UET_NIC(uet), ack, &ack->ipv4, (size_t)ack_pkt_len);
+	UET_PDS_PKT_HDR_TRACE(uet, NULL, ack, ack_pkt_len, "TX ACK PACKET");
+	rc = uet_nic_tx_pkt(UET_NIC(uet), ack,
+			    (ack + sizeof(struct ethhdr)),
+			    (size_t)ack_pkt_len);
 	free(ack);
 	return rc;
 }
@@ -574,7 +636,7 @@ void uet_pds_sng_ep_finalize(struct uet_ep *uet_ep)
 }
 
 /* pds packet transmission */
-int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt, 
+int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt,
 		       struct uet_ep *uet_ep,
 		       uet_addr_handle_t dst_addr_handle, uet_pds_mode_t mode,
 		       uet_pds_tx_flags_t flags, struct uet_pds_info *pds_info,
@@ -583,12 +645,11 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt,
 {
 	int rc;
 	uint8_t tos;
-	uint16_t tot_len;
 	size_t uet_hdr_len, uet_pkt_len;
 	void *ses_hdr, *payload;
 	uet_pds_pkt_type_t pds_pkt_type;
 	struct uet_instance *uet;
-	union uet_pkt *uet_pkt;
+	uint8_t *uet_pkt;
 	struct uet_av_entry *av_entry;
 	struct uet_addr *dst_addr;
 	struct uet_pds_req *pds;
@@ -598,11 +659,17 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt,
 		(struct uet_pds_sng_state *)uet_ep->pds;
 	uint32_t crc;
 	uint8_t *crc_start;
+	void *ip_hdr;
+	bool is_ipv6;
+	size_t ip_hdr_size;
 
 	uet = uet_ep->uet_domain->uet;
 	av_entry = (struct uet_av_entry *) dst_addr_handle;
 	dst_addr = av_entry->addr;
 	state = &pds_state->tx;
+	is_ipv6 = uet->nic.is_ipv6;
+	ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr) :
+				  sizeof(struct iphdr);
 
 	/* done for now if transmit in progress and not retry */
 	if (uet_pds_ep_tx_active(uet_ep) &&
@@ -617,8 +684,8 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt,
 		return -ENOMEM;
 	}
 
-	uet_build_eth_hdr(&uet_pkt->common.eth, av_entry->nh_mac_addr,
-			  uet->nic.mac_addr);
+	uet_build_eth_hdr((struct ethhdr *)uet_pkt, av_entry->nh_mac_addr,
+			  uet->nic.mac_addr, is_ipv6);
 
 	switch (next_hdr) {
 	case UET_HDR_REQ_STD:
@@ -636,26 +703,22 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt,
 			return -EINVAL;
 		}
 
-		/* TODO: IPv6 support and UDP support */
 		uet_hdr_len = (sizeof(struct ethhdr) +
-			       sizeof(struct iphdr) +
+			       ip_hdr_size +
 			       sizeof(struct uet_entropy) +
 			       sizeof(struct uet_pds_req) +
 			       ses_len);
 
-		if (next_hdr == UET_HDR_REQ_STD) {
-			pds = &uet_pkt->std_req.pds;
-			ses_hdr = &uet_pkt->std_req.ses;
-			payload = uet_pkt->std_req.payload;
-		} else {
-			pds = &uet_pkt->std_rsp_d.pds;
-			ses_hdr = &uet_pkt->std_rsp_d.ses;
-			payload = uet_pkt->std_rsp_d.payload;
-		}
-		pds->prlg.type_next_flags = htons(
-			(pds_pkt_type << UET_PDS_TYPE_SHIFT)          |
-			(UET_PDS_REQ_FLAGS_AR << UET_PDS_FLAGS_SHIFT) |
-			(next_hdr << UET_PDS_NEXT_HDR_SHIFT));
+		pds = (struct uet_pds_req *)(uet_pkt +
+					     sizeof(struct ethhdr) +
+					     ip_hdr_size +
+					     sizeof(struct uet_entropy));
+		ses_hdr = (void *)(pds + 1);
+		payload = ((uint8_t *)ses_hdr + ses_len);
+		pds->prlg.type_next_flags =
+			htons((pds_pkt_type << UET_PDS_TYPE_SHIFT) |
+			      (UET_PDS_REQ_FLAGS_AR << UET_PDS_FLAGS_SHIFT) |
+			      (next_hdr << UET_PDS_NEXT_HDR_SHIFT));
 		if (flags & UET_PDS_FLAG_RETRANSMIT)
 			pds->prlg.type_next_flags |= htons(
 				(UET_PDS_REQ_FLAGS_RETX << UET_PDS_FLAGS_SHIFT));
@@ -664,8 +727,6 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt,
 		pds_overlay->pid_on_fep = htons(uet_ep->uet_addr.pid_on_fep);
 		pds_overlay->index = htons(uet_ep->uet_addr.start_index);
 
-		tot_len = (uint16_t) (pkt_len +
-				      (uet_hdr_len - uet->nic.l2_hdr_size));
 		tos = uet_ep->msg_ip_tos;
 
 		uet_pkt_len = pkt_len + uet_hdr_len;
@@ -675,8 +736,25 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt,
 		return -EINVAL;
 	};
 
-	uet_build_ipv4_hdr(uet, &uet_pkt->common.ipv4, htonl(dst_addr->fa.v4),
-			   htonl(uet_ep->ipv4_addr), tot_len, tos, true);
+	ip_hdr = (void *)(uet_pkt + sizeof(struct ethhdr));
+	if (is_ipv6) {
+		uint16_t payload_len = (uint16_t)(pkt_len +
+						  (uet_hdr_len -
+						   uet->nic.l2_hdr_size -
+						   ip_hdr_size));
+		uet_build_ipv6_hdr(uet, (struct ipv6hdr *)ip_hdr,
+				   dst_addr->fa.v6,
+				   uet_ep->ip_addr.v6,
+				   payload_len, tos, true);
+	} else {
+		uint16_t tot_len = (uint16_t)(pkt_len +
+					      (uet_hdr_len -
+					       uet->nic.l2_hdr_size));
+		uet_build_ipv4_hdr(uet, (struct iphdr *)ip_hdr,
+				   htonl(dst_addr->fa.v4),
+				   htonl(uet_ep->ip_addr.v4),
+				   tot_len, tos, true);
+	}
 
 	if (!(flags & UET_PDS_FLAG_RETRANSMIT)) {
 		memcpy(state->pkt_parms.ses_hdr, ses, ses_len);
@@ -708,19 +786,20 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt,
 	state->pkt_parms.pkt_len = pkt_len;
 	state->pkt_parms.dma_rdy = dma_rdy;
 
-	/* calculate the CRC (include src/dst IP and UDP) */
-	/* TODO: IPv6 support */
-	crc_start = ((uint8_t *)&uet_pkt->common.ipv4 + 12);
-	crc = crc32c(crc_start,
-		     (uet_pkt_len -
-		      (crc_start - (uint8_t *)&uet_pkt->common.eth)));
+	/* calculate the CRC (include src/dst IP) */
+	if (is_ipv6)
+		crc_start = (uet_pkt + sizeof(struct ethhdr) + 8);
+	else
+		crc_start = (uet_pkt + sizeof(struct ethhdr) + 12);
+	crc = crc32c(crc_start, (uet_pkt_len - (crc_start - uet_pkt)));
 
 	/* append the CRC and adjust the transmit length */
 	memcpy(((uint8_t *)uet_pkt + uet_pkt_len), &crc, CRC_LEN);
 	uet_pkt_len += CRC_LEN;
 
 	UET_PDS_PKT_HDR_TRACE(uet, NULL, uet_pkt, uet_pkt_len, "TX PACKET");
-	rc = uet_nic_tx_pkt(UET_NIC(uet), uet_pkt, &uet_pkt->common.ipv4,
+	rc = uet_nic_tx_pkt(UET_NIC(uet), uet_pkt,
+			    (uet_pkt + sizeof(struct ethhdr)),
 			    uet_pkt_len);
 	if (rc == 0)
 		pds_state->tx.tx_active = true;
@@ -828,7 +907,7 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 	uet_ses_rc_t ses_rc;
 	size_t rx_pkt_size;
 	bool pkt_is_ack, pkt_is_rd_rsp, pkt_is_ctrl, ses_nack, gtd_del;
-	union uet_pkt *pkt;
+	uint8_t *pkt;
 	struct uet_parsed_pkt pp;
 	struct uet_ep *dst_uet_ep;
 	struct uet_msg_match_info match_info;
@@ -849,7 +928,7 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 	/* allocate temporary packet buffer                                */
 	/*  - need temp buffer to parse packet and determine what endpoint */
 	/*    the packet is destined for                                   */
-	pkt = (union uet_pkt *) malloc(uet->nic.max_pkt_size);
+	pkt = malloc(uet->nic.max_pkt_size);
 	if (pkt == NULL) {
 		UET_API_PRINT_ERRNO("malloc");
 		return -ENOMEM;
@@ -870,6 +949,11 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 	if (rc != 1)
 		goto exit;
 
+	/* validate the packet */
+	if (!uet_pds_rx_pkt_chk(uet, (uint8_t *)pkt, rx_pkt_size,
+				&pkt_is_ack, &pkt_is_rd_rsp, &pkt_is_ctrl))
+		goto exit;
+
 	/* parse the packet */
 	rc = uet_parse_pkt(uet, pkt, rx_pkt_size, &pp);
 	if (rc != 0) {
@@ -878,18 +962,13 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 		goto exit;
 	}
 
-	/* validate the packet */
-	if (!uet_pds_rx_pkt_chk(uet, (uint8_t *)pkt, rx_pkt_size,
-				&pkt_is_ack, &pkt_is_rd_rsp, &pkt_is_ctrl))
-		goto exit;
-
 	UET_PDS_PKT_HDR_TRACE(uet, &pp, pp.eth, pp.pkt_len, "RX PACKET");
 
 	/* find the endpoint the packet is for */
 	if (pp.ses_opcode == UET_DEFER_RTR) {
 		dst_uet_ep = uet_pds_rtr_lookup(uet, &pp);
 		if (dst_uet_ep == NULL) {
-			rc = uet_pds_tx_err_ack_pkt(uet, pkt,
+			rc = uet_pds_tx_err_ack_pkt(uet, pkt, &pp,
 						    UET_RC_UNDELIVERABLE);
 			goto exit;
 		}
@@ -910,7 +989,8 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 				ses_rc = UET_RC_BAD_INDEX;
 			else
 				ses_rc = UET_RC_UNDELIVERABLE;
-			rc = uet_pds_tx_err_ack_pkt(uet, pkt, ses_rc);
+			rc = uet_pds_tx_err_ack_pkt(uet, pkt, &pp,
+						    ses_rc);
 			goto exit;
 		}
 	}
@@ -930,7 +1010,8 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 		if (!uet_pds_ep_tx_active(dst_uet_ep))
 			goto exit;
 
-		if (pkt->common.pds.psn != htonl(pds_tx->psn))
+		if (((struct uet_pds_ack *)pp.pds)->cack_psn !=
+		    htonl(pds_tx->psn))
 			goto exit;
 
 		/* upcall for ses processing */
@@ -946,14 +1027,14 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 		/* (i.e., if ack was dropped)                        */
 		if (uet_pds_is_dup_req(dst_uet_ep, pkt, &ack_state)) {
 			/* retransmit ack */
-			UET_PDS_PKT_HDR_TRACE(
-				uet, NULL, (union uet_pkt *) &ack_state->ack,
-				ack_state->ack_len, "RETRANSMIT ACK PACKET");
-			rc = uet_nic_tx_pkt(
-				UET_NIC(uet),
-				ack_state->ack,
-				&((union uet_pkt *)ack_state->ack)->common.ipv4,
-				(ack_state->ack_len + CRC_LEN));
+			UET_PDS_PKT_HDR_TRACE(uet, NULL, ack_state->ack,
+					      ack_state->ack_len,
+					      "RETRANSMIT ACK PACKET");
+			rc = uet_nic_tx_pkt(UET_NIC(uet),
+					    ack_state->ack,
+					    (ack_state->ack +
+					     sizeof(struct ethhdr)),
+					    (ack_state->ack_len + CRC_LEN));
 			goto exit;
 		}
 
@@ -963,8 +1044,8 @@ int uet_pds_sng_progress_rx(struct uet_instance *uet)
 
 		/* upcall for ses processing */
 		memset(&pds_info, 0, sizeof(struct uet_pds_info));
-		pds_info.opsn = pkt->common.pds.psn;
-		rc = ses_upcall->rx_req((uet_pkt_handle_t) pkt,
+		pds_info.opsn = ((struct uet_pds_req *)pp.pds)->psn;
+		rc = ses_upcall->rx_req((uet_pkt_handle_t)pkt,
 					uet, &pp, &pds_info,
 					&rsp_next_hdr, rsp_ses_hdr,
 					&rsp_ses_hdr_len, &ses_nack, &gtd_del);

--- a/uet_pkt_hdr.h
+++ b/uet_pkt_hdr.h
@@ -11,6 +11,7 @@
 #include <netinet/if_ether.h>
 #include <linux/if_ether.h>
 #include <linux/ip.h>
+#include <linux/ipv6.h>
 #include <arpa/inet.h>
 
 #define UET_MAX_VLAN_TAGS	2
@@ -19,27 +20,27 @@
 #define UET_IP_VER_SHIFT	4
 #define UET_IPV4_VER		4
 #define UET_IPV6_VER		6
-#define UET_IPV4_IHL_NO_OPTIONS 5
-#define UET_IPV4_FRAG_OFF_DF    0x4000 /* don't fragment */
-#define UET_DSCP_CS0            0
-#define UET_DSCP_EF             46
-#define UET_IP_DEFAULT_MSG_DSCP UET_DSCP_CS0
-#define UET_IP_DEFAULT_ACK_DSCP UET_DSCP_EF
-#define UET_IPPROTO             253    /* for UET over IP encap */
+#define UET_IPV4_IHL_NO_OPTIONS	5
+#define UET_IPV4_FRAG_OFF_DF	0x4000 /* don't fragment */
+#define UET_DSCP_CS0		0
+#define UET_DSCP_EF		46
+#define UET_IP_DEFAULT_MSG_DSCP	UET_DSCP_CS0
+#define UET_IP_DEFAULT_ACK_DSCP	UET_DSCP_EF
+#define UET_IPPROTO		253    /* for UET over IP encap */
 
 #define UET_IPPROTO_EXT_HDR_HOP_BY_HOP	0
-#define UET_IPPROTO_EXT_HDR_ROUTING     43
+#define UET_IPPROTO_EXT_HDR_ROUTING	43
 #define UET_IPPROTO_EXT_HDR_FRAG	44
 #define UET_IPPROTO_EXT_HDR_ESP		50
 #define UET_IPPROTO_EXT_HDR_AUTH	51
 #define UET_IPPROTO_EXT_HDR_NONE	55
-#define UET_IPPROTO_EXT_HDR_DEST_OPTS   60
+#define UET_IPPROTO_EXT_HDR_DEST_OPTS	60
 #define UET_IPPROTO_EXT_HDR_MOBILITY	135
 
-#define UET_UDP_PORT	49150	/* for UET over UDP encap */
+#define UET_UDP_PORT	49150 /* for UET over UDP encap */
 
 #define UET_DEFAULT_MAX_PAYLOAD_LEN	1024
-#define UET_MAX_PAYLOAD_LEN		8192	/* upper bound */
+#define UET_MAX_PAYLOAD_LEN		8192 /* upper bound */
 
 #define UET_PACKED __attribute__((__packed__))
 
@@ -689,10 +690,13 @@ struct UET_PACKED uet_ses_rsp_ds {
 	uint32_t orig_req_psn;
 };
 
-/* TODO: IPv6 support */
-#define UET_MIN_PKT_SIZE (sizeof(struct ethhdr) + \
-			  sizeof(struct iphdr) + \
-			  sizeof(struct uet_pds_ctrl))
+#define UET_MIN_PKT_SIZE_V4 (sizeof(struct ethhdr) + \
+			     sizeof(struct iphdr) + \
+			     sizeof(struct uet_pds_ctrl))
+#define UET_MIN_PKT_SIZE_V6 (sizeof(struct ethhdr) + \
+			     sizeof(struct ipv6hdr) + \
+			     sizeof(struct uet_pds_ctrl))
+#define UET_MIN_PKT_SIZE UET_MIN_PKT_SIZE_V4
 
 /* get job id from standard request packet */
 static inline uint32_t uet_get_std_req_job_id(struct uet_ses_req_std *ses)

--- a/uet_sec.c
+++ b/uet_sec.c
@@ -56,8 +56,9 @@ static struct uet_sec_sd sdkdb[UET_SEC_MAX_SD];
 static char *uet_sec_label1 = "U1";
 static char *uet_sec_label2 = "U2";
 
-/**************************************************************************/
-/* FIXME: Default fields used for the fixed SD... not yet configurable!   */
+/************************************************************************/
+/* FIXME: Default fields used for the fixed SD... not yet configurable! */
+/************************************************************************/
 
 /* key generation: `dd if=/dev/urandom ibs=32 count=1 | xxd -i -c 8` */
 
@@ -80,11 +81,12 @@ static uint8_t def_key[2][UET_SEC_KDF_GEN_SIZE] = {
 	},
 };
 
-/* FIXME: support IPv6 for AOFF */
 #define DEF_SDI         1
 #define DEF_REKEY_MASK  0x0000FFFF00000000UL
 #define DEF_REKEY_SHIFT 32
-#define DEF_AOFF        -12 /* AAD includes source IPv4 address */
+#define DEF_AOFF_V4     -12 /* AAD src/dest IPv4 (8) + entropy (4) */
+#define DEF_AOFF_V6     -36 /* AAD src/dest IPv6 (32) + entropy (4) */
+#define DEF_AOFF        DEF_AOFF_V4
 #define DEF_COFF        12 /* sizeof security header, +4 if using SSI */
 
 static uint8_t fep_key[2][UET_SEC_KEY_SIZE] = {
@@ -111,7 +113,8 @@ int uet_sec_build_hdr(uint32_t sdi,
 		      uint8_t *pkt,
 		      int pkt_len,
 		      uint8_t **new_pkt,
-		      int *new_pkt_len)
+		      int *new_pkt_len,
+		      bool is_ipv6)
 {
 	struct uet_sec_sd *sd;
 	struct uet_sec *sec;
@@ -138,9 +141,9 @@ int uet_sec_build_hdr(uint32_t sdi,
 		return -EINVAL;
 	}
 
-	/* TODO: IPv6 support and UDP support */
 	copy_len = (sizeof(struct ethhdr) +
-		    sizeof(struct iphdr) +
+		    (is_ipv6 ? sizeof(struct ipv6hdr) :
+			       sizeof(struct iphdr)) +
 		    sizeof(struct uet_entropy));
 
 	/* move the Ethernet and IP headers down */
@@ -180,15 +183,10 @@ int uet_sec_build_hdr(uint32_t sdi,
 	uet_gettime((time_t *)&tsc);
 
 	if (sd->use_ssi) {
-		if (sd->mode == UET_SEC_MODE_SERVER) {
-			/* for server mode the client SSI is always used */
-			if (getenv(UET_SEC_SERVER)) {
-				client_ssi = getenv(UET_SEC_CLIENT_SSI);
-				sec_ssi->ssi = htonl(strtoul(client_ssi,
-							     NULL, 10));
-			} else {
-				sec_ssi->ssi = htonl(ssi);
-			}
+		if ((sd->mode == UET_SEC_MODE_SERVER) &&
+		    getenv(UET_SEC_SERVER)) {
+			client_ssi = getenv(UET_SEC_CLIENT_SSI);
+			sec_ssi->ssi = htonl(strtoul(client_ssi, NULL, 10));
 		} else {
 			sec_ssi->ssi = htonl(ssi);
 		}
@@ -209,7 +207,7 @@ int uet_sec_build_hdr(uint32_t sdi,
 	return 0;
 }
 
-int uet_sec_update_hdr_tsc(uint8_t *pkt)
+int uet_sec_update_hdr_tsc(uint8_t *pkt, bool is_ipv6)
 {
 	struct uet_sec *sec;
 	struct uet_sec_ssi *sec_ssi;
@@ -218,10 +216,10 @@ int uet_sec_update_hdr_tsc(uint8_t *pkt)
 	uint64_t tsc;
 	uint32_t tfs;
 
-	/* TODO: IPv6 support and UDP support */
 	sec = (struct uet_sec *)(pkt +
 				 sizeof(struct ethhdr) +
-				 sizeof(struct iphdr) +
+				 (is_ipv6 ? sizeof(struct ipv6hdr) :
+					    sizeof(struct iphdr)) +
 				 sizeof(struct uet_entropy));
 	sec_ssi = (struct uet_sec_ssi *)sec;
 
@@ -276,12 +274,13 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 {
 	uint8_t derived_key[UET_SEC_KDF_GEN_SIZE];
 	uint8_t small_context[UET_SEC_SMALL_CTX_SIZE];
-	//uint8_t large_context[UET_SEC_LARGE_CTX_SIZE];
+	uint8_t large_context[UET_SEC_LARGE_CTX_SIZE];
 	uint8_t iv[UET_SEC_IV_SIZE];
 	uint8_t tag[UET_SEC_TAG_LEN];
 	struct gcm_context gcm;
 	struct uet_sec_sd *sd;
-	struct iphdr *ipv4;
+	struct iphdr *ipv4 = NULL;
+	struct ipv6hdr *ipv6 = NULL;
 	uint8_t *sec_hdr, *aad;
 	struct uet_sec *sec;
 	struct uet_sec_ssi *sec_ssi;
@@ -296,12 +295,17 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 	uint32_t tmp_val;
 	uint64_t tmp_lval;
 	int i, rc, clrtxt_len;
+	bool is_ipv6 = uet->nic.is_ipv6;
 
-	/* TODO: IPv6 support (requires SSI) and UDP support */
-	ipv4 = (struct iphdr *)(pkt + sizeof(struct ethhdr));
+	if (is_ipv6)
+		ipv6 = (struct ipv6hdr *)(pkt + sizeof(struct ethhdr));
+	else
+		ipv4 = (struct iphdr *)(pkt + sizeof(struct ethhdr));
+
 	sec_hdr = (pkt +
 		   sizeof(struct ethhdr) +
-		   sizeof(struct iphdr) +
+		   (is_ipv6 ? sizeof(struct ipv6hdr) :
+			      sizeof(struct iphdr)) +
 		   sizeof(struct uet_entropy));
 	sec = (struct uet_sec *)sec_hdr;
 	sec_ssi = (struct uet_sec_ssi *)sec_hdr;
@@ -366,45 +370,79 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 		break;
 
 	case UET_SEC_MODE_CLUSTER:
-		/* TODO: support IPv6 w/ large_context (requires SSI) */
-		memset(small_context, 0, sizeof(small_context));
-		memcpy(small_context, (uint8_t *)&epoch, 2);
-		memcpy((small_context + 2), (uint8_t *)&rekey, 4);
-		tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
-		memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
+		if (is_ipv6) {
+			memset(large_context, 0, sizeof(large_context));
+			memcpy((large_context + 4), (uint8_t *)&epoch, 2);
+			memcpy((large_context + 6), (uint8_t *)&rekey, 4);
+			memcpy((large_context + 10), &ipv6->saddr, 16);
 
-		kdf_ctr_cmac_aes(sd->key[an],
-				 (UET_SEC_KEY_SIZE * 8),
-				 UET_SEC_CTR_SIZE,
-				 (uint8_t *)uet_sec_label1,
-				 strlen(uet_sec_label1), /* ignore delimiter */
-				 small_context,
-				 UET_SEC_SMALL_CTX_SIZE,
-				 derived_key,
-				 (UET_SEC_KDF_GEN_SIZE * 8));
+			kdf_ctr_cmac_aes(sd->key[an],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label1,
+					 strlen(uet_sec_label1),
+					 large_context,
+					 UET_SEC_LARGE_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+		} else {
+			memset(small_context, 0, sizeof(small_context));
+			memcpy(small_context, (uint8_t *)&epoch, 2);
+			memcpy((small_context + 2), (uint8_t *)&rekey, 4);
+			tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
+			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
+
+			kdf_ctr_cmac_aes(sd->key[an],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label1,
+					 strlen(uet_sec_label1),
+					 small_context,
+					 UET_SEC_SMALL_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+		}
+
 		break;
 
 	case UET_SEC_MODE_SERVER:
+		/* in client/server mode the client operates in direct mode */
 		if (!getenv(UET_SEC_SERVER)) {
 			memcpy(derived_key, sd->key[an], UET_SEC_KDF_GEN_SIZE);
 			break;
 		}
 
-		/* TODO: support IPv6 w/ large_context (requires SSI) */
-		memset(small_context, 0, sizeof(small_context));
-		memcpy(small_context, (uint8_t *)&epoch, 2);
-		tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
-		memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
+		if (is_ipv6) {
+			memset(large_context, 0, sizeof(large_context));
+			memcpy((large_context + 4), (uint8_t *)&epoch, 2);
+			memcpy((large_context + 10), &ipv6->daddr, 16);
 
-		kdf_ctr_cmac_aes(sd->key[sd->an],
-				 (UET_SEC_KEY_SIZE * 8),
-				 UET_SEC_CTR_SIZE,
-				 (uint8_t *)uet_sec_label2,
-				 strlen(uet_sec_label2), /* ignore delimiter */
-				 small_context,
-				 UET_SEC_SMALL_CTX_SIZE,
-				 derived_key,
-				 (UET_SEC_KDF_GEN_SIZE * 8));
+			kdf_ctr_cmac_aes(sd->key[an],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label2,
+					 strlen(uet_sec_label2),
+					 large_context,
+					 UET_SEC_LARGE_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+		} else {
+			memset(small_context, 0, sizeof(small_context));
+			memcpy(small_context, (uint8_t *)&epoch, 2);
+			tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->daddr;
+			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
+
+			kdf_ctr_cmac_aes(sd->key[sd->an],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label2,
+					 strlen(uet_sec_label2),
+					 small_context,
+					 UET_SEC_SMALL_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+		}
+
 		break;
 
 	default:
@@ -415,11 +453,10 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 
 	/* encrypt the packet */
 
-	/* TODO: account for the entropy or UDP header */
 	aad = (sec_hdr + sd->aoff); /* likely negative and moves backwards */
 
-	/* TODO: support IPv6 (requires SSI) */
-	tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
+	tmp_val = (sd->use_ssi) ? sec_ssi->ssi :
+				  (is_ipv6) ? htonl(sdi) : ipv4->saddr;
 	memcpy(iv, (uint8_t *)&tmp_val, 4);
 	tmp_lval = htonll(tsc);
 	memcpy((iv + 4), (uint8_t *)&tmp_lval, 8);
@@ -466,14 +503,15 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 {
 	uint8_t derived_key[UET_SEC_KDF_GEN_SIZE];
 	uint8_t small_context[UET_SEC_SMALL_CTX_SIZE];
-	//uint8_t large_context[UET_SEC_LARGE_CTX_SIZE];
+	uint8_t large_context[UET_SEC_LARGE_CTX_SIZE];
 	uint8_t iv[UET_SEC_IV_SIZE];
 	struct gcm_context gcm;
 	struct uet_sec_sd *sd;
 	struct uet_sec *sec;
 	struct uet_sec_ssi *sec_ssi;
 	struct ethhdr *eth;
-	struct iphdr *ipv4;
+	struct iphdr *ipv4 = NULL;
+	struct ipv6hdr *ipv6 = NULL;
 	uint8_t *sec_hdr, *aad;
 	uint32_t rekey;
 	uint32_t tmp_val;
@@ -484,23 +522,33 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	uint32_t sdi;
 	uint32_t tfs;
 	int i, rc, clrtxt_len;
+	bool is_ipv6 = uet->nic.is_ipv6;
 
-	/* TODO: IPv6 support (requires SSI) and UDP support */
 	eth = (struct ethhdr *)pkt;
-	ipv4 = (struct iphdr *)(pkt + sizeof(struct ethhdr));
 
 	/* do some preliminary sanity checks */
-	if ((eth->h_proto != htons(ETH_P_IP)) ||
-	    (ipv4->version != IPVERSION) ||
-	    (ipv4->ihl != UET_IPV4_IHL_NO_OPTIONS) ||
-	    (ipv4->protocol != uet->uet_ipproto)) {
-		*tag_len = 0;
-		return 0;
+	if (is_ipv6) {
+		ipv6 = (struct ipv6hdr *)(pkt + sizeof(struct ethhdr));
+		if ((eth->h_proto != htons(ETH_P_IPV6)) ||
+		    (ipv6->nexthdr != uet->uet_ipproto)) {
+			*tag_len = 0;
+			return 0;
+		}
+	} else {
+		ipv4 = (struct iphdr *)(pkt + sizeof(struct ethhdr));
+		if ((eth->h_proto != htons(ETH_P_IP)) ||
+		    (ipv4->version != IPVERSION) ||
+		    (ipv4->ihl != UET_IPV4_IHL_NO_OPTIONS) ||
+		    (ipv4->protocol != uet->uet_ipproto)) {
+			*tag_len = 0;
+			return 0;
+		}
 	}
 
 	sec_hdr = (pkt +
 		   sizeof(struct ethhdr) +
-		   sizeof(struct iphdr) +
+		   (is_ipv6 ? sizeof(struct ipv6hdr) :
+			      sizeof(struct iphdr)) +
 		   sizeof(struct uet_entropy));
 	sec = (struct uet_sec *)sec_hdr;
 	sec_ssi = (struct uet_sec_ssi *)sec_hdr;
@@ -539,7 +587,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	epoch = (uint16_t)((tsc & UET_SEC_EPOCH_MASK) >> UET_SEC_EPOCH_SHIFT);
 	tsc = ((tsc & UET_SEC_TSC_MASK) >> UET_SEC_TSC_SHIFT);
 
-	/* generate the key needed for encrypting the packet */
+	/* generate the key needed for decrypting the packet */
 
 	memset(derived_key, 0, sizeof(derived_key));
 
@@ -555,45 +603,79 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 		break;
 
 	case UET_SEC_MODE_CLUSTER:
-		/* TODO: support IPv6 w/ large_context (requires SSI) */
-		memset(small_context, 0, sizeof(small_context));
-		memcpy(small_context, (uint8_t *)&epoch, 2);
-		memcpy((small_context + 2), (uint8_t *)&rekey, 4);
-		tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
-		memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
+		if (is_ipv6) {
+			memset(large_context, 0, sizeof(large_context));
+			memcpy((large_context + 4), (uint8_t *)&epoch, 2);
+			memcpy((large_context + 6), (uint8_t *)&rekey, 4);
+			memcpy((large_context + 10), &ipv6->saddr, 16);
 
-		kdf_ctr_cmac_aes(sd->key[an],
-				 (UET_SEC_KEY_SIZE * 8),
-				 UET_SEC_CTR_SIZE,
-				 (uint8_t *)uet_sec_label1,
-				 strlen(uet_sec_label1), /* ignore delimiter */
-				 small_context,
-				 UET_SEC_SMALL_CTX_SIZE,
-				 derived_key,
-				 (UET_SEC_KDF_GEN_SIZE * 8));
+			kdf_ctr_cmac_aes(sd->key[an],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label1,
+					 strlen(uet_sec_label1),
+					 large_context,
+					 UET_SEC_LARGE_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+		} else {
+			memset(small_context, 0, sizeof(small_context));
+			memcpy(small_context, (uint8_t *)&epoch, 2);
+			memcpy((small_context + 2), (uint8_t *)&rekey, 4);
+			tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
+			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
+
+			kdf_ctr_cmac_aes(sd->key[an],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label1,
+					 strlen(uet_sec_label1),
+					 small_context,
+					 UET_SEC_SMALL_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+		}
+
 		break;
 
 	case UET_SEC_MODE_SERVER:
+		/* in client/server mode the client operates in direct mode */
 		if (!getenv(UET_SEC_SERVER)) {
 			memcpy(derived_key, sd->key[an], UET_SEC_KDF_GEN_SIZE);
 			break;
 		}
 
-		/* TODO: support IPv6 w/ large_context (requires SSI) */
-		memset(small_context, 0, sizeof(small_context));
-		memcpy(small_context, (uint8_t *)&epoch, 2);
-		tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
-		memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
+		if (is_ipv6) {
+			memset(large_context, 0, sizeof(large_context));
+			memcpy((large_context + 4), (uint8_t *)&epoch, 2);
+			memcpy((large_context + 10), &ipv6->saddr, 16);
 
-		kdf_ctr_cmac_aes(sd->key[sd->an],
-				 (UET_SEC_KEY_SIZE * 8),
-				 UET_SEC_CTR_SIZE,
-				 (uint8_t *)uet_sec_label2,
-				 strlen(uet_sec_label2), /* ignore delimiter */
-				 small_context,
-				 UET_SEC_SMALL_CTX_SIZE,
-				 derived_key,
-				 (UET_SEC_KDF_GEN_SIZE * 8));
+			kdf_ctr_cmac_aes(sd->key[an],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label2,
+					 strlen(uet_sec_label2),
+					 large_context,
+					 UET_SEC_LARGE_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+		} else {
+			memset(small_context, 0, sizeof(small_context));
+			memcpy(small_context, (uint8_t *)&epoch, 2);
+			tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
+			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
+
+			kdf_ctr_cmac_aes(sd->key[sd->an],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label2,
+					 strlen(uet_sec_label2),
+					 small_context,
+					 UET_SEC_SMALL_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+		}
+
 		break;
 
 	default:
@@ -604,11 +686,10 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 
 	/* decrypt the packet */
 
-	/* TODO: account for the entropy or UDP header */
 	aad = (sec_hdr + sd->aoff); /* likely negative and moves backwards */
 
-	/* TODO: support IPv6 (requires SSI) */
-	tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
+	tmp_val = (sd->use_ssi) ? sec_ssi->ssi :
+				  (is_ipv6) ? htonl(sdi) : ipv4->saddr;
 	memcpy(iv, (uint8_t *)&tmp_val, 4);
 	tmp_lval = htonll(tsc);
 	memcpy((iv + 4), (uint8_t *)&tmp_lval, 8);
@@ -646,11 +727,13 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 static int uet_sec_init_sd(uint32_t sdi,
 			   uet_sec_mode_t mode,
 			   bool use_ssi,
-			   bool rekey)
+			   bool rekey,
+			   struct uet_fa *local_ip,
+			   bool is_ipv6)
 {
 	uint8_t derived_key[UET_SEC_KDF_GEN_SIZE];
 	uint8_t small_context[UET_SEC_SMALL_CTX_SIZE];
-	//uint8_t large_context[UET_SEC_LARGE_CTX_SIZE];
+	uint8_t large_context[UET_SEC_LARGE_CTX_SIZE];
 	struct uet_sec_sd *sd;
 	char *client_ssi;
 	uint32_t tmp_val;
@@ -668,60 +751,100 @@ static int uet_sec_init_sd(uint32_t sdi,
 	sd->mode        = mode;
 	sd->use_ssi     = use_ssi;
 	sd->rekey       = rekey;
+
+	/* IPv6 with direct or client/server mode requires the SSI */
+	if (is_ipv6 && !use_ssi && ((mode == UET_SEC_MODE_DIRECT) ||
+				    (mode == UET_SEC_MODE_SERVER))) {
+		UET_TSS_ERR("IPv6 MODE_DIRECT requires SSI\n");
+		memset(sd, 0, sizeof(*sd));
+		return -EINVAL;
+	}
+
 	sd->rekey_mask  = DEF_REKEY_MASK;
 	sd->rekey_shift = DEF_REKEY_SHIFT;
-	sd->aoff        = DEF_AOFF;
+	sd->aoff        = is_ipv6 ? DEF_AOFF_V6 : DEF_AOFF_V4;
 	sd->coff        = (use_ssi) ? (DEF_COFF + 4) : DEF_COFF;
 	sd->alg         = UET_SEC_ALG_AES_GCM_256;
 	sd->epoch       = 1; /* FIXME: init/roll epoch */
 	sd->an          = 0;
 	memcpy(sd->key, def_key, sizeof(def_key));
 
-	/* for client side of server mode, do KDFs now */
+	/*
+	 * For the client side of server mode, do the KDFs now (no exchange).
+	 * Normally for client/server mode the server key is hidden on the
+	 * server and there is an exchange where the server gives each client
+	 * a key to use in direct mode which is a derivation from the server
+	 * key using the client's SSI.
+	 */
 	if ((mode == UET_SEC_MODE_SERVER) && !getenv(UET_SEC_SERVER)) {
-		/* TODO: support both SSI and source IPv4 for server mode */
-		if (!getenv(UET_SEC_SSI)) {
-			UET_TSS_ERR("server mode requires SSI\n");
-			memset(sd, 0, sizeof(*sd));
-			return -EINVAL;
+		if (is_ipv6) {
+			memset(large_context, 0, sizeof(large_context));
+			memcpy((large_context + 4), (uint8_t *)&sd->epoch, 2);
+			memcpy((large_context + 10), local_ip->v6, 16);
+
+			kdf_ctr_cmac_aes(sd->key[0],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label2,
+					 strlen(uet_sec_label2), /* ignore delimiter */
+					 large_context,
+					 UET_SEC_LARGE_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+
+			memcpy(sd->key[0], derived_key, UET_SEC_KDF_GEN_SIZE);
+
+			kdf_ctr_cmac_aes(sd->key[1],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label2,
+					 strlen(uet_sec_label2), /* ignore delimiter */
+					 large_context,
+					 UET_SEC_LARGE_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+
+			memcpy(sd->key[1], derived_key, UET_SEC_KDF_GEN_SIZE);
+		} else {
+			memset(small_context, 0, sizeof(small_context));
+			memcpy(small_context, (uint8_t *)&sd->epoch, 2);
+			/* use SSI if available, otherwise use IPv4 */
+			client_ssi = getenv(UET_SEC_SSI);
+			tmp_val = (client_ssi)
+				? htonl(strtoul(client_ssi, NULL, 10))
+				: htonl(local_ip->v4);
+			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
+
+			kdf_ctr_cmac_aes(sd->key[0],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label2,
+					 strlen(uet_sec_label2), /* ignore delimiter */
+					 small_context,
+					 UET_SEC_SMALL_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+
+			memcpy(sd->key[0], derived_key, UET_SEC_KDF_GEN_SIZE);
+
+			kdf_ctr_cmac_aes(sd->key[1],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label2,
+					 strlen(uet_sec_label2), /* ignore delimiter */
+					 small_context,
+					 UET_SEC_SMALL_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+
+			memcpy(sd->key[1], derived_key, UET_SEC_KDF_GEN_SIZE);
 		}
-
-		/* TODO: support IPv6 w/ large_context (requires SSI) */
-		memset(small_context, 0, sizeof(small_context));
-		memcpy(small_context, (uint8_t *)&sd->epoch, 2);
-		client_ssi = getenv(UET_SEC_SSI);
-		tmp_val = htonl(strtoul(client_ssi, NULL, 10));
-		memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
-
-		kdf_ctr_cmac_aes(sd->key[0],
-				 (UET_SEC_KEY_SIZE * 8),
-				 UET_SEC_CTR_SIZE,
-				 (uint8_t *)uet_sec_label2,
-				 strlen(uet_sec_label2), /* ignore delimiter */
-				 small_context,
-				 UET_SEC_SMALL_CTX_SIZE,
-				 derived_key,
-				 (UET_SEC_KDF_GEN_SIZE * 8));
-
-		memcpy(sd->key[0], derived_key, UET_SEC_KDF_GEN_SIZE);
-
-		kdf_ctr_cmac_aes(sd->key[1],
-				 (UET_SEC_KEY_SIZE * 8),
-				 UET_SEC_CTR_SIZE,
-				 (uint8_t *)uet_sec_label2,
-				 strlen(uet_sec_label2), /* ignore delimiter */
-				 small_context,
-				 UET_SEC_SMALL_CTX_SIZE,
-				 derived_key,
-				 (UET_SEC_KDF_GEN_SIZE * 8));
-
-		memcpy(sd->key[1], derived_key, UET_SEC_KDF_GEN_SIZE);
 	}
 
 	return 0;
 }
 
-int uet_sec_init(void)
+int uet_sec_init(struct uet_fa *local_ip, bool is_ipv6)
 {
 	char *sec, *sec_mode, *sec_ssi;
 	int i, rc;
@@ -741,15 +864,25 @@ int uet_sec_init(void)
 
 	if ((sec_mode == NULL) || (strcmp(sec_mode, "direct") == 0)) {
 
+		/* IPv6 with direct mode requires the SSI */
+		if (is_ipv6 && (sec_ssi == NULL)) {
+			UET_TSS_ERR("UET_SEC_SSI required for IPv6 direct mode");
+			return -EINVAL;
+		}
+
 		rc = uet_sec_init_sd(DEF_SDI, UET_SEC_MODE_DIRECT,
-				     (sec_ssi != NULL), false);
+				     (sec_ssi != NULL), false,
+				     local_ip, is_ipv6);
 
 	} else if (strcmp(sec_mode, "cluster") == 0) {
 
 		rc = uet_sec_init_sd(DEF_SDI, UET_SEC_MODE_CLUSTER,
-				     (sec_ssi != NULL), true);
+				     (sec_ssi != NULL), true,
+				     local_ip, is_ipv6);
 
 	} else if (strcmp(sec_mode, "server") == 0) {
+
+		/* this implemention requires the SSI for IPv4 and IPv6 */
 
 		if (sec_ssi == NULL) {
 			UET_TSS_ERR("UET_SEC_SSI required for server mode");
@@ -763,7 +896,8 @@ int uet_sec_init(void)
 		}
 
 		rc = uet_sec_init_sd(DEF_SDI, UET_SEC_MODE_SERVER,
-				     true, false);
+				     true, false,
+				     local_ip, is_ipv6);
 
 	} else {
 

--- a/uet_sec.h
+++ b/uet_sec.h
@@ -35,12 +35,13 @@ int uet_sec_build_hdr(uint32_t sdi,
 		      uint8_t *pkt,
 		      int pkt_len,
 		      uint8_t **new_pkt,
-		      int *new_pkt_len);
+		      int *new_pkt_len,
+		      bool is_ipv6);
 
 /*
  * Update the TSC field in the security header. Used for retransmits.
  */
-int uet_sec_update_hdr_tsc(uint8_t *pkt);
+int uet_sec_update_hdr_tsc(uint8_t *pkt, bool is_ipv6);
 
 /*
  * Encryption does not occur inplace.
@@ -75,5 +76,6 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 		    int pkt_len,
 		    int *tag_len);
 
-int uet_sec_init(void);
+int uet_sec_init(struct uet_fa *local_ip,
+		 bool is_ipv6);
 

--- a/util/uet_log.h
+++ b/util/uet_log.h
@@ -37,7 +37,7 @@
 #define UET_LOG_WARN 2
 #define UET_LOG_INFO 3
 #define UET_LOG_DBG  4
-#define UET_LOG_LVL  UET_LOG_DBG /* max log level to print (+below) */
+#define UET_LOG_LVL  UET_LOG_INFO /* max log level to print (+below) */
 
 #define UET_SES_LBL "[SES] "
 #define UET_PDS_LBL "[PDS] "

--- a/util/uet_pkt_chk.c
+++ b/util/uet_pkt_chk.c
@@ -12,6 +12,7 @@
 /* determine if uet packet type is valid */
 static bool uet_pds_pkt_type_valid(uint8_t *pkt,
 				   size_t pkt_size,
+				   bool is_ipv6,
 				   bool *pkt_is_ack,
 				   bool *pkt_is_rd_rsp,
 				   bool *pkt_is_ctrl)
@@ -20,22 +21,22 @@ static bool uet_pds_pkt_type_valid(uint8_t *pkt,
 	struct uet_pds_req *pds_hdr;
 	uint16_t pds_type, next_hdr;
 	bool pds_req;
+	size_t ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr) :
+					 sizeof(struct iphdr);
 
 	*pkt_is_ack = false;
 	*pkt_is_rd_rsp = false;
 	*pkt_is_ctrl = false;
 
-	/* TODO: IPv6 support and UDP support */
 	pds_hdr = (struct uet_pds_req *)(pkt +
 					 sizeof(struct ethhdr) +
-					 sizeof(struct iphdr) +
+					 ip_hdr_size +
 					 sizeof(struct uet_entropy));
 
 	pds_type = ((ntohs(pds_hdr->prlg.type_next_flags) &
 		     UET_PDS_TYPE_MASK) >> UET_PDS_TYPE_SHIFT);
 
 	if (pds_type == UET_PDS_TYPE_SECURITY) {
-		/* TODO: IPv6 support */
 		sec_hdr = (struct uet_sec *)pds_hdr;
 		if (ntohl(sec_hdr->type_flags_sdi) & UET_SEC_SP_MASK) {
 			pds_hdr = (struct uet_pds_req *)
@@ -124,51 +125,76 @@ bool uet_pds_rx_pkt_chk(struct uet_instance *uet,
 			bool *pkt_is_ctrl)
 {
 	struct ethhdr *eth = (struct ethhdr *)pkt;
-	struct iphdr *ipv4 = (struct iphdr *)(eth + 1);
-
-	/* TODO: IPv6 support */
+	bool is_ipv6;
 
 	if (memcmp(eth->h_dest, uet->nic.mac_addr, ETH_ALEN) != 0) {
 		UET_PDS_WARN("dest MAC mismatch");
 		return false;
 	}
 
-	if (eth->h_proto != htons(ETH_P_IP)) {
-		UET_PDS_WARN("not an IPv4 packet");
+	if (eth->h_proto == htons(ETH_P_IPV6)) {
+		struct ipv6hdr *ipv6 = (struct ipv6hdr *)(eth + 1);
+
+		is_ipv6 = true;
+
+		if (ipv6->version != 6) {
+			UET_PDS_WARN("invalid IPv6 header version");
+			return false;
+		}
+
+		if (ipv6->nexthdr != uet->uet_ipproto) {
+			UET_PDS_WARN("unsupported IP protocol");
+			return false;
+		}
+
+		if (ntohs(ipv6->payload_len) + sizeof(struct ipv6hdr) +
+		    sizeof(struct ethhdr) > pkt_size) {
+			UET_PDS_WARN("IPv6 payload length too large");
+			return false;
+		}
+
+		/* IPv6 has no header checksum */
+
+	} else if (eth->h_proto == htons(ETH_P_IP)) {
+		struct iphdr *ipv4 = (struct iphdr *)(eth + 1);
+
+		is_ipv6 = false;
+
+		if (ipv4->version != IPVERSION) {
+			UET_PDS_WARN("invalid IPv4 header version");
+			return false;
+		}
+
+		if (ipv4->ihl != UET_IPV4_IHL_NO_OPTIONS) {
+			UET_PDS_WARN("IPv4 header options not supported");
+			return false;
+		}
+
+		if (ipv4->protocol != uet->uet_ipproto) {
+			UET_PDS_WARN("unsupported IP protocol");
+			return false;
+		}
+
+		if (ipv4->tot_len < htons(uet->nic.min_ip_pkt_size)) {
+			UET_PDS_WARN("IPv4 total length too small");
+			return false;
+		}
+
+		if (ipv4->tot_len > htons((pkt_size - uet->nic.l2_hdr_size))) {
+			UET_PDS_WARN("IPv4 total length too large");
+			return false;
+		}
+
+		if (uet_ipv4_csum(ipv4) != 0) {
+			UET_PDS_WARN("IPv4 header checksum invalid");
+			return false;
+		}
+	} else {
+		UET_PDS_WARN("unsupported ethertype");
 		return false;
 	}
 
-	if (ipv4->version != IPVERSION) {
-		UET_PDS_WARN("invalid IPv4 header version");
-		return false;
-	}
-
-	if (ipv4->ihl != UET_IPV4_IHL_NO_OPTIONS) {
-		UET_PDS_WARN("IPv4 header options not supported");
-		return false;
-	}
-
-	if (ipv4->protocol != uet->uet_ipproto) {
-		UET_PDS_WARN("unsupported IP protocol");
-		return false;
-	}
-
-	if (ipv4->tot_len < htons(uet->nic.min_ip_pkt_size)) {
-		UET_PDS_WARN("IPv4 total length too small");
-		return false;
-	}
-
-	if (ipv4->tot_len > htons((pkt_size - uet->nic.l2_hdr_size))) {
-		UET_PDS_WARN("IPv4 total length too large");
-		return false;
-	}
-
-	if (uet_ipv4_csum(ipv4) != 0) {
-		UET_PDS_WARN("IPv4 header checksum invalid");
-		return false;
-	}
-
-	if (!uet_pds_pkt_type_valid(pkt, pkt_size, pkt_is_ack,
+	if (!uet_pds_pkt_type_valid(pkt, pkt_size, is_ipv6, pkt_is_ack,
 				    pkt_is_rd_rsp, pkt_is_ctrl)) {
 		UET_PDS_WARN("invalid UET PDS packet type");
 		return false;

--- a/util/uet_util.c
+++ b/util/uet_util.c
@@ -52,6 +52,21 @@ void uet_ipv4_addr_to_str(uint32_t ipv4_addr, char *ipv4_addr_str)
 	inet_ntop(AF_INET, (char *) &net_order, ipv4_addr_str, INET_ADDRSTRLEN);
 }
 
+/* convert ipv6 address to string */
+void uet_ipv6_addr_to_str(const uint8_t *ipv6_addr, char *ipv6_addr_str)
+{
+	inet_ntop(AF_INET6, ipv6_addr, ipv6_addr_str, INET6_ADDRSTRLEN);
+}
+
+/* convert ip address (v4 or v6) to string */
+void uet_ip_addr_to_str(const struct uet_fa *fa, bool is_ipv6, char *str)
+{
+	if (is_ipv6)
+		uet_ipv6_addr_to_str(fa->v6, str);
+	else
+		uet_ipv4_addr_to_str(fa->v4, str);
+}
+
 /* convert ses return code to string */
 char *uet_ses_rc_to_str(uet_ses_rc_t rc)
 {
@@ -195,12 +210,22 @@ void uet_print_ipv4_addr(uint32_t ipv4_addr)
 	       (ipv4_addr >> 8)  & 0xff, ipv4_addr & 0xff);
 }
 
+/* print ipv6 address */
+void uet_print_ipv6_addr(const uint8_t *ipv6_addr)
+{
+	char str[INET6_ADDRSTRLEN];
+
+	uet_ipv6_addr_to_str(ipv6_addr, str);
+	printf("%s\n", str);
+}
+
 /* print uet address */
 void uet_print_uet_addr(struct uet_addr *uet_addr)
 {
-	char ip_addr_str[INET_ADDRSTRLEN];
+	char ip_addr_str[INET6_ADDRSTRLEN];
 
-	uet_ipv4_addr_to_str(uet_addr->fa.v4, ip_addr_str);
+	uet_ip_addr_to_str(&uet_addr->fa, uet_addr_is_ipv6(uet_addr),
+			   ip_addr_str);
 
 	printf("UET Address\n");
 	printf("  IP Address:      %s\n", ip_addr_str);
@@ -245,6 +270,26 @@ void uet_print_ipv4_hdr(struct iphdr *ipv4)
 	uet_print_ipv4_addr(ntohl(ipv4->daddr));
 	printf("    Source Addr:          ");
 	uet_print_ipv4_addr(ntohl(ipv4->saddr));
+}
+
+/* print ipv6 header */
+void uet_print_ipv6_hdr(struct ipv6hdr *ipv6)
+{
+	printf("  IPv6 Header (%lu)\n", sizeof(struct ipv6hdr));
+	printf("    IP Version:           %u\n", ipv6->version);
+	printf("    Traffic Class:        0x%x\n",
+	       (ipv6->priority << 4) | (ipv6->flow_lbl[0] >> 4));
+	printf("    Flow Label:           0x%x%02x%02x\n",
+	       ipv6->flow_lbl[0] & 0x0f,
+	       ipv6->flow_lbl[1],
+	       ipv6->flow_lbl[2]);
+	printf("    Payload Length:       %u\n", ntohs(ipv6->payload_len));
+	printf("    Next Header:          0x%x\n", ipv6->nexthdr);
+	printf("    Hop Limit:            %u\n", ipv6->hop_limit);
+	printf("    Destination Addr:     ");
+	uet_print_ipv6_addr((const uint8_t *)&ipv6->daddr);
+	printf("    Source Addr:          ");
+	uet_print_ipv6_addr((const uint8_t *)&ipv6->saddr);
 }
 
 /* print uet header */
@@ -527,7 +572,10 @@ void uet_print_pkt_hdrs(struct uet_parsed_pkt *pp)
 {
 	printf("UET Packet Headers (pkt_len=%d)\n", pp->pkt_len);
 	uet_print_mac_hdr((struct ethhdr *) pp->eth);
-	uet_print_ipv4_hdr((struct iphdr *) pp->ip); /* TODO: IPv6 support */
+	if (pp->is_ipv6)
+		uet_print_ipv6_hdr((struct ipv6hdr *) pp->ip);
+	else
+		uet_print_ipv4_hdr((struct iphdr *) pp->ip);
 	/* TODO: UDP support */
 	uet_print_uet_hdr(pp);
 }
@@ -626,6 +674,45 @@ void uet_update_ipv4_tl(struct iphdr *ipv4, uint16_t tot_len)
 }
 
 /*
+ * build ipv6 header
+ *
+ * parms:
+ *      uet         - ptr to uet instance struct
+ *      ipv6        - ptr to location where ipv6 header is to be built
+ *      dip         - destination ipv6 address (16 bytes, network order)
+ *      sip         - source ipv6 address (16 bytes, network order)
+ *      payload_len - value for payload length field of ipv6 header
+ *      tc          - value for traffic class field of ipv6 header
+ *      crc_en      - CRC will or will not be appended to the frame
+ */
+void uet_build_ipv6_hdr(struct uet_instance *uet, struct ipv6hdr *ipv6,
+			const uint8_t *dip, const uint8_t *sip,
+			uint16_t payload_len, uint8_t tc, bool crc_en)
+{
+	memset(ipv6, 0, sizeof(*ipv6));
+	ipv6->version = 6;
+	ipv6->priority = (tc >> 4);
+	ipv6->flow_lbl[0] = (tc << 4);
+	ipv6->payload_len = htons(payload_len + (crc_en ? CRC_LEN : 0));
+	ipv6->nexthdr = uet->uet_ipproto;
+	ipv6->hop_limit = IPDEFTTL;
+	memcpy(&ipv6->saddr, sip, 16);
+	memcpy(&ipv6->daddr, dip, 16);
+}
+
+/*
+ * update ipv6 payload length field
+ *
+ * parms:
+ *      ipv6        - ptr to location where ipv6 header is located
+ *      payload_len - value for payload length field of ipv6 header
+ */
+void uet_update_ipv6_pl(struct ipv6hdr *ipv6, uint16_t payload_len)
+{
+	ipv6->payload_len = htons(payload_len);
+}
+
+/*
  * build ethernet header
  *
  * parms:
@@ -633,9 +720,10 @@ void uet_update_ipv4_tl(struct iphdr *ipv4, uint16_t tot_len)
  *      dmac - ptr to destination mac address
  *      smac - ptr to source mac address
  */
-void uet_build_eth_hdr(struct ethhdr *eth, uint8_t *dmac, uint8_t *smac)
+void uet_build_eth_hdr(struct ethhdr *eth, uint8_t *dmac, uint8_t *smac,
+		       bool is_ipv6)
 {
-	eth->h_proto = htons(ETH_P_IP);
+	eth->h_proto = htons(is_ipv6 ? ETH_P_IPV6 : ETH_P_IP);
 	memcpy(eth->h_dest, dmac, ETH_ALEN);
 	memcpy(eth->h_source, smac, ETH_ALEN);
 }
@@ -971,6 +1059,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 	}
 	switch (ethertype) {
 	case ETH_P_IP:
+		pp->is_ipv6 = false;
 		ipv4 = (struct iphdr *) p;
 		pp->ip_protocol = ipv4->protocol;
 		pp->ip_len = (ipv4->ihl << 2);
@@ -978,6 +1067,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 				      sizeof(struct iphdr));
 		break;
 	case ETH_P_IPV6:
+		pp->is_ipv6 = true;
 		rc = uet_get_ipv6_nexthdr(uet, pp);
 		if (rc != 0)
 			return rc;

--- a/util/uet_util.h
+++ b/util/uet_util.h
@@ -68,6 +68,7 @@ struct uet_parsed_pkt {
 	uint16_t ip_len;
 	uint16_t ip_payload_len;
 	uint8_t ip_protocol;                        /* next protocol after ip */
+	bool is_ipv6;                      /* true if ip points to ipv6 header */
 	void *udp;
 	uint16_t udp_len;
 	void *entropy;                                  /* uet entropy header */
@@ -137,12 +138,16 @@ struct uet_instance; /* forward reference */
 int uet_gettime(time_t *time_ms);
 void uet_mac_addr_to_str(char *mac_addr_str, uint8_t *mac_addr);
 void uet_ipv4_addr_to_str(uint32_t ipv4_addr, char *ipv4_addr_str);
+void uet_ipv6_addr_to_str(const uint8_t *ipv6_addr, char *ipv6_addr_str);
+void uet_ip_addr_to_str(const struct uet_fa *fa, bool is_ipv6, char *str);
 char *uet_ses_rc_to_str(uet_ses_rc_t rc);
 void uet_print_mac_addr(uint8_t *mac);
 void uet_print_ipv4_addr(uint32_t ipv4_addr);
+void uet_print_ipv6_addr(const uint8_t *ipv6_addr);
 void uet_print_uet_addr(struct uet_addr *uet_addr);
 void uet_print_mac_hdr(struct ethhdr *eth);
 void uet_print_ipv4_hdr(struct iphdr *ipv4);
+void uet_print_ipv6_hdr(struct ipv6hdr *ipv6);
 void uet_print_uet_hdr(struct uet_parsed_pkt *pp);
 void uet_print_pkt_hdrs(struct uet_parsed_pkt *pp);
 size_t uet_roundup_8(size_t val);
@@ -152,8 +157,13 @@ uint16_t uet_ipv4_csum(struct iphdr *ipv4);
 void uet_build_ipv4_hdr(struct uet_instance *uet, struct iphdr *ipv4,
 			uint32_t dip, uint32_t sip, uint16_t tot_len,
 			uint8_t tos, bool crc_en);
+void uet_build_ipv6_hdr(struct uet_instance *uet, struct ipv6hdr *ipv6,
+			const uint8_t *dip, const uint8_t *sip,
+			uint16_t payload_len, uint8_t tc, bool crc_en);
 void uet_update_ipv4_tl(struct iphdr *ipv4, uint16_t tot_len);
-void uet_build_eth_hdr(struct ethhdr *eth, uint8_t *dmac, uint8_t *smac);
+void uet_update_ipv6_pl(struct ipv6hdr *ipv6, uint16_t payload_len);
+void uet_build_eth_hdr(struct ethhdr *eth, uint8_t *dmac, uint8_t *smac,
+		       bool is_ipv6);
 void uet_pkt_hex_dump(void *pkt, uint32_t length, uint64_t addr, bool is_tx);
 void uet_rw_lock(struct uet_rw_lock *lock, uet_rw_lock_access_t access);
 void uet_rw_unlock(struct uet_rw_lock *lock, uet_rw_lock_access_t access);


### PR DESCRIPTION
- complete refactor of SNG to support for IPv6
- UET PDS support for IPv6
- UET TSS support for IPv6 (large context, IV construction with SDI, etc)
- NIC shim support for IPv6 (shared v4/v6 code paths for learning next hop)
- updated UET application to accept IPv4/IPv6 addresses on command line
- updated UET test script to properly set TSS env for IPv6 and direct mode
- set default logging to INFO