### PR TITLE
Support sack bitmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Replace `2` with the desired number of senders.
 - **UET_NIC_SHIM** - [ `rawsock` | `xdp` ]
 - **UET_PDS** - [ `sng` | `pds` ] (default=`sng` stop-n-go)
 - **UET_PDS_PER_PKT_ACK_ENB** - [ `0` | `1` ] (default=`0`)
+- **UET_PDS_ACK_TYPE** - [ `ack` | `ack_cc` | `ack_ccx` ] (default=`ack`)
 - **UET_SEC_MODE** - [ `direct` | `cluster` | `server` ]
 - **UET_SEC_SSI** - The SSI to be used for crypto operations. This value must be unique for all instances of `uet`. If not set the source IP address will be used instead as the source identifier.
 - **UET_SEC_CLIENT_SSI** - If set, the client SSI to be used by the server side of the session. This is only valid for the `UET_SEC_MODE=server` configuration.

--- a/tests/util/Makefile
+++ b/tests/util/Makefile
@@ -1,0 +1,24 @@
+
+CC=gcc
+
+INCS=-I. -I../../util
+CFLAGS=-Wall -Wextra -g
+LDFLAGS=
+
+BIN=bitmap_test
+SRC=test_bitmap.c ../../util/bitmap.c
+HDRS=../../util/bitmap.h
+
+$(BIN): $(SRC) $(HDRS)
+	@echo 'Building program: $@'
+	@$(CC) $(CFLAGS) $(INCS) $(SRC) -o $@ $(LDFLAGS)
+
+all: $(BIN)
+
+test: $(BIN)
+	@./$(BIN)
+
+clean:
+	@rm -rf $(BIN)
+
+.PHONY: all test clean

--- a/tests/util/test_bitmap.c
+++ b/tests/util/test_bitmap.c
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) 2026, Broadcom. All rights reserved. The term
+ * Broadcom refers to Broadcom Limited and/or its subsidiaries.
+ */
+
+/*
+ * Unit tests for the bitmap implementation in util/bitmap.c.
+ *
+ * The harness is intentionally tiny: every check funnels through CHECK()/
+ * CHECK_EQ(), which record pass/fail counts and print the first failing
+ * location. Run with no args to execute every group, or pass -h for usage.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "../../util/bitmap.h"
+
+static int g_checks;
+static int g_failures;
+
+#define CHECK(cond)                                                          \
+	do {                                                                 \
+		g_checks++;                                                  \
+		if (!(cond)) {                                               \
+			g_failures++;                                        \
+			printf("  [FAIL] %s:%d: CHECK(%s)\n",                \
+			       __func__, __LINE__, #cond);                   \
+		}                                                            \
+	} while (0)
+
+#define CHECK_EQ(got, exp)                                                   \
+	do {                                                                 \
+		uint64_t _g = (uint64_t)(got);                               \
+		uint64_t _e = (uint64_t)(exp);                               \
+		g_checks++;                                                  \
+		if (_g != _e) {                                              \
+			g_failures++;                                        \
+			printf("  [FAIL] %s:%d: %s == %s "                   \
+			       "(got 0x%" PRIx64 ", want 0x%" PRIx64 ")\n",  \
+			       __func__, __LINE__, #got, #exp, _g, _e);      \
+		}                                                            \
+	} while (0)
+
+/* A few distinct non-NULL sentinels to exercise the per-bit data array. */
+static int marker_a, marker_b, marker_c;
+#define PA ((void *)&marker_a)
+#define PB ((void *)&marker_b)
+#define PC ((void *)&marker_c)
+
+/* ------------------------------------------------------------------ */
+/* bm_create / bm_destroy: sizing rules and input validation          */
+/* ------------------------------------------------------------------ */
+static void test_create_destroy(void)
+{
+	struct bitmap *bm;
+
+	/* Valid sizes must be multiples of 64. */
+	bm = bm_create(64);
+	CHECK(bm != NULL);
+	if (bm) {
+		CHECK_EQ(bm->size, 64);
+		CHECK_EQ(bm->bit_arr_len, 1);
+		bm_destroy(bm);
+	}
+
+	bm = bm_create(128);
+	CHECK(bm != NULL);
+	if (bm) {
+		CHECK_EQ(bm->size, 128);
+		CHECK_EQ(bm->bit_arr_len, 2);
+		/* Freshly created bitmap must be all-zero. */
+		CHECK_EQ(bm_count(bm), 0);
+		CHECK_EQ(bm_min(bm), -1);
+		CHECK_EQ(bm_max(bm), -1);
+		bm_destroy(bm);
+	}
+
+	/*
+	 * Regression for the input-validation fix: sizes that are a multiple
+	 * of 8 but NOT of 64 used to slip through and produce bit_arr_len == 0.
+	 * They must now be rejected.
+	 */
+	CHECK(bm_create(8) == NULL);
+	CHECK(bm_create(16) == NULL);
+	CHECK(bm_create(63) == NULL);
+	CHECK(bm_create(100) == NULL);
+
+	/* a larger multiple of 64 is still valid */
+	bm = bm_create(192);
+	CHECK(bm != NULL);
+	if (bm) {
+		CHECK_EQ(bm->bit_arr_len, 3);
+		bm_destroy(bm);
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* bm_set / bm_get / bm_unset / bm_count                              */
+/* ------------------------------------------------------------------ */
+static void test_set_get_unset(void)
+{
+	struct bitmap *bm = bm_create(128);
+	void *data;
+
+	CHECK(bm != NULL);
+	if (!bm)
+		return;
+
+	/* set a handful of bits across both 64-bit words */
+	bm_set(bm, 0, PA);
+	bm_set(bm, 63, PB);
+	bm_set(bm, 64, PC);
+	bm_set(bm, 127, PA);
+	CHECK_EQ(bm_count(bm), 4);
+
+	/* bm_get returns the bit state and hands back the stored pointer */
+	data = NULL;
+	CHECK(bm_get(bm, 0, &data) == true);
+	CHECK(data == PA);
+	data = NULL;
+	CHECK(bm_get(bm, 64, &data) == true);
+	CHECK(data == PC);
+
+	/* an unset bit reports false; data pointer for it is NULL */
+	data = PB;
+	CHECK(bm_get(bm, 1, &data) == false);
+	CHECK(data == NULL);
+
+	/* bm_get tolerates a NULL data out-param */
+	CHECK(bm_get(bm, 63, NULL) == true);
+
+	/* unset clears both the bit and its data slot */
+	bm_unset(bm, 63);
+	data = PB;
+	CHECK(bm_get(bm, 63, &data) == false);
+	CHECK(data == NULL);
+	CHECK_EQ(bm_count(bm), 3);
+
+	/* out-of-range / negative indices are silently ignored, no crash */
+	bm_set(bm, -1, PA);
+	bm_set(bm, 128, PA);
+	bm_set(bm, 100000, PA);
+	CHECK_EQ(bm_count(bm), 3);
+	CHECK(bm_get(bm, -1, NULL) == false);
+	CHECK(bm_get(bm, 128, NULL) == false);
+
+	bm_destroy(bm);
+}
+
+/* ------------------------------------------------------------------ */
+/* bm_clear: must zero the WHOLE data array, not just bit_arr_len ptrs */
+/* ------------------------------------------------------------------ */
+static void test_clear(void)
+{
+	struct bitmap *bm = bm_create(128);
+	void *data;
+	int i;
+
+	CHECK(bm != NULL);
+	if (!bm)
+		return;
+
+	/* populate every bit with a non-NULL data pointer */
+	for (i = 0; i < 128; i++)
+		bm_set(bm, i, PA);
+	CHECK_EQ(bm_count(bm), 128);
+
+	bm_clear(bm);
+
+	/* all bits gone */
+	CHECK_EQ(bm_count(bm), 0);
+	CHECK_EQ(bm_min(bm), -1);
+
+	/*
+	 * Regression for the bm_clear fix: every data slot (including those
+	 * beyond index bit_arr_len) must be reset to NULL. We read the data
+	 * array directly so the check does not depend on bm_get's bit gating.
+	 */
+	for (i = 0; i < bm->size; i++)
+		CHECK(bm->data_arr[i] == NULL);
+
+	/* after clear the map is fully reusable */
+	bm_set(bm, 70, PB);
+	data = NULL;
+	CHECK(bm_get(bm, 70, &data) == true);
+	CHECK(data == PB);
+
+	bm_destroy(bm);
+}
+
+/* ------------------------------------------------------------------ */
+/* bm_min / bm_max                                                    */
+/* ------------------------------------------------------------------ */
+static void test_min_max(void)
+{
+	struct bitmap *bm = bm_create(128);
+
+	CHECK(bm != NULL);
+	if (!bm)
+		return;
+
+	CHECK_EQ(bm_min(bm), -1);
+	CHECK_EQ(bm_max(bm), -1);
+
+	bm_set(bm, 10, PA);
+	CHECK_EQ(bm_min(bm), 10);
+	CHECK_EQ(bm_max(bm), 10);
+
+	bm_set(bm, 5, PA);
+	bm_set(bm, 120, PA);
+	CHECK_EQ(bm_min(bm), 5);
+	CHECK_EQ(bm_max(bm), 120);
+
+	/* boundary bits 0 and size-1 */
+	bm_set(bm, 0, PA);
+	bm_set(bm, 127, PA);
+	CHECK_EQ(bm_min(bm), 0);
+	CHECK_EQ(bm_max(bm), 127);
+
+	bm_destroy(bm);
+}
+
+/* ------------------------------------------------------------------ */
+/* bm_next_set_bit_iter                                               */
+/* ------------------------------------------------------------------ */
+static void test_iter(void)
+{
+	struct bitmap *bm = bm_create(128);
+	int expect[] = { 0, 1, 63, 64, 65, 127 };
+	int n = (int)(sizeof(expect) / sizeof(expect[0]));
+	int seen = 0;
+	int i;
+
+	CHECK(bm != NULL);
+	if (!bm)
+		return;
+
+	for (i = 0; i < n; i++)
+		bm_set(bm, expect[i], PA);
+
+	for (i = 0; bm_next_set_bit_iter(bm, &i); i++) {
+		CHECK(seen < n);
+		if (seen < n)
+			CHECK_EQ(i, expect[seen]);
+		seen++;
+	}
+	CHECK_EQ(seen, n);
+
+	/* empty bitmap: iterator finds nothing */
+	bm_clear(bm);
+	i = 0;
+	CHECK(bm_next_set_bit_iter(bm, &i) == false);
+
+	bm_destroy(bm);
+}
+
+/* ------------------------------------------------------------------ */
+/* bm_extract64: SACK-style 64-bit window extraction                  */
+/* ------------------------------------------------------------------ */
+static void test_extract64(void)
+{
+	struct bitmap *bm = bm_create(128);
+
+	CHECK(bm != NULL);
+	if (!bm)
+		return;
+
+	/* empty map extracts to 0 at a valid index */
+	CHECK_EQ(bm_extract64(bm, 0), 0ULL);
+
+	/* bit 0 set -> lsb of the window */
+	bm_set(bm, 0, PA);
+	CHECK_EQ(bm_extract64(bm, 0), 0x1ULL);
+
+	/* bit 5 set, extract from index 5 -> lsb again */
+	bm_clear(bm);
+	bm_set(bm, 5, PA);
+	CHECK_EQ(bm_extract64(bm, 5), 0x1ULL);
+	CHECK_EQ(bm_extract64(bm, 0), (1ULL << 5));
+
+	/* window straddling the 64-bit word boundary */
+	bm_clear(bm);
+	bm_set(bm, 63, PA);
+	bm_set(bm, 64, PA);
+	/* extract from 63: bit63 -> pos0, bit64 -> pos1 */
+	CHECK_EQ(bm_extract64(bm, 63), 0x3ULL);
+
+	/* index >= size returns 0 */
+	CHECK_EQ(bm_extract64(bm, 128), 0ULL);
+	CHECK_EQ(bm_extract64(bm, 200), 0ULL);
+
+	/* fully negative window (i + 64 <= 0) is all ones */
+	CHECK_EQ(bm_extract64(bm, -64), ~0ULL);
+	CHECK_EQ(bm_extract64(bm, -100), ~0ULL);
+
+	/*
+	 * Partially negative window: positions below 0 are filled with 1,
+	 * the rest come from the bitmap. With bit 0 set and shift = 3, the
+	 * low 3 bits are fill-ones and bit0 lands at position 3.
+	 */
+	bm_clear(bm);
+	bm_set(bm, 0, PA);
+	CHECK_EQ(bm_extract64(bm, -3), (0x7ULL | (1ULL << 3)));
+
+	bm_destroy(bm);
+}
+
+/* ------------------------------------------------------------------ */
+/* bm_shift_left / bm_shift_right (bits and the parallel data array)   */
+/* ------------------------------------------------------------------ */
+static void test_shift(void)
+{
+	struct bitmap *bm = bm_create(128);
+	void *data;
+
+	CHECK(bm != NULL);
+	if (!bm)
+		return;
+
+	/* shift by 0 is a no-op */
+	bm_set(bm, 10, PA);
+	bm_shift_left(bm, 0);
+	CHECK(bm_get(bm, 10, NULL) == true);
+	bm_shift_right(bm, 0);
+	CHECK(bm_get(bm, 10, NULL) == true);
+
+	/* left shift within a word moves bit and data together */
+	bm_clear(bm);
+	bm_set(bm, 1, PA);
+	bm_set(bm, 2, PB);
+	bm_shift_left(bm, 4);
+	CHECK(bm_get(bm, 1, NULL) == false);
+	data = NULL;
+	CHECK(bm_get(bm, 5, &data) == true);
+	CHECK(data == PA);
+	data = NULL;
+	CHECK(bm_get(bm, 6, &data) == true);
+	CHECK(data == PB);
+
+	/* left shift across the word boundary */
+	bm_clear(bm);
+	bm_set(bm, 60, PC);
+	bm_shift_left(bm, 8);
+	CHECK(bm_get(bm, 60, NULL) == false);
+	data = NULL;
+	CHECK(bm_get(bm, 68, &data) == true);
+	CHECK(data == PC);
+
+	/* right shift is the inverse direction */
+	bm_clear(bm);
+	bm_set(bm, 70, PA);
+	bm_set(bm, 65, PB);
+	bm_shift_right(bm, 8);
+	data = NULL;
+	CHECK(bm_get(bm, 62, &data) == true);
+	CHECK(data == PA);
+	data = NULL;
+	CHECK(bm_get(bm, 57, &data) == true);
+	CHECK(data == PB);
+
+	/* right shift by a whole word (multiple of 64) */
+	bm_clear(bm);
+	bm_set(bm, 100, PA);
+	bm_shift_right(bm, 64);
+	data = NULL;
+	CHECK(bm_get(bm, 36, &data) == true);
+	CHECK(data == PA);
+	CHECK(bm_get(bm, 100, NULL) == false);
+
+	/* bits shifted off the low end are dropped, and freed slots are NULL */
+	bm_clear(bm);
+	bm_set(bm, 3, PA);
+	bm_shift_right(bm, 8);
+	CHECK_EQ(bm_count(bm), 0);
+	data = PA;
+	CHECK(bm_get(bm, 0, &data) == false);
+	CHECK(data == NULL);
+
+	bm_destroy(bm);
+}
+
+/* ------------------------------------------------------------------ */
+
+static void run_all(void)
+{
+	printf("== test_create_destroy ==\n"); test_create_destroy();
+	printf("== test_set_get_unset ==\n");  test_set_get_unset();
+	printf("== test_clear ==\n");          test_clear();
+	printf("== test_min_max ==\n");        test_min_max();
+	printf("== test_iter ==\n");           test_iter();
+	printf("== test_extract64 ==\n");      test_extract64();
+	printf("== test_shift ==\n");          test_shift();
+}
+
+int main(void)
+{
+	run_all();
+
+	printf("\n----------------------------------------\n");
+	printf("bitmap unit tests: %d checks, %d failure(s)\n",
+	       g_checks, g_failures);
+
+	return (g_failures == 0) ? 0 : 1;
+}

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -77,6 +77,7 @@ struct uet_pdc_pkt {
 	int                   tx_retry_cnt;  /* number of retransmissions */
 	uet_pkt_handle_t      tx_pkt_handle;
 	bool                  tx_pkt_acked; /* this packet has been acked */
+	bool                  dst_recvd; /* this packet has arrived at dst */
 	uet_pds_tx_flags_t    flags;
 
 	bool                  needs_clear;
@@ -1612,14 +1613,135 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	return 0;
 }
 
+static int uet_pds_send_ack_req_cp(struct uet_instance *uet,
+				   struct uet_pdc *pdc,
+				   struct uet_pdc_pkt *orig_pdc_pkt)
+{
+	struct uet_pdc_pkt *pdc_pkt;
+	struct uet_pds_ctrl *ctrl_hdr;
+	struct uet_entropy *entropy_hdr;
+	size_t ip_hdr_size;
+	uint16_t ctrl_flags;
+	int rc;
+
+	/* allocate the packet descriptor */
+	pdc_pkt = calloc(1, sizeof(struct uet_pdc_pkt));
+	if (pdc_pkt == NULL) {
+		UET_PDS_ERR("failed to alloc PDC packet for ack req cp");
+		return -ENOMEM;
+	}
+
+	/* allocate the packet buffer */
+	pdc_pkt->pkt_buf_len = (uet->nic.max_pkt_size *
+				((pdc->sec_enabled) ? 2 : 1));
+	pdc_pkt->pkt_buf = calloc(1, pdc_pkt->pkt_buf_len);
+	if (pdc_pkt->pkt_buf == NULL) {
+		UET_PDS_ERR("failed to alloc packet buffer for ack req cp");
+		free(pdc_pkt);
+		return -ENOMEM;
+	}
+
+	/* reserve head space for security header if needed */
+	pdc_pkt->pkt = (pdc->sec_enabled)
+			? (pdc_pkt->pkt_buf + UET_SEC_MAX_HDR_LEN)
+			: pdc_pkt->pkt_buf;
+
+	ip_hdr_size = (pdc->is_ipv6) ? sizeof(struct ipv6hdr) :
+				       sizeof(struct iphdr);
+
+	/* build Ethernet header */
+	uet_build_eth_hdr((struct ethhdr *)pdc_pkt->pkt,
+			  pdc->dst_mac_addr, pdc->src_mac_addr,
+			  pdc->is_ipv6);
+
+	/* set up pointers to headers */
+	entropy_hdr = (struct uet_entropy *)(pdc_pkt->pkt +
+					     sizeof(struct ethhdr) +
+					     ip_hdr_size);
+	ctrl_hdr = (struct uet_pds_ctrl *)(pdc_pkt->pkt +
+					   sizeof(struct ethhdr) +
+					   ip_hdr_size +
+					   sizeof(struct uet_entropy));
+
+	pdc_pkt->pkt_len = (sizeof(struct ethhdr) +
+			    ip_hdr_size +
+			    sizeof(struct uet_entropy) +
+			    sizeof(struct uet_pds_ctrl));
+
+	/* fill in the entropy header */
+	entropy_hdr->entropy = htons(UET_DEFAULT_ENTROPY);
+
+	/* fill in the control packet header */
+	ctrl_flags = ((UET_PDS_TYPE_CTRL << UET_PDS_TYPE_SHIFT) |
+		      (UET_PDS_CTRL_TYPE_ACK_REQ << UET_PDS_CTRL_TYPE_SHIFT));
+
+	ctrl_hdr->prlg.type_ctrl_flags = htons(ctrl_flags);
+	ctrl_hdr->rsvd = 0;
+	ctrl_hdr->psn = htonl(orig_pdc_pkt->psn);
+	ctrl_hdr->spdcid = htons(pdc->pdc_id);
+	ctrl_hdr->dpdcid = htons(pdc->dpdcid);
+
+	/* payload is msg_id for ack request cp */
+	ctrl_hdr->payload = htonl((uint32_t)orig_pdc_pkt->msg_id);
+
+	/* build the IP header */
+	if (pdc->is_ipv6) {
+		uet_build_ipv6_hdr(uet,
+				   (struct ipv6hdr *)(pdc_pkt->pkt +
+						      sizeof(struct ethhdr)),
+				   pdc->dst_addr.v6,
+				   pdc->src_addr.v6,
+				   (pdc_pkt->pkt_len - uet->nic.l2_hdr_size -
+				    ip_hdr_size),
+				   uet->pds.ack_ip_tos,
+				   !pdc->sec_enabled);
+	} else {
+		uet_build_ipv4_hdr(uet,
+				   (struct iphdr *)(pdc_pkt->pkt +
+						    sizeof(struct ethhdr)),
+				   htonl(pdc->dst_addr.v4),
+				   htonl(pdc->src_addr.v4),
+				   (pdc_pkt->pkt_len - uet->nic.l2_hdr_size),
+				   uet->pds.ack_ip_tos,
+				   !pdc->sec_enabled);
+	}
+
+	/* send the packet */
+	rc = uet_pds_sec_tx_pkt(uet, pdc, pdc_pkt, true, false);
+	if (rc != 0) {
+		UET_PDS_ERR("failed to send ack req cp for PDC %u",
+			    pdc->pdc_id);
+		free(pdc_pkt->pkt_buf);
+		free(pdc_pkt);
+		return rc;
+	}
+
+	/* the packet was sent successfully */
+	uet_pds_pkt_dbg(uet, &pdc_pkt->pkt_pp, true, "ACK REQ CP");
+
+	free(pdc_pkt->pkt_buf);
+	free(pdc_pkt);
+
+	return 0;
+}
+
 static int uet_pds_rtx_pkt(struct uet_instance *uet,
 			   struct uet_pdc *pdc,
 			   struct uet_pdc_pkt *pdc_pkt)
 {
 	struct uet_pds_req *pds_hdr;
-	uint8_t *new_pkt;
-	int new_pkt_len;
 	int rc;
+
+	if (pdc_pkt->dst_recvd &&
+	    pdc_pkt->tx_retry_cnt < uet->pds.max_tx_retries) {
+		rc = uet_pds_send_ack_req_cp(uet, pdc, pdc_pkt);
+		if (rc != 0)
+			return rc;
+
+		pdc_pkt->tx_retry_cnt++;
+		uet_gettime(&pdc_pkt->tx_time);
+		return 0;
+	}
 
 	/* set the retransmit flag in the PDS header */
 	pds_hdr = (struct uet_pds_req *)pdc_pkt->pkt_pp.pds;
@@ -2442,14 +2564,8 @@ static void uet_pds_process_sack_bitmap(struct uet_instance *uet,
 		if (!bm_get(pdc->tx_bm, idx, (void **)&pdc_pkt))
 			continue;
 
-		/*
-		 * TODO How the initiator side process the sack bitmap?
-		 * When the initiator side does not konw whether the PDC ACK
-		 * packet corresponding to bit 1 requires guaranteed
-		 * transmission, it cannot directly notify the SES layer that
-		 * the PDC REQ packet corresponding to bit 1 has been delivered
-		 * to the peer.
-		 */
+		/* The packet has arrived at the target side */
+		pdc_pkt->dst_recvd = true;
 	}
 }
 
@@ -2730,6 +2846,56 @@ static int uet_pds_process_syn_pkt(struct uet_instance *uet,
 	return uet_pds_process_data_pkt(uet, pdc, pdc_pkt);
 }
 
+static int uet_pds_process_ack_req_cp(struct uet_instance *uet,
+				      struct uet_parsed_pkt *pp)
+{
+	struct uet_pdc *pdc;
+	struct uet_pdc_pkt *orig_pdc_pkt = NULL;
+	int rc;
+
+	UET_PDS_DBG("Received ACK_REQ cp (spdcid=%u dpdcid=%u)",
+		     pp->pds_spdcid, pp->pds_dpdcid);
+
+	/* find the target PDC */
+	pdc = uet_pdsm_get_pdc(pp->pds_dpdcid, false);
+	if (!pdc) {
+		UET_PDS_WARN("ACK REQ cp for unknown PDC %u", pp->pds_dpdcid);
+		return -EINVAL;
+	}
+
+	/* check the psn is within MPR, if not, drop the packet */
+	if (!PSN_IN_MPR(pp->pds_psn, pdc->rx_bm_base_psn)) {
+		UET_PDS_WARN("ACK REQ cp PDC %u PSN %u outside MPR",
+			     pp->pds_dpdcid, pp->pds_psn);
+		return 0;
+	}
+
+	if (!bm_get(pdc->rx_bm, (pp->pds_psn - pdc->rx_bm_base_psn),
+		    (void **)&orig_pdc_pkt)) {
+		UET_PDS_WARN("ACK REQ cp PDC %u PSN %u original pkt not found",
+			     pp->pds_dpdcid, pp->pds_psn);
+		return 0;
+	}
+
+	/* find previous ACK/response */
+	if (orig_pdc_pkt->ack == NULL) {
+		/* TODO: reply with NACK packet */
+		UET_PDS_WARN("ACK REQ cp PDC %u PSN %u original ack not found",
+			     pp->pds_dpdcid, pp->pds_psn);
+		return 0;
+	}
+
+	/* resend previous ACK/response */
+	rc = uet_pds_sec_tx_pkt(uet, pdc, orig_pdc_pkt, false, true);
+	if (rc != 0)
+		return rc;
+
+	uet_pds_pkt_dbg(uet, &orig_pdc_pkt->ack_pp, true,
+			"TX ACK PACKET (duplicate)");
+
+	return 0;
+}
+
 static int uet_pds_process_control(struct uet_instance *uet,
 				   struct uet_parsed_pkt *pp,
 				   uint8_t *pkt,
@@ -2744,6 +2910,9 @@ static int uet_pds_process_control(struct uet_instance *uet,
 		send_ack = true;
 
 	switch (pp->pds_ctrl_type) {
+	case UET_PDS_CTRL_TYPE_ACK_REQ:
+		return uet_pds_process_ack_req_cp(uet, pp);
+
 	case UET_PDS_CTRL_TYPE_CLOSE:
 		UET_PDS_DBG("Received CLOSE command (spdcid=%u dpdcid=%u)",
 			    pp->pds_spdcid, pp->pds_dpdcid);
@@ -3113,4 +3282,3 @@ void uet_pds_ep_close_wait(struct uet_ep *uet_ep)
 		uet->pds.downcall.progress_rx(uet);
 	}
 }
-

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -151,6 +151,7 @@ struct uet_pdc {
 	uint32_t            prev_ar_psn; /* highest PSN received with ar flag */
 	uint32_t            max_rcvd_psn; /* highest PSN received */
 	uint32_t            accepted_bytes; /* bytes received between ACKs */
+	uint32_t            sack_base_track; /* track SACK bitmap base PSN */
 
 	/* security fields, for Tx */
 	bool                sec_enabled;
@@ -774,6 +775,7 @@ static struct uet_pdc *uet_pdsm_assign_tgt_pdc(struct uet_parsed_pkt *pp)
 	pdc->max_clear_psn  = UET_DEFAULT_START_PSN - 1;
 	pdc->prev_ar_psn    = UET_DEFAULT_START_PSN - 1;
 	pdc->max_rcvd_psn   = UET_DEFAULT_START_PSN - 1;
+	pdc->sack_base_track = pdc->cack_psn;
 	pdc->accepted_bytes = 0;
 	memcpy(&pdc->tgt_hkey, &pdc_key, sizeof(pdc_key));
 	HASH_ADD(pdc_tgt_hh, pds_state.pdc_tgt_ht, tgt_hkey,
@@ -1810,12 +1812,73 @@ int uet_pds_msg_cmpl_ind(struct uet_ep *uet_ep,
 	return 0;
 }
 
+static void uet_pds_update_sack_base(struct uet_pdc *pdc,
+				     struct uet_pdc_pkt *pdc_pkt,
+				     bool is_sack_trigger)
+{
+	if (is_sack_trigger) {
+		if (UET_PDS_PSN_AFTER(pdc->max_rcvd_psn,
+				      pdc->sack_base_track + 63)) {
+			pdc->sack_base_track += 64;
+		}
+		return;
+	}
+
+	if (UET_PDS_PSN_AFTER(pdc->cack_psn, pdc->sack_base_track))
+		pdc->sack_base_track = pdc->cack_psn;
+	else if (UET_PDS_PSN_AFTER(pdc_pkt->pkt_pp.pds_psn, pdc->cack_psn) &&
+		 UET_PDS_PSN_AFTER(pdc->sack_base_track,
+				   pdc_pkt->pkt_pp.pds_psn)) {
+		pdc->sack_base_track = pdc_pkt->pkt_pp.pds_psn;
+	}
+}
+
+static void uet_pds_build_ack_cc_ext(struct uet_instance *uet,
+				     struct uet_pdc *pdc,
+				     struct uet_pdc_pkt *pdc_pkt,
+				     struct uet_pds_ack *ack_pds,
+				     uet_pds_pkt_type_t ack_type)
+{
+	struct uet_pds_ack_cc *ack_cc;
+	struct uet_pds_ack_ccx *ack_ccx;
+	uint32_t sack_base_psn;
+	int bm_start_idx;
+
+	/*
+	 * Selection of sack_base_psn:
+	 *   - Per-packet ACKs, the SACK bitmap base PSN is the PSN that
+	 *     triggered this ACK
+	 *   - Coalesced ACKs, the SACK bitmap base PSN is the sack_base_track
+	 */
+	if (uet->pds.per_pkt_ack_enabled)
+		sack_base_psn = pdc_pkt->pkt_pp.pds_psn;
+	else {
+		sack_base_psn = pdc->sack_base_track;
+		uet_pds_update_sack_base(pdc, pdc_pkt, true);
+	}
+
+	bm_start_idx = UET_PDS_PSN_OFFSET(sack_base_psn, pdc->rx_bm_base_psn);
+	ack_cc = (struct uet_pds_ack_cc *)ack_pds;
+	ack_cc->cc_type_flags = 0;
+	ack_cc->mpr = UET_DEFAULT_MPR;
+	ack_cc->sack_psn_offset =
+		htons(psn_2c_offset(pdc->cack_psn, sack_base_psn));
+	ack_cc->sack_bitmap = htonll(bm_extract64(pdc->rx_bm, bm_start_idx));
+	ack_cc->ack_cc_state = 0;
+
+	if (ack_type == UET_PDS_TYPE_ACK_CCX) {
+		ack_ccx = (struct uet_pds_ack_ccx *)ack_pds;
+		ack_ccx->ack_ccx_state = 0;
+	}
+}
+
 static void uet_pds_build_ack_pkt(struct uet_instance *uet,
 				  struct uet_pdc *pdc,
 				  struct uet_pdc_pkt *pdc_pkt,
 				  uet_pds_next_hdr_t next_hdr,
 				  void *ses_hdr,
-				  size_t ses_hdr_len)
+				  size_t ses_hdr_len,
+				  size_t pds_ack_hdr_len)
 {
 	uint8_t flags;
 	struct uet_entropy *entropy_hdr;
@@ -1863,7 +1926,6 @@ static void uet_pds_build_ack_pkt(struct uet_instance *uet,
 	/* TODO: UDP support */
 	entropy_hdr->entropy = htons(pdc_pkt->pkt_pp.entropy_val);
 
-	/* TODO: support ACK_CC and ACK_CCX */
 	flags = (pdc_pkt->needs_clear) ? UET_PDS_ACK_FLAGS_REQ_CLR_CLS
 				       : UET_PDS_ACK_FLAGS_NONE;
 	ack_pds->prlg.type_next_flags =
@@ -1880,9 +1942,15 @@ static void uet_pds_build_ack_pkt(struct uet_instance *uet,
 	ack_pds->spdcid = htons(pdc->pdc_id);
 	ack_pds->dpdcid = htons(pdc->dpdcid);
 
+	if ((uet->pds.ack_type == UET_PDS_TYPE_ACK_CC) ||
+	    (uet->pds.ack_type == UET_PDS_TYPE_ACK_CCX)) {
+		uet_pds_build_ack_cc_ext(uet, pdc, pdc_pkt, ack_pds,
+					 uet->pds.ack_type);
+	}
+
 	/* only copy SES header if needed */
 	if (ses_hdr && ses_hdr_len > 0) {
-		ack_ses = (uint8_t *)(ack_pds + 1);
+		ack_ses = (uint8_t *)(ack_pds) + pds_ack_hdr_len;
 		memcpy(ack_ses, ses_hdr, ses_hdr_len);
 	}
 }
@@ -1909,6 +1977,19 @@ static void uet_pds_update_cack(struct uet_pdc *pdc,
 	pdc->cack_psn = pdc->rx_bm_base_psn + i - 1;
 }
 
+static size_t uet_pds_ack_hdr_len(struct uet_instance *uet)
+{
+	switch (uet->pds.ack_type) {
+	case UET_PDS_TYPE_ACK_CC:
+		return sizeof(struct uet_pds_ack_cc);
+	case UET_PDS_TYPE_ACK_CCX:
+		return sizeof(struct uet_pds_ack_ccx);
+	case UET_PDS_TYPE_ACK:
+	default:
+		return sizeof(struct uet_pds_ack);
+	}
+}
+
 static int uet_pds_tx_ack_pkt(struct uet_instance *uet,
 			      struct uet_pdc *pdc,
 			      struct uet_pdc_pkt *pdc_pkt,
@@ -1917,29 +1998,31 @@ static int uet_pds_tx_ack_pkt(struct uet_instance *uet,
 			      void *ses_hdr,
 			      bool gtd_del)
 {
-	uint16_t ack_pkt_len;
 	uint16_t ack_data_len;
+	size_t pds_ack_hdr_len;
 	int rc;
 	size_t ip_hdr_size = (pdc->is_ipv6) ? sizeof(struct ipv6hdr) :
 					      sizeof(struct iphdr);
+
+	pds_ack_hdr_len = uet_pds_ack_hdr_len(uet);
 
 	if (next_hdr == UET_HDR_NONE) {
 		pdc_pkt->ack_len = (sizeof(struct ethhdr) +
 				    ip_hdr_size +
 				    sizeof(struct uet_entropy) +
-				    sizeof(struct uet_pds_ack));
+				    pds_ack_hdr_len);
 	} else if (next_hdr == UET_HDR_RSP) {
 		pdc_pkt->ack_len = (sizeof(struct ethhdr) +
 				    ip_hdr_size +
 				    sizeof(struct uet_entropy) +
-				    sizeof(struct uet_pds_ack) +
+				    pds_ack_hdr_len +
 				    sizeof(struct uet_ses_rsp));
 	} else { /* response w/ data */
 		ack_data_len = (ses_hdr_len - sizeof(struct uet_ses_rsp_d));
 		pdc_pkt->ack_len = (sizeof(struct ethhdr) +
 				    ip_hdr_size +
 				    sizeof(struct uet_entropy) +
-				    sizeof(struct uet_pds_ack) +
+				    pds_ack_hdr_len +
 				    sizeof(struct uet_ses_rsp_d) +
 				    ack_data_len);
 	}
@@ -1962,8 +2045,8 @@ static int uet_pds_tx_ack_pkt(struct uet_instance *uet,
 			: pdc_pkt->ack_buf;
 
 	/* build the ACK packet */
-	uet_pds_build_ack_pkt(uet, pdc, pdc_pkt, next_hdr,
-			      ses_hdr, ses_hdr_len);
+	uet_pds_build_ack_pkt(uet, pdc, pdc_pkt, next_hdr, ses_hdr,
+			      ses_hdr_len, pds_ack_hdr_len);
 
 	/* send the ACK packet */
 	rc = uet_pds_sec_tx_pkt(uet, pdc, pdc_pkt, false, false);
@@ -1991,14 +2074,16 @@ static int uet_pds_tx_def_rsp_ack_pkt(struct uet_instance *uet,
 	struct uet_entropy *entropy_hdr;
 	struct uet_pds_ack *ack_pds;
 	struct uet_pds_def_rsp *ack_ses;
+	size_t pds_ack_hdr_len;
 	int rc;
 	size_t ip_hdr_size = (pdc->is_ipv6) ? sizeof(struct ipv6hdr) :
 					      sizeof(struct iphdr);
 
+	pds_ack_hdr_len = uet_pds_ack_hdr_len(uet);
 	def_rsp_len = (sizeof(struct ethhdr) +
 		       ip_hdr_size +
 		       sizeof(struct uet_entropy) +
-		       sizeof(struct uet_pds_ack) +
+		       pds_ack_hdr_len +
 		       sizeof(struct uet_pds_def_rsp));
 
 	/* allocate buffer for ack packet */
@@ -2032,7 +2117,6 @@ static int uet_pds_tx_def_rsp_ack_pkt(struct uet_instance *uet,
 					 sizeof(struct ethhdr) +
 					 ip_hdr_size +
 					 sizeof(struct uet_entropy));
-	ack_ses = (struct uet_pds_def_rsp *)(ack_pds + 1);
 
 	/* TODO: UDP support */
 	entropy_hdr->entropy = htons(pdc_pkt->pkt_pp.entropy_val);
@@ -2080,6 +2164,14 @@ static int uet_pds_tx_def_rsp_ack_pkt(struct uet_instance *uet,
 	ack_pds->spdcid = htons(pdc->pdc_id);
 	ack_pds->dpdcid = htons(pdc->dpdcid);
 
+	if ((uet->pds.ack_type == UET_PDS_TYPE_ACK_CC) ||
+	    (uet->pds.ack_type == UET_PDS_TYPE_ACK_CCX)) {
+		uet_pds_build_ack_cc_ext(uet, pdc, pdc_pkt, ack_pds,
+					 uet->pds.ack_type);
+	}
+
+	ack_ses = (struct uet_pds_def_rsp *)((uint8_t *)ack_pds +
+					     pds_ack_hdr_len);
 	ack_ses->list_opcode =
 		(UET_DEFAULT_RESPONSE << UET_PDS_SES_DEF_RSP_OPCODE_SHIFT);
 	ack_ses->ver_return_code =
@@ -2225,10 +2317,12 @@ static int uet_pds_upcall_ses_rx_req(struct uet_instance *uet,
 				uet_max(pdc_pkt->pkt_pp.pkt_payload_len,
 					uet->pds.ack_gen_min_pkt_add);
 			uet_pds_update_cack(pdc, pdc_pkt);
+			uet_pds_update_sack_base(pdc, pdc_pkt, false);
 			/* transmit ACK */
 			if (uet_pds_should_sack(uet, pdc, pdc_pkt)) {
 				rc = uet_pds_tx_ack_pkt(uet, pdc, pdc_pkt,
-							rsp_next_hdr, rsp_ses_hdr_len,
+							rsp_next_hdr,
+							rsp_ses_hdr_len,
 							rsp_ses_hdr, gtd_del);
 				pdc->accepted_bytes = 0;
 			}
@@ -2325,6 +2419,40 @@ static int uet_pds_shift_tx_window(struct uet_instance *uet,
 	return 0;
 }
 
+static void uet_pds_process_sack_bitmap(struct uet_instance *uet,
+					struct uet_pdc *pdc,
+					struct uet_parsed_pkt *pp)
+{
+	struct uet_pdc_pkt *pdc_pkt;
+	uint32_t psn;
+	int i, idx;
+
+	for (i = 0; i < 64; i++) {
+		psn = pp->pds_sack_base_psn + i;
+		if (UET_PDS_PSN_AFTER_EQ(pdc->max_cack_psn, psn))
+			continue;
+
+		if (!(pp->pds_sack_bitmap & (1ULL << i)))
+			continue;
+
+		idx = UET_PDS_PSN_OFFSET(psn, pdc->tx_bm_base_psn);
+		if (idx < 0)
+			continue;
+
+		if (!bm_get(pdc->tx_bm, idx, (void **)&pdc_pkt))
+			continue;
+
+		/*
+		 * TODO How the initiator side process the sack bitmap?
+		 * When the initiator side does not konw whether the PDC ACK
+		 * packet corresponding to bit 1 requires guaranteed
+		 * transmission, it cannot directly notify the SES layer that
+		 * the PDC REQ packet corresponding to bit 1 has been delivered
+		 * to the peer.
+		 */
+	}
+}
+
 static void uet_pds_process_cack(struct uet_instance *uet,
 				 struct uet_pdc *pdc,
 				 struct uet_parsed_pkt *pp)
@@ -2417,6 +2545,10 @@ static int uet_pds_process_ack(struct uet_instance *uet,
 	pdc_pkt->tx_pkt_acked = true;
 	dlist_remove(&pdc_pkt->node); /* remove from Tx list */
 	uet_pds_process_cack(uet, pdc, pp);
+	if (pp->pds_type == UET_PDS_TYPE_ACK_CC ||
+	    pp->pds_type == UET_PDS_TYPE_ACK_CCX) {
+		uet_pds_process_sack_bitmap(uet, pdc, pp);
+	}
 
 	if (UET_LOG_LVL >= UET_LOG_DBG) {
 		UET_PDS_DBG("PDC %d tx_bm (base %u):",

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -1123,6 +1123,7 @@ static int uet_pds_initiate_pdc_close(struct uet_instance *uet,
 int uet_pds_initialize(struct uet_instance *uet)
 {
 	struct uet_pdc *pdc;
+	char *pds_ack_type;
 	int i;
 
 	/* seed random number generator for PDC close and packet drop */
@@ -1156,6 +1157,20 @@ int uet_pds_initialize(struct uet_instance *uet)
 	if (getenv("UET_PDS_PER_PKT_ACK_ENB")) {
 		uet->pds.per_pkt_ack_enabled =
 			strtoul(getenv("UET_PDS_PER_PKT_ACK_ENB"), NULL, 10);
+	}
+
+	/* configure ack type */
+	pds_ack_type = getenv("UET_PDS_ACK_TYPE");
+	if (pds_ack_type == NULL || strcmp(pds_ack_type, "ack") == 0) {
+		uet->pds.ack_type = UET_PDS_TYPE_ACK;
+	} else if (strcmp(pds_ack_type, "ack_cc") == 0) {
+		uet->pds.ack_type = UET_PDS_TYPE_ACK_CC;
+	} else if (strcmp(pds_ack_type, "ack_ccx") == 0) {
+		uet->pds.ack_type = UET_PDS_TYPE_ACK_CCX;
+	} else {
+		UET_PDS_ERR("Invalid env variable UET_PDS_ACK_TYPE=%s",
+			    pds_ack_type);
+		return -EINVAL;
 	}
 
 	memset(&pds_state, 0, sizeof(struct uet_pds_state));
@@ -1852,7 +1867,7 @@ static void uet_pds_build_ack_pkt(struct uet_instance *uet,
 	flags = (pdc_pkt->needs_clear) ? UET_PDS_ACK_FLAGS_REQ_CLR_CLS
 				       : UET_PDS_ACK_FLAGS_NONE;
 	ack_pds->prlg.type_next_flags =
-		htons((UET_PDS_TYPE_ACK << UET_PDS_TYPE_SHIFT) |
+		htons((uet->pds.ack_type << UET_PDS_TYPE_SHIFT) |
 		      (next_hdr << UET_PDS_NEXT_HDR_SHIFT) |
 		      (flags << UET_PDS_FLAGS_SHIFT));
 
@@ -2052,7 +2067,7 @@ static int uet_pds_tx_def_rsp_ack_pkt(struct uet_instance *uet,
 
 	/* TODO: add SACK header, UET_PDS_ACK_FLAGS_AX */
 	ack_pds->prlg.type_next_flags =
-		htons((UET_PDS_TYPE_ACK << UET_PDS_TYPE_SHIFT) |
+		htons((uet->pds.ack_type << UET_PDS_TYPE_SHIFT) |
 		      (UET_HDR_RSP << UET_PDS_NEXT_HDR_SHIFT) |
 		      (UET_PDS_ACK_FLAGS_NONE << UET_PDS_FLAGS_SHIFT));
 

--- a/uet_pds.h
+++ b/uet_pds.h
@@ -310,6 +310,7 @@ struct uet_pds {
 	bool per_pkt_ack_enabled;       /* true=> enable per packet ack mode */
 	uint32_t ack_gen_trigger; /* rx bytes threshold for ack triggering */
 	uint32_t ack_gen_min_pkt_add; /* min bytes per pkt add to accept_bytes */
+	uet_pds_pkt_type_t ack_type; /* UET_PDS_TYPE_ACK / ACK_CC / ACK_CCX */
 };
 
 /* initialize the PDS and set the proper downcall function pointers */

--- a/util/bitmap.c
+++ b/util/bitmap.c
@@ -208,6 +208,41 @@ void bm_shift_right(struct bitmap *bm, int s)
 		bm->data_arr[i] = NULL;
 }
 
+/*
+ * Extract 64 bits starting at index i from the bitmap.
+ * For SACK use:
+ *   - bits at positions < 0 (before bitmap start) are filled with 1
+ *   - bits at positions >= bm->size are filled with 0
+ */
+uint64_t bm_extract64(const struct bitmap *bm, int i)
+{
+	int word_idx, bit_idx, shift;
+	uint64_t lo, hi, fill_ones;
+
+	if (i >= bm->size)
+		return 0; /* could assert() here */
+
+	if (i + 64 <= 0)
+		return ~(uint64_t)0;
+
+	if (i < 0) {
+		shift = -i;
+		fill_ones = (1ULL << shift) - 1;
+		return ((bm_extract64(bm, 0) << shift) | fill_ones);
+	}
+
+	word_idx = i / 64;
+	bit_idx = i % 64;
+
+	lo = bm->bit_arr[word_idx] >> bit_idx;
+	if (bit_idx != 0 && (word_idx + 1) < bm->bit_arr_len) {
+		hi = bm->bit_arr[word_idx + 1] << (64 - bit_idx);
+		lo |= hi;
+	}
+
+	return lo;
+}
+
 bool bm_next_set_bit_iter(const struct bitmap *bm, int *i)
 {
 	uint64_t idx_val;

--- a/util/bitmap.c
+++ b/util/bitmap.c
@@ -17,7 +17,7 @@ struct bitmap *bm_create(int size)
 {
 	struct bitmap *bm = NULL;
 
-	if ((size % sizeof(uint64_t)) != 0)
+	if ((size % (sizeof(uint64_t) * 8)) != 0)
 		return NULL;
 
 	/* Allocate the bm itself. */
@@ -54,7 +54,7 @@ void bm_destroy(struct bitmap *bm)
 void bm_clear(struct bitmap *bm)
 {
 	memset(bm->bit_arr, 0, (sizeof(uint64_t) * bm->bit_arr_len));
-	memset(bm->data_arr, 0, (sizeof(void *) * bm->bit_arr_len));
+	memset(bm->data_arr, 0, (sizeof(void *) * bm->size));
 }
 
 int bm_count(const struct bitmap *bm)
@@ -307,4 +307,3 @@ void bm_print_bits(const struct bitmap *b, char (*bit_char)(void *))
 		       (idx * word_size));
 	}
 }
-

--- a/util/bitmap.h
+++ b/util/bitmap.h
@@ -27,6 +27,7 @@ int bm_min(const struct bitmap *bm); /* -1 if empty */
 int bm_max(const struct bitmap *bm); /* -1 if empty */
 void bm_shift_left(struct bitmap *bm, int s);
 void bm_shift_right(struct bitmap *bm, int s);
+uint64_t bm_extract64(const struct bitmap *bm, int start_idx);
 
 /*
  * Iterate over all the set bits:

--- a/util/uet_pkt_chk.c
+++ b/util/uet_pkt_chk.c
@@ -65,13 +65,10 @@ static bool uet_pds_pkt_type_valid(uint8_t *pkt,
 		UET_PDS_WARN("UUD_REQ packets not supported");
 		return false;
 	case UET_PDS_TYPE_ACK:
-		pds_req = false;
-		break;
 	case UET_PDS_TYPE_ACK_CC:
 	case UET_PDS_TYPE_ACK_CCX:
-		/* TODO: unsupported */
-		UET_PDS_WARN("ACK_CC packets not supported");
-		return false;
+		pds_req = false;
+		break;
 	case UET_PDS_TYPE_NACK:
 		/* TODO: unsupported */
 		UET_PDS_WARN("NACK packets not supported");

--- a/util/uet_util.c
+++ b/util/uet_util.c
@@ -1011,6 +1011,8 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 	struct uet_pds_prlg *pds_prlg;
 	struct uet_pds_req *pds_req;
 	struct uet_pds_ack *pds_ack;
+	struct uet_pds_ack_cc *pds_ack_cc;
+	struct uet_pds_ack_ccx *pds_ack_ccx;
 	struct uet_pds_nack *pds_nack;
 	struct uet_pds_ctrl *pds_ctrl;
 	struct uet_ses_req_std *ses_req;
@@ -1205,8 +1207,31 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 			       pp->pds_cack_psn);
 		pp->pds_spdcid = ntohs(pds_ack->spdcid);
 		pp->pds_dpdcid = ntohs(pds_ack->dpdcid);
+
+		if (pp->pds_type == UET_PDS_TYPE_ACK_CC ||
+		    pp->pds_type == UET_PDS_TYPE_ACK_CCX) {
+			pds_ack_cc = (struct uet_pds_ack_cc *)pp->pds;
+			pp->pds_len = sizeof(struct uet_pds_ack_cc);
+			pp->pds_cc_type = (pds_ack_cc->cc_type_flags &
+					   UET_PDS_ACK_CC_TYPE_MASK) >>
+					  UET_PDS_ACK_CC_TYPE_SHIFT;
+			pp->pds_cc_flags = (pds_ack_cc->cc_type_flags &
+					    UET_PDS_ACK_CC_FLAGS_MASK) >>
+					   UET_PDS_ACK_CC_FLAGS_SHIFT;
+			pp->pds_mpr = pds_ack_cc->mpr;
+			pp->pds_sack_base_psn =
+				((int16_t)ntohs(pds_ack_cc->sack_psn_offset) +
+				 pp->pds_cack_psn);
+			pp->pds_sack_bitmap = ntohll(pds_ack_cc->sack_bitmap);
+			pp->pds_cc_state = ntohll(pds_ack_cc->ack_cc_state);
+		}
+
+		if (pp->pds_type == UET_PDS_TYPE_ACK_CCX) {
+			pds_ack_ccx = (struct uet_pds_ack_ccx *)pp->pds;
+			pp->pds_len = sizeof(struct uet_pds_ack_ccx);
+			pp->pds_ccx_state = ntohll(pds_ack_ccx->ack_ccx_state);
+		}
 		break;
-	/* TODO: support for parsing the two extended ACK headers */
 	case UET_PDS_TYPE_NACK:
 		pds_nack = (struct uet_pds_nack *)pp->pds;
 		pp->pds_len = sizeof(struct uet_pds_nack);

--- a/util/uet_util.h
+++ b/util/uet_util.h
@@ -90,6 +90,13 @@ struct uet_parsed_pkt {
 	uint32_t pds_psn;
 	uint16_t pds_spdcid;
 	uint16_t pds_dpdcid;
+	uint8_t pds_cc_type;
+	uint8_t pds_cc_flags;
+	uint8_t pds_mpr;
+	uint32_t pds_sack_base_psn;
+	uint64_t pds_sack_bitmap;
+	uint64_t pds_cc_state;
+	uint64_t pds_ccx_state;
 	uint8_t pds_syn_off;
 	uint32_t pds_clear_psn;
 	uint8_t pds_nack_code;


### PR DESCRIPTION
1. Support encapsulation and parsing of ack_cc/ccx type ACK packets
2. Support extracting the SACK bitmap from rx_bitmap at the target side
3. Support parsing the SACK bitmap on the initiator side and obtaining information that packets have been received by the peer