### PR TITLE
uet_sec: Fix TSS deviations from spec

### DIFF
--- a/uet_sec.c
+++ b/uet_sec.c
@@ -341,7 +341,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 	/* get the epoch/tsc */
 	tsc = (sd->use_ssi) ? ntohll(sec_ssi->epoch_tsc)
 		            : ntohll(sec->epoch_tsc);
-	epoch = (uint16_t)((tsc & UET_SEC_EPOCH_MASK) >> UET_SEC_EPOCH_SHIFT);
+	epoch = htons((uint16_t)((tsc & UET_SEC_EPOCH_MASK) >> UET_SEC_EPOCH_SHIFT));
 	tsc = ((tsc & UET_SEC_TSC_MASK) >> UET_SEC_TSC_SHIFT);
 
 	/* crypto output is going in the upper half of the pkt_buf */
@@ -584,7 +584,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	/* get the epoch/tsc */
 	tsc = (sd->use_ssi) ? ntohll(sec_ssi->epoch_tsc)
 		            : ntohll(sec->epoch_tsc);
-	epoch = (uint16_t)((tsc & UET_SEC_EPOCH_MASK) >> UET_SEC_EPOCH_SHIFT);
+	epoch = htons((uint16_t)((tsc & UET_SEC_EPOCH_MASK) >> UET_SEC_EPOCH_SHIFT));
 	tsc = ((tsc & UET_SEC_TSC_MASK) >> UET_SEC_TSC_SHIFT);
 
 	/* generate the key needed for decrypting the packet */

--- a/uet_sec.c
+++ b/uet_sec.c
@@ -290,6 +290,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 	uint32_t ssi;
 	uint16_t epoch;
 	uint64_t tsc;
+	uint64_t counter; // 48b
 	uint32_t tfs;
 	uint32_t rekey;
 	uint32_t tmp_val;
@@ -342,7 +343,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 	tsc = (sd->use_ssi) ? ntohll(sec_ssi->epoch_tsc)
 		            : ntohll(sec->epoch_tsc);
 	epoch = htons((uint16_t)((tsc & UET_SEC_EPOCH_MASK) >> UET_SEC_EPOCH_SHIFT));
-	tsc = ((tsc & UET_SEC_TSC_MASK) >> UET_SEC_TSC_SHIFT);
+	counter = ((tsc & UET_SEC_TSC_MASK) >> UET_SEC_TSC_SHIFT);
 
 	/* crypto output is going in the upper half of the pkt_buf */
 	enc_out = (pkt_buf + (pkt_buf_len / 2));
@@ -360,7 +361,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 
 	rekey = 0;
 	if (sd->rekey) {
-		rekey = (uint32_t)((tsc & sd->rekey_mask) >> sd->rekey_shift);
+		rekey = (uint32_t)((counter & sd->rekey_mask) >> sd->rekey_shift);
 		rekey = htonl(rekey);
 	}
 
@@ -518,6 +519,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	uint64_t tmp_lval;
 	uint16_t epoch;
 	uint64_t tsc;
+	uint64_t counter; // 48b
 	uint8_t an;
 	uint32_t sdi;
 	uint32_t tfs;
@@ -585,7 +587,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	tsc = (sd->use_ssi) ? ntohll(sec_ssi->epoch_tsc)
 		            : ntohll(sec->epoch_tsc);
 	epoch = htons((uint16_t)((tsc & UET_SEC_EPOCH_MASK) >> UET_SEC_EPOCH_SHIFT));
-	tsc = ((tsc & UET_SEC_TSC_MASK) >> UET_SEC_TSC_SHIFT);
+	counter = ((tsc & UET_SEC_TSC_MASK) >> UET_SEC_TSC_SHIFT);
 
 	/* generate the key needed for decrypting the packet */
 
@@ -593,7 +595,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 
 	rekey = 0;
 	if (sd->rekey) {
-		rekey = (uint32_t)((tsc & sd->rekey_mask) >> sd->rekey_shift);
+		rekey = (uint32_t)((counter & sd->rekey_mask) >> sd->rekey_shift);
 		rekey = htonl(rekey);
 	}
 


### PR DESCRIPTION
This PR addresses 2 deviations from the spec that were found in `uet_sec.c`.

---

## 1. KDF context `epoch` endianness

### What the spec says

UE Specification v1.0.2 §3.7.8.4 ("KDF Examples") gives worked examples with
explicit byte strings. For the IPv4 cluster, ssi-mode=FALSE case:

```
TSC from packet = 0x1DC074E500000023
Epoch           = 0x1DC0
Rekey           = 0x000074E5
Context4        = 0x1dc0 000074e5 c0a82a01
                    ^^^^ epoch is big-endian
Kdf_fixed4      = 0x5531 00 1dc0 000074e5 c0a82a01 0160
SDK             = 0x151b4ddb30112971ddeff3213000ee74d8f18aac2135601f1e5215e505fed449
IVMask          = 0xa7c6992c26b0bd5dd5c20e0c
```

Both `epoch` and `rekey` appear big-endian (MSB first) in the context.

### What the vector generator does (correct)

`crypto/test/test_uec_kdf.c` byte-swaps **both** fields before placing them in
the context:

```c
rekey = htonl(rekey);            /* big-endian */
epoch = htons(epoch);            /* big-endian */
...
memcpy(context,       (uint8_t *)&epoch, 2);
memcpy((context + 2), (uint8_t *)&rekey, 4);
memcpy((context + 6), ipv4, 4);
```

This reproduces the spec's `Context4 = 0x1dc0000074e5c0a82a01` exactly, and the
file states the outputs were verified against NIST CAVP vectors.

### What the datapath does (bug)

`uet_sec.c` byte-swaps `rekey` but **not** `epoch`:

```c
epoch = (uint16_t)((tsc & UET_SEC_EPOCH_MASK) >> UET_SEC_EPOCH_SHIFT);
...
rekey = htonl(rekey);                          /* big-endian */
...
memcpy(small_context,       (uint8_t *)&epoch, 2);   /* HOST-endian, no htons */
memcpy((small_context + 2), (uint8_t *)&rekey, 4);
memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
```

`epoch` is a host `uint16_t` copied raw. On a little-endian host this writes
`0xc0 0x1d` into the context instead of `0x1d 0xc0`, so the derived SDK and
IVMask differ from both the spec examples and the vector generator.

### Why the test suite still passes

The bug survives because the test and the buggy code are in different files
and never meet:

- `test_uec_kdf.c` calls the KDF **primitive** (`kdf_ctr_cmac_aes()`)
  directly and builds the context itself with `htons(epoch)` — so it tests a
  *correctly-built* context against the CAVP vectors, and passes.
- `uet_sec.c` is the **datapath** that builds the context for real packets,
  with the raw `memcpy(&epoch)` (no `htons`). Nothing routes `uet_sec.c`'s
  context construction through the vectors.

A regression test that drives `uet_sec.c`'s encrypt path end-to-end and checks
the derived key (or full ciphertext) against a spec vector would have caught
this.

---

## 2. IV `tss.tsc` field — datapath strips the epoch

### What the spec says

UE Spec v1.0.2 Table 3-90 ("IV Construction") describes the IV as
`tss.ssi || tss.tsc` (and `ip.src_addr || tss.tsc`, `tss.sdi || tss.tsc`),
with an explicit note:

> The tss.tsc field referenced in this table is the concatenation of the
> tss.tsc.epoch and tss.tsc.counter fields shown in the TSS header diagrams.

So the IV's low 64 bits are the **full 64-bit `epoch||counter`** field — the
same value that appears on the wire in the TSS header.

### What the datapath does (bug)

`uet_sec.c` strips the epoch before building the IV, leaving the 16-bit epoch
slot zero:

```c
epoch = (uint16_t)((tsc & UET_SEC_EPOCH_MASK) >> UET_SEC_EPOCH_SHIFT);
tsc   = ((tsc & UET_SEC_TSC_MASK) >> UET_SEC_TSC_SHIFT);   /* 48-bit counter */
...
tmp_lval = htonll(tsc);
memcpy((iv + 4), (uint8_t *)&tmp_lval, 8);                 /* IV[4:5] == 0x0000 */
```

This contradicts the Table 3-90 note: the two differ in IV bytes [4:5] (the
epoch). As with deviation 1, this lives in the
untested datapath; there is no IV vector test that would catch it.