### PR TITLE
report the SourceID (SES initiator) on receive completions

### DIFF
--- a/uet_api.c
+++ b/uet_api.c
@@ -1708,6 +1708,9 @@ static void uet_rx_cq_read_entry(void *buf, struct uet_ring *ring)
 
 	memcpy(buf, ring_entry->cq_entry, uet_ep->recv_cq.format_size);
 
+	/* stash the SourceID so it can be read alongside the completion */
+	uet_ep->recv_cq.last_src_id = ring_entry->src_id;
+
 	uet_rx_desc_list_insert(ring_entry->desc.rx);
 
 	uet_ring_tail_advance(ring);
@@ -1778,6 +1781,7 @@ static void uet_rx_cq_post_entry(struct uet_rx_desc *rx_desc)
 	ring_entry = &(((struct uet_cq_ring_entry *) (ring->base))[ring->head]);
 	memset(ring_entry, 0, ring->entry_size);
 	ring_entry->desc.rx = rx_desc;
+	ring_entry->src_id = rx_desc->src_id;
 
 	cq_entry = (struct fi_cq_tagged_entry *) ring_entry->cq_entry;
 	cq_entry->op_context = rx_desc->context;
@@ -3259,6 +3263,9 @@ static uet_ses_rc_t uet_rx_req_pkt(
 				     buf_off);
 		memcpy(buf_ptr, pp->payload, pp->ses_payload_len);
 	}
+
+	/* capture the initiator (SourceID) to report on the completion */
+	rx_desc->src_id = ntohl(ses->initiator);
 
 	/* check for message completion */
 	rx_desc->remaining_bytes -= pp->ses_payload_len;
@@ -6099,6 +6106,13 @@ int uet_ep_close(uet_ep_handle_t ep_handle)
 	uet_ep_free(uet_ep);
 
 	return FI_SUCCESS;
+}
+
+uint32_t uet_cq_read_src_id(uet_cq_handle_t cq_handle)
+{
+	struct uet_cq *cq = (struct uet_cq *) cq_handle;
+
+	return cq->last_src_id;
 }
 
 ssize_t uet_cq_read(uet_cq_handle_t cq_handle, void *buf, size_t count)

--- a/uet_api.h
+++ b/uet_api.h
@@ -777,6 +777,17 @@ ssize_t uet_cq_read(uet_cq_handle_t cq_handle, void *buf,
 		    size_t count);
 
 /*
+ * get the initiator (SourceID) of the most recently read completion
+ *
+ * parms:
+ *   cq_handle - handle identifying uet completion queue instance
+ *
+ * returns:
+ *   the SES initiator value of the last entry read via uet_cq_read
+ */
+uint32_t uet_cq_read_src_id(uet_cq_handle_t cq_handle);
+
+/*
  * non-blocking read of completion queue error
  *
  * parms:

--- a/uet_api_private.h
+++ b/uet_api_private.h
@@ -258,6 +258,7 @@ struct uet_rx_desc {
 	UT_hash_handle tag_hh;                /* handle for tag hash function */
 	struct uet_mr_desc *mr_desc;          /* ptr to mr desc if applicable */
 	uint64_t imm_data;                        /* data for write immediate */
+	uint32_t src_id;                   /* initiator (SourceID) of the msg */
 	struct uet_ep *uet_ep;             /* endpoint msg is associated with */
 	time_t prev_pkt_time;     /* time most recent pkt of msg was received */
 	struct uet_tx_desc *tx_desc;     /* associated tx descriptor for read */
@@ -564,6 +565,7 @@ struct uet_cq_ring_entry {
 		struct uet_rx_desc *rx;
 		struct uet_tx_desc *tx;
 	} desc;
+	uint32_t src_id; /* initiator (SourceID); valid for rx entries */
 	/* err entry is largest cq entry format */
 	uint8_t cq_entry[sizeof(struct fi_cq_err_entry)];
 };
@@ -579,6 +581,7 @@ struct uet_cq {
 	enum fi_cq_format format;                  /* format of entries in cq */
 	size_t format_size;             /* size of each entry in cq, in bytes */
 	struct uet_ring ring;           /* ring implementing completion queue */
+	uint32_t last_src_id;     /* SourceID of the most recently read entry */
 };
 
 /* endpoint control block */


### PR DESCRIPTION
Capture the request's SES initiator into the rx descriptor and carry it through the completion ring entry so it can be reported per completion. Add a new uet_cq_read_src_id() API to return the initiator of the most recently read completion.