### PR TITLE
add uet_mr_derive() for derived memory regions

### DIFF
--- a/uet_api.c
+++ b/uet_api.c
@@ -6464,8 +6464,8 @@ int uet_mr_reg(uet_domain_handle_t domain_handle, const void *buf, size_t len,
 }
 
 int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
-	       size_t iov_count, uint64_t access, uint64_t requested_key,
-		   uint64_t flags, void *context, uet_mr_handle_t *mr_handle)
+		size_t iov_count, uint64_t access, uint64_t requested_key,
+		uint64_t flags, void *context, uet_mr_handle_t *mr_handle)
 {
 	int rc;
 	uint64_t key, rkey;
@@ -6559,6 +6559,42 @@ int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
 	*mr_handle = mr_desc;
 
 	return FI_SUCCESS;
+}
+
+/*
+ * Register a derived memory region that is wholly contained within an
+ * existing (parent) region. A derived region shares the parent's domain
+ * and may carry different access rights. This reference implementation
+ * registers the sub-range as an independent region. A vendor may instead
+ * share the parent's page mappings (derived regions are an optional
+ * optimization).
+ */
+int uet_mr_derive(uet_domain_handle_t domain_handle,
+		  uet_mr_handle_t parent_mr_handle,
+		  const void *buf, size_t len, uint64_t access,
+		  uint64_t requested_key, void *context,
+		  uet_mr_handle_t *mr_handle)
+{
+	struct uet_mr_desc *parent = (struct uet_mr_desc *) parent_mr_handle;
+	const uint8_t *pbase, *cbase;
+
+	if ((parent == NULL) ||
+	    (parent->buf_desc.type != UET_MR_BUF_TYPE_CONTIG)) {
+		UET_API_ERR("derived MR parent must be a contiguous region");
+		return -FI_EINVAL;
+	}
+
+	pbase = parent->buf_desc.buf;
+	cbase = buf;
+
+	if ((cbase < pbase) ||
+	    ((cbase + len) > (pbase + parent->buf_desc.len))) {
+		UET_API_ERR("derived MR must be contained in the parent region");
+		return -FI_EINVAL;
+	}
+
+	return uet_mr_reg(domain_handle, buf, len, access, requested_key,
+			  UET_FLAGS_NONE, context, mr_handle);
 }
 
 uint64_t uet_mr_key(uet_mr_handle_t mr_handle)

--- a/uet_api.h
+++ b/uet_api.h
@@ -244,8 +244,8 @@ int uet_mr_reg(uet_domain_handle_t domain_handle, const void *buf, size_t len,
  *     - fi_mr_reg
  */
 int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
-	       size_t iov_count, uint64_t access, uint64_t requested_key,
-		   uint64_t flags, void *context, uet_mr_handle_t *mr_handle);
+		size_t iov_count, uint64_t access, uint64_t requested_key,
+		uint64_t flags, void *context, uet_mr_handle_t *mr_handle);
 
 /*
  * flexible api to register a memory region with a domain
@@ -275,6 +275,30 @@ int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
 int uet_mr_regattr(uet_domain_handle_t domain_handle, uint32_t job_id,
 		   const struct fi_mr_attr *attr, uint64_t flags,
 		   uet_mr_handle_t *mr_handle);
+
+/*
+ * register a derived memory region contained within an existing region
+ *
+ * parms:
+ *   domain_handle     - handle identifying uet domain instance
+ *   parent_mr_handle  - handle of the existing (parent) memory region
+ *   buf               - start of the derived region (within the parent)
+ *   len               - length of the derived region
+ *   access            - operations supported for the derived region
+ *   requested_key     - requested key (UET_MR_KEY_NONE for provider key)
+ *   context           - user specified context associated with the region
+ *   mr_handle         - ptr to location where the derived region handle
+ *                       is returned
+ *
+ * returns:
+ *   0 on success,
+ *   negative value corresponding to fabric errno on error
+ */
+int uet_mr_derive(uet_domain_handle_t domain_handle,
+		  uet_mr_handle_t parent_mr_handle,
+		  const void *buf, size_t len, uint64_t access,
+		  uint64_t requested_key, void *context,
+		  uet_mr_handle_t *mr_handle);
 
 /*
  * get memory region protection key


### PR DESCRIPTION
New API to register a memory region wholly contained within an existing (parent) region, sharing the parent's domain and optionally carrying different access rights. This reference implementation registers the sub-range as an independent region after validating containment.