### PR TITLE
Fix atomic return value

### DIFF
--- a/uet.c
+++ b/uet.c
@@ -1333,7 +1333,7 @@ static uet_rc_t uet_atomic_client(struct uet_context *ctx)
 		return UET_ERR_RC;
 	}
 
-	if (*result_buf != *local_op_buf) {
+	if (*result_buf != val) {
 		UET_ERR("uet_compare_atomic: bad result %lu", *result_buf);
 		return UET_ERR_RC;
 	}

--- a/uet_api.c
+++ b/uet_api.c
@@ -2805,12 +2805,11 @@ static uet_ses_rc_t uet_rx_fetch_atomic_req_pkt(
 	} else {
 		expected = ntohll(ses_cswap->ext.cmp_val_lo);
 		desired = ntohll(ses_cswap->ext.swp_val_lo);
-		if (__atomic_compare_exchange_n(
+		__atomic_compare_exchange_n(
 			addr, &expected, desired, false,
-			__ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST))
-			*((uint64_t *) payload) = htonll(desired);
-		else
-			*((uint64_t *) payload) = htonll(expected);
+			__ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+		/* return old value, always equal to expected variable */
+		*((uint64_t *) payload) = htonll(expected);
 	}
 
 	return UET_RC_OK;


### PR DESCRIPTION
Should always return old value of buffer
As described in Fetch-Atomic Functions in libfabric documentation: 
"The initial value is read into the user provided result buffer"