### PR TITLE
added the uet_ep_reset() API for verbs QP error recovery

### DIFF
--- a/uet_api.c
+++ b/uet_api.c
@@ -6160,6 +6160,23 @@ int uet_ep_enable(uet_ep_handle_t ep_handle)
 	return FI_SUCCESS;
 }
 
+int uet_ep_reset(uet_ep_handle_t ep_handle)
+{
+	struct uet_ep *uet_ep;
+
+	uet_ep = (struct uet_ep *) ep_handle;
+
+	/* Teturn the endpoint to the pre-enable state and clear the transient
+	 * generation state so a subsequent uet_ep_enable() gives a clean,
+	 * usable endpoint (verbs QP error recovery: ERR -> RST -> RTS).
+	 */
+	uet_ep->ep_state = UET_EP_DISABLED;
+	uet_ep->untagged_gen_disabled = false;
+	uet_ep->tagged_gen_disabled = false;
+
+	return FI_SUCCESS;
+}
+
 int uet_ep_close(uet_ep_handle_t ep_handle)
 {
 	struct uet_ep *uet_ep;

--- a/uet_api.h
+++ b/uet_api.h
@@ -675,6 +675,19 @@ int uet_ep_bind_mr(uet_ep_handle_t ep_handle,
 int uet_ep_enable(uet_ep_handle_t ep_handle);
 
 /*
+ * reset an endpoint back to the pre-enable (disabled) state so it can be
+ * re-enabled, e.g. to recover a verbs QP through the ERR -> RST -> RTS path
+ *
+ * parms:
+ *   ep_handle - handle identifying uet endpoint instance
+ *
+ * returns:
+ *   0 on success,
+ *   negative value corresponding to fabric errno on error
+ */
+int uet_ep_reset(uet_ep_handle_t ep_handle);
+
+/*
  * cancel a pending asynchronous data transfer
  *
  * parms:


### PR DESCRIPTION
Reset an enabled endpoint back to the disabled state and clear the transient generation-disabled flags so it can be cleanly re-enabled. Backs the verbs QP ERR -> RST -> RTS recovery path.