### PR TITLE
support registration of job-restricted memory regions

### DIFF
--- a/uet_api.c
+++ b/uet_api.c
@@ -2128,6 +2128,7 @@ struct uet_mr_desc *uet_get_mr_desc(struct uet_ep *uet_ep,
 	struct uet_domain *uet_dom;
 	struct uet_mr_desc *mr_desc;
 	struct uet_mr_key mr_key;
+	struct uet_ses_req_std *ses;
 
 	uet_dom = uet_ep->uet_domain;
 	uet_mr_key_init(&mr_key, pp);
@@ -2141,6 +2142,18 @@ struct uet_mr_desc *uet_get_mr_desc(struct uet_ep *uet_ep,
 		}
 	} else
 		mr_desc = uet_mr_hash_lookup(uet_ep, &mr_key);
+
+	/* Enforce job-restricted access as a region bound to a JobID may only
+	 * be accessed by requests within that job.
+	 */
+	if (mr_desc && mr_desc->job_restricted) {
+		ses = (struct uet_ses_req_std *)pp->ses;
+
+		if (mr_desc->job_id != uet_get_std_req_job_id(ses)) {
+			UET_API_ERR("MR access denied: JobID mismatch");
+			mr_desc = NULL;
+		}
+	}
 
 	return mr_desc;
 }
@@ -6595,6 +6608,29 @@ int uet_mr_derive(uet_domain_handle_t domain_handle,
 
 	return uet_mr_reg(domain_handle, buf, len, access, requested_key,
 			  UET_FLAGS_NONE, context, mr_handle);
+}
+
+/*
+ * Register a memory region restricted to a specific JobID. Only incoming
+ * requests within that job are allowed to access the region.
+ */
+int uet_mr_reg_job(uet_domain_handle_t domain_handle, const void *buf,
+		   size_t len, uint64_t access, uint64_t requested_key,
+		   uint64_t flags, uint32_t job_id, void *context,
+		   uet_mr_handle_t *mr_handle)
+{
+	int rc;
+
+	rc = uet_mr_reg(domain_handle, buf, len, access, requested_key,
+			flags, context, mr_handle);
+	if (rc == FI_SUCCESS) {
+		struct uet_mr_desc *mr_desc = (struct uet_mr_desc *) *mr_handle;
+
+		mr_desc->job_id = job_id;
+		mr_desc->job_restricted = true;
+	}
+
+	return rc;
 }
 
 uint64_t uet_mr_key(uet_mr_handle_t mr_handle)

--- a/uet_api.h
+++ b/uet_api.h
@@ -301,6 +301,29 @@ int uet_mr_derive(uet_domain_handle_t domain_handle,
 		  uet_mr_handle_t *mr_handle);
 
 /*
+ * register a memory region restricted to a specific JobID
+ *
+ * parms:
+ *   domain_handle - handle identifying uet domain instance
+ *   buf           - start of the region
+ *   len           - length of the region
+ *   access        - operations supported for the region
+ *   requested_key - requested key (UET_MR_KEY_NONE for provider key)
+ *   flags         - registration flags
+ *   job_id        - JobID the region is restricted to
+ *   context       - user specified context associated with the region
+ *   mr_handle     - ptr to location where the region handle is returned
+ *
+ * returns:
+ *   0 on success,
+ *   negative value corresponding to fabric errno on error
+ */
+int uet_mr_reg_job(uet_domain_handle_t domain_handle, const void *buf,
+		   size_t len, uint64_t access, uint64_t requested_key,
+		   uint64_t flags, uint32_t job_id, void *context,
+		   uet_mr_handle_t *mr_handle);
+
+/*
  * get memory region protection key
  *
  * parms:

--- a/uet_api_private.h
+++ b/uet_api_private.h
@@ -175,6 +175,8 @@ struct uet_mr_desc {
 	uint64_t full_key;                      /* full key for memory region */
 	uint64_t access;            /* operations supported for memory region */
 	uint64_t flags;                        /* properties of memory region */
+	uint32_t job_id;                 /* JobID the region is restricted to */
+	bool job_restricted;               /* region is restricted to a JobID */
 	void *context;                                      /* for completion */
 	struct uet_mr_key hash_key;                     /* key for hash entry */
 	UT_hash_handle mr_hh;                     /* handle for hash function */


### PR DESCRIPTION
Add uet_mr_reg_job() API to register a memory region bound to a JobID, and verify the binding on the receive path (using the JobID carried on the wire).