### PR TITLE
support dynamic IPv4/IPv6 dual-stack support

### DIFF
--- a/nic_shim/nic_rawsock.c
+++ b/nic_shim/nic_rawsock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Broadcom. All rights reserved. The term
+ * Copyright (c) 2024,2025,2026 Broadcom. All rights reserved. The term
  * Broadcom refers to Broadcom Limited and/or its subsidiaries.
  */
 
@@ -236,24 +236,11 @@ int nic_rawsock_initialize(struct uet_nic *nic)
 					       nic->ipv6_addr,
 					       nic->ipv6_addr_str) == 0);
 
-	if (nic->is_ipv6) {
-		if (!nic->has_ipv6) {
-			UET_API_ERR("Error: IPv6 requested but no IPv6 address");
-			rc = -ENODEV;
-			goto err_return;
-		}
-
-		memcpy(nic->ip_addr.v6, nic->ipv6_addr, 16);
-		strncpy(nic->ip_addr_str, nic->ipv6_addr_str, INET6_ADDRSTRLEN);
-	} else {
-		if (!nic->has_ipv4) {
-			UET_API_ERR("Error: IPv4 requested but no IPv4 address");
-			rc = -ENODEV;
-			goto err_return;
-		}
-
-		nic->ip_addr.v4 = nic->ipv4_addr;
-		strncpy(nic->ip_addr_str, nic->ipv4_addr_str, INET_ADDRSTRLEN);
+	/* dual-stack: both families are kept, require at least one address */
+	if (!nic->has_ipv4 && !nic->has_ipv6) {
+		UET_API_ERR("Error: interface has no IPv4 or IPv6 address");
+		rc = -ENODEV;
+		goto err_return;
 	}
 
 	/* get mac address of interface */

--- a/nic_shim/nic_xdp.c
+++ b/nic_shim/nic_xdp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Broadcom. All rights reserved. The term
+ * Copyright (c) 2024,2025,2026 Broadcom. All rights reserved. The term
  * Broadcom refers to Broadcom Limited and/or its subsidiaries.
  */
 
@@ -873,24 +873,11 @@ int nic_xdp_initialize(struct uet_nic *nic)
 					       nic->ipv6_addr,
 					       nic->ipv6_addr_str) == 0);
 
-	if (nic->is_ipv6) {
-		if (!nic->has_ipv6) {
-			UET_API_ERR("ERROR: IPv6 requested but no IPv6 address");
-			rc = -ENODEV;
-			goto exit_err;
-		}
-
-		memcpy(nic->ip_addr.v6, nic->ipv6_addr, 16);
-		strncpy(nic->ip_addr_str, nic->ipv6_addr_str, INET6_ADDRSTRLEN);
-	} else {
-		if (!nic->has_ipv4) {
-			UET_API_ERR("ERROR: IPv4 requested but no IPv4 address");
-			rc = -ENODEV;
-			goto exit_err;
-		}
-
-		nic->ip_addr.v4 = nic->ipv4_addr;
-		strncpy(nic->ip_addr_str, nic->ipv4_addr_str, INET_ADDRSTRLEN);
+	/* dual-stack: both families are kept, require at least one address */
+	if (!nic->has_ipv4 && !nic->has_ipv6) {
+		UET_API_ERR("ERROR: interface has no IPv4 or IPv6 address");
+		rc = -ENODEV;
+		goto exit_err;
 	}
 
 	/* get the MAC address of the interface */

--- a/nic_shim/uet_nic.c
+++ b/nic_shim/uet_nic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Broadcom. All rights reserved. The term
+ * Copyright (c) 2024,2025,2026 Broadcom. All rights reserved. The term
  * Broadcom refers to Broadcom Limited and/or its subsidiaries.
  */
 
@@ -350,13 +350,9 @@ extern int nic_xdp_initialize(struct uet_nic *nic);
 #endif
 
 /* init nic resources */
-int uet_nic_initialize(struct uet_nic *nic,
-		       bool is_ipv6)
+int uet_nic_initialize(struct uet_nic *nic)
 {
 	char *nic_shim;
-
-	/* set IP version before calling shim-specific initializer */
-	nic->is_ipv6 = is_ipv6;
 
 	/* get interface name from environment variable */
 	nic_shim = getenv(UET_NIC_SHIM);

--- a/nic_shim/uet_nic.h
+++ b/nic_shim/uet_nic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Broadcom. All rights reserved. The term
+ * Copyright (c) 2024,2025,2026 Broadcom. All rights reserved. The term
  * Broadcom refers to Broadcom Limited and/or its subsidiaries.
  */
 
@@ -54,18 +54,18 @@ struct uet_nic {
 	uint8_t mac_addr[ETH_ALEN];
 	char mac_addr_str[ETH_ALEN*3];
 
-	/* v4/v6 local addresses - both populated at init if available */
-	uint32_t ipv4_addr;
+	/*
+	 * Dual-stack: Both the IPv4 and IPv6 local addresses are populated at
+	 * init (whichever are present). The address family is selected per
+	 * destination/packet at runtime, so there is no single active family.
+	 */
+	uint32_t ipv4_addr;                            /* host order */
 	char ipv4_addr_str[INET_ADDRSTRLEN];
 	bool has_ipv4;
 	uint8_t ipv6_addr[16];
 	char ipv6_addr_str[INET6_ADDRSTRLEN];
 	bool has_ipv6;
 
-	/* active address for this session (set by upper layer) */
-	struct uet_fa ip_addr;                         /* host order */
-	bool is_ipv6;                          /* true if using IPv6 */
-	char ip_addr_str[INET6_ADDRSTRLEN];            /* local addr */
 	char dst_ip_addr_str[INET6_ADDRSTRLEN];  /* destination addr */
 	char nh_ip_addr_str[INET6_ADDRSTRLEN];      /* next hop addr */
 
@@ -173,14 +173,15 @@ int uet_nic_resolve_ipv6_nh(struct uet_nic *nic,
  *
  * parms:
  *      uet - ptr to uet nic struct
- *      is_ipv6 - initialize for IPv6
+ *
+ * Discovers both IPv4 and IPv6 local addresses (whichever are present);
+ * the address family is selected per destination/packet at runtime.
  *
  * returns:
  *      0 on success
  *      negative value corresponding to errno on error
  */
-int uet_nic_initialize(struct uet_nic *nic,
-		       bool is_ipv6);
+int uet_nic_initialize(struct uet_nic *nic);
 
 /*
  * free nic resources

--- a/scripts/uet_test.sh
+++ b/scripts/uet_test.sh
@@ -31,8 +31,12 @@ shim_names=(rawsock xdp)
 # (not for sng) default ACK type: ack, ack_cc, ack_ccx
 ACK_TYPE=ack_cc
 
-# (not for sng) default Tx timeout (in millisecs) and max Tx retries
+# (not for sng) default Tx timeout (in millisecs) and max Tx retries.
+# Security (TSS) runs use a longer timeout because the crypto path adds
+# per-packet latency that can trip the aggressive default and cause
+# spurious retransmits.
 TX_TIMEOUT=5
+TX_TIMEOUT_SEC=10
 MAX_TX_RETRIES=5
 
 function usage()
@@ -157,12 +161,20 @@ if [ -n "$UET_IMPAIRMENT_SHIM" ]; then
     IMP_SHIM="UET_IMPAIRMENT_SHIM=${UET_IMPAIRMENT_SHIM}"
 fi
 
-CMD_BASE="LD_LIBRARY_PATH=${LIBFABRIC}:. UET_IFNAME=${iface} UET_NIC_SHIM=${shim} UET_PDS_ACK_TYPE=${ACK_TYPE} UET_PDS_TX_TIMEOUT=${TX_TIMEOUT} UET_PDS_MAX_TX_RETRIES=${MAX_TX_RETRIES} ${IMP_SHIM} ./${app_name}"
+CMD_BASE="LD_LIBRARY_PATH=${LIBFABRIC}:. UET_IFNAME=${iface} UET_NIC_SHIM=${shim} UET_PDS_ACK_TYPE=${ACK_TYPE} UET_PDS_MAX_TX_RETRIES=${MAX_TX_RETRIES} ${IMP_SHIM} ./${app_name}"
 
 function run_test()
 {
-    echo sudo $1
-    eval sudo $1 || { rc=$?; echo -e "\nERROR: Test failed!\n"; exit $rc; }
+    # TSS runs (UET_SEC_MODE set) use a longer Tx timeout since the crypto
+    # path adds per-packet latency.
+    local timeout=$TX_TIMEOUT
+    if [[ "$1" == *UET_SEC_MODE* ]]; then
+        timeout=$TX_TIMEOUT_SEC
+    fi
+
+    local cmd="UET_PDS_TX_TIMEOUT=$timeout $1"
+    echo sudo $cmd
+    eval sudo $cmd || { rc=$?; echo -e "\nERROR: Test failed!\n"; exit $rc; }
 }
 
 function sng()

--- a/uet.c
+++ b/uet.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Broadcom. All rights reserved. The term
+ * Copyright (c) 2024,2025,2026 Broadcom. All rights reserved. The term
  * Broadcom refers to Broadcom Limited and/or its subsidiaries.
  */
 
@@ -463,6 +463,7 @@ static uet_rc_t uet_init_transport(struct uet_context *ctx)
 	void *context = NULL;
 	struct fi_info *hints = NULL, *info;
 	struct uet_addr *uet_addr;
+	struct uet_addr src_node;
 	uet_rc_t rc = UET_ERR_RC;
 	ssize_t remaining_size;
 
@@ -470,7 +471,7 @@ static uet_rc_t uet_init_transport(struct uet_context *ctx)
 	if (!ctx->cfg.client)
 		setenv(UET_SEC_SERVER, "1", 1);
 
-	ret = uet_initialize(&ctx->uet_handle, ctx->cfg.is_ipv6);
+	ret = uet_initialize(&ctx->uet_handle);
 	if (ret) {
 		UET_ERR("uet_initialize: %s", fi_strerror(-ret));
 		goto exit;
@@ -491,7 +492,11 @@ static uet_rc_t uet_init_transport(struct uet_context *ctx)
 	else
 		hints->caps |= FI_MSG;
 
-	ret = uet_getinfo(ctx->uet_handle, NULL, hints, &ctx->info);
+	/* dual-stack: tell the library which address family this run uses */
+	memset(&src_node, 0, sizeof(src_node));
+	src_node.flags = ctx->cfg.is_ipv6 ? UET_ADDR_IPV6 : UET_ADDR_IPV4;
+
+	ret = uet_getinfo(ctx->uet_handle, &src_node, hints, &ctx->info);
 	if (ret) {
 		UET_ERR("uet_getinfo: %s", fi_strerror(-ret));
 		goto exit;

--- a/uet_api.c
+++ b/uet_api.c
@@ -5552,7 +5552,7 @@ err:
  * Below functions implement UET APIs
  *********************************************************************/
 
-int uet_initialize(uet_handle_t *handle, bool is_ipv6)
+int uet_initialize(uet_handle_t *handle)
 {
 	int rc;
 	time_t seed;
@@ -5593,7 +5593,7 @@ int uet_initialize(uet_handle_t *handle, bool is_ipv6)
 		goto err_return;
 
 	UET_NIC(uet)->uet_ipproto = uet->uet_ipproto;
-	rc = uet_nic_initialize(UET_NIC(uet), is_ipv6);
+	rc = uet_nic_initialize(UET_NIC(uet));
 	if (rc != FI_SUCCESS)
 		goto err_return;
 
@@ -5601,7 +5601,7 @@ int uet_initialize(uet_handle_t *handle, bool is_ipv6)
 	if (rc != 0)
 		goto err_imp_shim;
 
-	rc = uet_sec_init(&uet->nic.ip_addr, is_ipv6);
+	rc = uet_sec_init(&uet->nic);
 	if (rc != FI_SUCCESS)
 		goto err_sec;
 
@@ -5660,6 +5660,8 @@ int uet_getinfo(uet_handle_t handle, struct uet_addr *node,
 	struct fi_info *new_info;
 	struct fid_nic *nic = NULL;
 	struct uet_addr *src_addr;
+	struct uet_fa def_ip;
+	bool def_ipv6;
 
 	uet = (struct uet_instance *) handle;
 
@@ -5750,7 +5752,27 @@ int uet_getinfo(uet_handle_t handle, struct uet_addr *node,
 		rc = -FI_ENOMEM;
 		goto err_return;
 	}
-	uet_init_uet_addr(src_addr, &uet->nic.ip_addr, uet->nic.is_ipv6);
+
+	/*
+	 * Dual-stack: select the local address family. If the caller
+	 * supplies a node address (non-VERBS path), honor its family.
+	 * Otherwise default to an available family (prefer IPv4). On the
+	 * VERBS path the per-endpoint family is (re)bound in uet_endpoint()
+	 * from the QP's local GID, so the advertised address here is only
+	 * a placeholder.
+	 */
+	if (node)
+		def_ipv6 = uet_addr_is_ipv6(node);
+	else
+		def_ipv6 = (!uet->nic.has_ipv4 && uet->nic.has_ipv6);
+
+	memset(&def_ip, 0, sizeof(def_ip));
+	if (def_ipv6)
+		memcpy(def_ip.v6, uet->nic.ipv6_addr, 16);
+	else
+		def_ip.v4 = uet->nic.ipv4_addr;
+
+	uet_init_uet_addr(src_addr, &def_ip, def_ipv6);
 
 	new_info->dest_addrlen = 0;
 	new_info->src_addrlen = sizeof(struct uet_addr);
@@ -5896,7 +5918,7 @@ int uet_endpoint(uet_domain_handle_t domain_handle,
 		 void *context, uet_ep_handle_t *ep_handle,
 		 uint16_t pid_on_fep, uint16_t resource_index,
 		 uint32_t initiator_id, uint32_t job_id,
-		 bool absolute)
+		 bool absolute, bool is_ipv6)
 #else
 int uet_endpoint(uet_domain_handle_t domain_handle,
 		 struct fi_info *info, struct fid_ep *ep,
@@ -5935,6 +5957,17 @@ int uet_endpoint(uet_domain_handle_t domain_handle,
 	uet_ep->absolute = absolute;
 	if (absolute)
 		uet_ep->uet_addr.flags |= UET_ADDR_ABSOLUTE_MODE;
+
+	/* dual-stack: bind the endpoint to the specified address family */
+	uet_ep->uet_addr.flags &= ~(UET_ADDR_IPV4 | UET_ADDR_IPV6);
+	memset(&uet_ep->uet_addr.fa, 0, sizeof(struct uet_fa));
+	if (is_ipv6) {
+		uet_ep->uet_addr.flags |= UET_ADDR_IPV6;
+		memcpy(uet_ep->uet_addr.fa.v6, uet_dom->uet->nic.ipv6_addr, 16);
+	} else {
+		uet_ep->uet_addr.flags |= UET_ADDR_IPV4;
+		uet_ep->uet_addr.fa.v4 = uet_dom->uet->nic.ipv4_addr;
+	}
 #else
 	rc = uet_addr_resolution(&uet_ep->uet_addr, &uet_ep->job_id);
 	if (rc != FI_SUCCESS) {

--- a/uet_api.h
+++ b/uet_api.h
@@ -90,13 +90,12 @@ typedef void (*uet_eq_err_callback_t)(uet_handle_t handle,
  *
  * parms:
  *   handle - ptr to location where uet instance handle is returned
- *   is_ipv6 - initialize for IPv6
  *
  * returns:
  *   0 on success,
  *   negative value corresponding to fabric errno on error
  */
-int uet_initialize(uet_handle_t *handle, bool is_ipv6);
+int uet_initialize(uet_handle_t *handle);
 
 /*
  * free resources of uet instance
@@ -456,7 +455,7 @@ int uet_endpoint(uet_domain_handle_t domain_handle,
 		 void *context, uet_ep_handle_t *ep_handle,
 		 uint16_t pid_on_fep, uint16_t resource_index,
 		 uint32_t initiator_id, uint32_t job_id,
-		 bool absolute);
+		 bool absolute, bool is_ipv6);
 #endif
 
 /*

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Broadcom. All rights reserved. The term
+ * Copyright (c) 2024,2025,2026 Broadcom. All rights reserved. The term
  * Broadcom refers to Broadcom Limited and/or its subsidiaries.
  */
 
@@ -447,7 +447,8 @@ static int uet_pds_sec_tx_pkt(struct uet_instance *uet,
 			     *pkt,
 			     *pkt_len,
 			     &new_pkt,
-			     &new_pkt_len);
+			     &new_pkt_len,
+			     pdc->is_ipv6);
 	if (rc != 0)
 		return rc;
 
@@ -625,8 +626,17 @@ static struct uet_pdc *uet_pdsm_assign_ini_pdc(struct uet_ep *uet_ep,
 {
 	struct uet_pdc_ini_key pdc_key;
 	struct uet_pdc *pdc;
+	struct uet_nic *nic = &uet_ep->uet_domain->uet->nic;
+	bool dst_is_ipv6 = uet_addr_is_ipv6(av_entry->addr);
+	struct uet_fa local_ip;
 
 	PDS_GO();
+
+	memset(&local_ip, 0, sizeof(local_ip));
+	if (dst_is_ipv6)
+		memcpy(local_ip.v6, nic->ipv6_addr, 16);
+	else
+		local_ip.v4 = nic->ipv4_addr;
 
 	/* get the PDC if it already exists */
 	memset(&pdc_key, 0, sizeof(pdc_key));
@@ -635,7 +645,7 @@ static struct uet_pdc *uet_pdsm_assign_ini_pdc(struct uet_ep *uet_ep,
 						     PDC_TYPE_NONE);
 	pdc_key.job_id = uet_ep->job_id;
 	pdc_key.tc = UET_DEFAULT_TC;
-	memcpy(&pdc_key.src_ip, &uet_ep->ip_addr, sizeof(struct uet_fa));
+	memcpy(&pdc_key.src_ip, &local_ip, sizeof(struct uet_fa));
 	memcpy(&pdc_key.dst_ip, &av_entry->addr->fa, sizeof(struct uet_fa));
 
 	HASH_FIND(pdc_ini_hh, pds_state.pdc_ini_ht, &pdc_key,
@@ -673,9 +683,9 @@ static struct uet_pdc *uet_pdsm_assign_ini_pdc(struct uet_ep *uet_ep,
 	memcpy(pdc->dst_mac_addr, av_entry->nh_mac_addr,
 	       ETH_ALEN);
 
-	memcpy(&pdc->src_addr, &uet_ep->ip_addr, sizeof(struct uet_fa));
+	memcpy(&pdc->src_addr, &local_ip, sizeof(struct uet_fa));
 	memcpy(&pdc->dst_addr, &av_entry->addr->fa, sizeof(struct uet_fa));
-	pdc->is_ipv6 = uet_addr_is_ipv6(av_entry->addr);
+	pdc->is_ipv6 = dst_is_ipv6;
 
 	pdc->next_psn       = UET_DEFAULT_START_PSN;
 	pdc->tx_bm_base_psn = UET_DEFAULT_START_PSN;

--- a/uet_pds_sng.c
+++ b/uet_pds_sng.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Broadcom. All rights reserved. The term
+ * Copyright (c) 2024,2025,2026 Broadcom. All rights reserved. The term
  * Broadcom refers to Broadcom Limited and/or its subsidiaries.
  */
 
@@ -87,6 +87,14 @@ static bool uet_pds_ep_tx_active(struct uet_ep *uet_ep)
 	return pds_state->tx.tx_active;
 }
 
+/* determine the address family from a received frame's ethertype */
+static inline bool uet_pkt_is_ipv6(const void *pkt)
+{
+	const struct ethhdr *eth = (const struct ethhdr *)pkt;
+
+	return (eth->h_proto == htons(ETH_P_IPV6));
+}
+
 /* determine if pkt is destined for endpoint */
 static bool uet_pds_ep_addr_match(
 	struct uet_ep *uet_ep, void *pkt, bool pkt_is_ack,
@@ -98,22 +106,21 @@ static bool uet_pds_ep_addr_match(
 		(struct uet_pds_sng_state *)uet_ep->pds;
 	struct uet_rx_desc *rx_desc;
 	struct uet_instance *uet = uet_ep->uet_domain->uet;
-	bool is_ipv6 = uet->nic.is_ipv6;
+	bool is_ipv6 = uet_pkt_is_ipv6(pkt);
 	size_t ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr) :
 					 sizeof(struct iphdr);
 
-	/* check destination IP address match */
 	if (is_ipv6) {
 		struct ipv6hdr *ipv6 =
 			(struct ipv6hdr *)((uint8_t *)pkt +
 					   sizeof(struct ethhdr));
-		if (memcmp(&ipv6->daddr, uet_ep->ip_addr.v6, 16) != 0)
+		if (memcmp(&ipv6->daddr, uet->nic.ipv6_addr, 16) != 0)
 			return false;
 	} else {
 		struct iphdr *ipv4 =
 			(struct iphdr *)((uint8_t *)pkt +
 					 sizeof(struct ethhdr));
-		if (ntohl(ipv4->daddr) != uet_ep->ip_addr.v4)
+		if (ntohl(ipv4->daddr) != uet->nic.ipv4_addr)
 			return false;
 	}
 
@@ -241,7 +248,7 @@ static bool uet_pds_is_dup_req(struct uet_ep *uet_ep, void *pkt,
 	struct uet_pds_sng_state *pds_state =
 		(struct uet_pds_sng_state *) uet_ep->pds;
 	struct uet_instance *uet = uet_ep->uet_domain->uet;
-	bool is_ipv6 = uet->nic.is_ipv6;
+	bool is_ipv6 = uet_pkt_is_ipv6(pkt);
 	size_t ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr) :
 					 sizeof(struct iphdr);
 	/* PDS spdcid offset from start of packet */
@@ -341,7 +348,7 @@ static void uet_pds_build_ack_pkt(struct uet_instance *uet, void *pkt,
 				  uet_pds_next_hdr_t next_hdr,
 				  size_t ses_hdr_len, void *ses_hdr)
 {
-	bool is_ipv6 = uet->nic.is_ipv6;
+	bool is_ipv6 = uet_pkt_is_ipv6(pkt);
 	size_t ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr) :
 					 sizeof(struct iphdr);
 	void *ack_ip = (uint8_t *)ack + sizeof(struct ethhdr);
@@ -441,7 +448,7 @@ static int uet_pds_tx_ack_pkt(struct uet_ep *uet_ep, void *pkt,
 	size_t ip_hdr_size;
 
 	uet = uet_ep->uet_domain->uet;
-	is_ipv6 = uet->nic.is_ipv6;
+	is_ipv6 = uet_pkt_is_ipv6(pkt);
 	ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr) :
 				  sizeof(struct iphdr);
 
@@ -527,7 +534,7 @@ static int uet_pds_tx_err_ack_pkt(struct uet_instance *uet,
 	struct uet_ses_req_std *pkt_ses;
 	uint32_t crc;
 	uint8_t *crc_start;
-	bool is_ipv6 = uet->nic.is_ipv6;
+	bool is_ipv6 = pp->is_ipv6;
 	size_t ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr) :
 					 sizeof(struct iphdr);
 
@@ -668,7 +675,7 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt,
 	av_entry = (struct uet_av_entry *) dst_addr_handle;
 	dst_addr = av_entry->addr;
 	state = &pds_state->tx;
-	is_ipv6 = uet->nic.is_ipv6;
+	is_ipv6 = uet_addr_is_ipv6(dst_addr);
 	ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr) :
 				  sizeof(struct iphdr);
 
@@ -745,7 +752,7 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt,
 						   ip_hdr_size));
 		uet_build_ipv6_hdr(uet, (struct ipv6hdr *)ip_hdr,
 				   dst_addr->fa.v6,
-				   uet_ep->ip_addr.v6,
+				   uet->nic.ipv6_addr,
 				   payload_len, tos, true);
 	} else {
 		uint16_t tot_len = (uint16_t)(pkt_len +
@@ -753,7 +760,7 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt,
 					       uet->nic.l2_hdr_size));
 		uet_build_ipv4_hdr(uet, (struct iphdr *)ip_hdr,
 				   htonl(dst_addr->fa.v4),
-				   htonl(uet_ep->ip_addr.v4),
+				   htonl(uet->nic.ipv4_addr),
 				   tot_len, tos, true);
 	}
 

--- a/uet_sec.c
+++ b/uet_sec.c
@@ -16,6 +16,9 @@
 #include "gcm.h"
 
 #define UET_SEC_MAX_SD         8
+#define UET_SEC_FAM_V4         0
+#define UET_SEC_FAM_V6         1
+#define UET_SEC_FAM(is_ipv6)   ((is_ipv6) ? UET_SEC_FAM_V6 : UET_SEC_FAM_V4)
 #define UET_SEC_KEY_SIZE       32
 #define UET_SEC_KDF_GEN_SIZE   44
 #define UET_SEC_CTR_SIZE       8
@@ -43,12 +46,12 @@ struct uet_sec_sd {
 	bool           rekey;
 	uint64_t       rekey_mask;
 	uint8_t        rekey_shift;
-	int16_t        aoff;
 	uint16_t       coff;
 	uet_sec_alg_t  alg;
 	uint16_t       epoch;
 	uint8_t        an;
-	uint8_t        key[2][UET_SEC_KDF_GEN_SIZE];
+	/* [family][an] - per-family key material (aoff derived from family) */
+	uint8_t        key[2][2][UET_SEC_KDF_GEN_SIZE];
 };
 
 static struct uet_sec_sd sdkdb[UET_SEC_MAX_SD];
@@ -86,7 +89,7 @@ static uint8_t def_key[2][UET_SEC_KDF_GEN_SIZE] = {
 #define DEF_REKEY_SHIFT 32
 #define DEF_AOFF_V4     -12 /* AAD src/dest IPv4 (8) + entropy (4) */
 #define DEF_AOFF_V6     -36 /* AAD src/dest IPv6 (32) + entropy (4) */
-#define DEF_AOFF        DEF_AOFF_V4
+#define UET_SEC_AOFF(is_ipv6) ((is_ipv6) ? DEF_AOFF_V6 : DEF_AOFF_V4)
 #define DEF_COFF        12 /* sizeof security header, +4 if using SSI */
 
 static uint8_t fep_key[2][UET_SEC_KEY_SIZE] = {
@@ -270,7 +273,8 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 		    uint8_t *pkt,
 		    int pkt_len,
 		    uint8_t **enc_pkt,
-		    int *enc_pkt_len)
+		    int *enc_pkt_len,
+		    bool is_ipv6)
 {
 	uint8_t derived_key[UET_SEC_KDF_GEN_SIZE];
 	uint8_t small_context[UET_SEC_SMALL_CTX_SIZE];
@@ -296,7 +300,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 	uint32_t tmp_val;
 	uint64_t tmp_lval;
 	int i, rc, clrtxt_len;
-	bool is_ipv6 = uet->nic.is_ipv6;
+	int fam = UET_SEC_FAM(is_ipv6);
 
 	if (is_ipv6)
 		ipv6 = (struct ipv6hdr *)(pkt + sizeof(struct ethhdr));
@@ -367,7 +371,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 
 	switch (sd->mode) {
 	case UET_SEC_MODE_DIRECT:
-		memcpy(derived_key, sd->key[an], UET_SEC_KEY_SIZE);
+		memcpy(derived_key, sd->key[fam][an], UET_SEC_KEY_SIZE);
 		break;
 
 	case UET_SEC_MODE_CLUSTER:
@@ -377,7 +381,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 			memcpy((large_context + 6), (uint8_t *)&rekey, 4);
 			memcpy((large_context + 10), &ipv6->saddr, 16);
 
-			kdf_ctr_cmac_aes(sd->key[an],
+			kdf_ctr_cmac_aes(sd->key[fam][an],
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label1,
@@ -393,7 +397,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 			tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
 			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
 
-			kdf_ctr_cmac_aes(sd->key[an],
+			kdf_ctr_cmac_aes(sd->key[fam][an],
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label1,
@@ -409,7 +413,8 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 	case UET_SEC_MODE_SERVER:
 		/* in client/server mode the client operates in direct mode */
 		if (!getenv(UET_SEC_SERVER)) {
-			memcpy(derived_key, sd->key[an], UET_SEC_KDF_GEN_SIZE);
+			memcpy(derived_key, sd->key[fam][an],
+			       UET_SEC_KDF_GEN_SIZE);
 			break;
 		}
 
@@ -418,7 +423,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 			memcpy((large_context + 4), (uint8_t *)&epoch, 2);
 			memcpy((large_context + 10), &ipv6->daddr, 16);
 
-			kdf_ctr_cmac_aes(sd->key[an],
+			kdf_ctr_cmac_aes(sd->key[fam][an],
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label2,
@@ -433,7 +438,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 			tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->daddr;
 			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
 
-			kdf_ctr_cmac_aes(sd->key[sd->an],
+			kdf_ctr_cmac_aes(sd->key[fam][sd->an],
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label2,
@@ -454,7 +459,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 
 	/* encrypt the packet */
 
-	aad = (sec_hdr + sd->aoff); /* likely negative and moves backwards */
+	aad = (sec_hdr + UET_SEC_AOFF(is_ipv6)); /* likely negative, moves back */
 
 	tmp_val = (sd->use_ssi) ? sec_ssi->ssi :
 				  (is_ipv6) ? htonl(sdi) : ipv4->saddr;
@@ -524,9 +529,21 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	uint32_t sdi;
 	uint32_t tfs;
 	int i, rc, clrtxt_len;
-	bool is_ipv6 = uet->nic.is_ipv6;
+	int fam;
+	bool is_ipv6;
 
 	eth = (struct ethhdr *)pkt;
+
+	if (eth->h_proto == htons(ETH_P_IPV6)) {
+		is_ipv6 = true;
+	} else if (eth->h_proto == htons(ETH_P_IP)) {
+		is_ipv6 = false;
+	} else {
+		*tag_len = 0;
+		return 0;
+	}
+
+	fam = UET_SEC_FAM(is_ipv6);
 
 	/* do some preliminary sanity checks */
 	if (is_ipv6) {
@@ -601,7 +618,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 
 	switch (sd->mode) {
 	case UET_SEC_MODE_DIRECT:
-		memcpy(derived_key, sd->key[an], UET_SEC_KEY_SIZE);
+		memcpy(derived_key, sd->key[fam][an], UET_SEC_KEY_SIZE);
 		break;
 
 	case UET_SEC_MODE_CLUSTER:
@@ -611,7 +628,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 			memcpy((large_context + 6), (uint8_t *)&rekey, 4);
 			memcpy((large_context + 10), &ipv6->saddr, 16);
 
-			kdf_ctr_cmac_aes(sd->key[an],
+			kdf_ctr_cmac_aes(sd->key[fam][an],
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label1,
@@ -627,7 +644,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 			tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
 			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
 
-			kdf_ctr_cmac_aes(sd->key[an],
+			kdf_ctr_cmac_aes(sd->key[fam][an],
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label1,
@@ -643,7 +660,8 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	case UET_SEC_MODE_SERVER:
 		/* in client/server mode the client operates in direct mode */
 		if (!getenv(UET_SEC_SERVER)) {
-			memcpy(derived_key, sd->key[an], UET_SEC_KDF_GEN_SIZE);
+			memcpy(derived_key, sd->key[fam][an],
+			       UET_SEC_KDF_GEN_SIZE);
 			break;
 		}
 
@@ -652,7 +670,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 			memcpy((large_context + 4), (uint8_t *)&epoch, 2);
 			memcpy((large_context + 10), &ipv6->saddr, 16);
 
-			kdf_ctr_cmac_aes(sd->key[an],
+			kdf_ctr_cmac_aes(sd->key[fam][an],
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label2,
@@ -667,7 +685,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 			tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
 			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
 
-			kdf_ctr_cmac_aes(sd->key[sd->an],
+			kdf_ctr_cmac_aes(sd->key[fam][sd->an],
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label2,
@@ -688,7 +706,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 
 	/* decrypt the packet */
 
-	aad = (sec_hdr + sd->aoff); /* likely negative and moves backwards */
+	aad = (sec_hdr + UET_SEC_AOFF(is_ipv6)); /* likely negative, moves back */
 
 	tmp_val = (sd->use_ssi) ? sec_ssi->ssi :
 				  (is_ipv6) ? htonl(sdi) : ipv4->saddr;
@@ -726,19 +744,71 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	return 0;
 }
 
-static int uet_sec_init_sd(uint32_t sdi,
-			   uet_sec_mode_t mode,
-			   bool use_ssi,
-			   bool rekey,
-			   struct uet_fa *local_ip,
-			   bool is_ipv6)
+/*
+ * Derive the client-side server-mode keys for one address family. Each
+ * family's keys are derived from that family's local address (IPv4) or the
+ * SSI, so a dual-stack SD derives both families' key material independently
+ * into sd->key[fam][an].
+ */
+static void uet_sec_derive_family_keys(struct uet_sec_sd *sd,
+				       int fam,
+				       const struct uet_fa *local_ip)
 {
 	uint8_t derived_key[UET_SEC_KDF_GEN_SIZE];
 	uint8_t small_context[UET_SEC_SMALL_CTX_SIZE];
 	uint8_t large_context[UET_SEC_LARGE_CTX_SIZE];
-	struct uet_sec_sd *sd;
 	char *client_ssi;
 	uint32_t tmp_val;
+	int an;
+	uint16_t epoch = htons(sd->epoch);
+
+	for (an = 0; an < 2; an++) {
+		if (fam == UET_SEC_FAM_V6) {
+			memset(large_context, 0, sizeof(large_context));
+			memcpy((large_context + 4), (uint8_t *)&epoch, 2);
+			memcpy((large_context + 10), local_ip->v6, 16);
+
+			kdf_ctr_cmac_aes(sd->key[fam][an],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label2,
+					 strlen(uet_sec_label2), /* ignore delimiter */
+					 large_context,
+					 UET_SEC_LARGE_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+		} else {
+			memset(small_context, 0, sizeof(small_context));
+			memcpy(small_context, (uint8_t *)&epoch, 2);
+			/* use SSI if available, otherwise use IPv4 */
+			client_ssi = getenv(UET_SEC_SSI);
+			tmp_val = (client_ssi)
+				? htonl(strtoul(client_ssi, NULL, 10))
+				: htonl(local_ip->v4);
+			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
+
+			kdf_ctr_cmac_aes(sd->key[fam][an],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label2,
+					 strlen(uet_sec_label2), /* ignore delimiter */
+					 small_context,
+					 UET_SEC_SMALL_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+		}
+
+		memcpy(sd->key[fam][an], derived_key, UET_SEC_KDF_GEN_SIZE);
+	}
+}
+
+static int uet_sec_init_sd(uint32_t sdi,
+			   uet_sec_mode_t mode,
+			   bool use_ssi,
+			   bool rekey,
+			   struct uet_nic *nic)
+{
+	struct uet_sec_sd *sd;
 
 	if (sdi >= UET_SEC_MAX_SD) {
 		UET_TSS_ERR("invalid SDI %u\n", sdi);
@@ -753,23 +823,26 @@ static int uet_sec_init_sd(uint32_t sdi,
 	sd->mode        = mode;
 	sd->use_ssi     = use_ssi;
 	sd->rekey       = rekey;
-
-	/* IPv6 with direct or client/server mode requires the SSI */
-	if (is_ipv6 && !use_ssi && ((mode == UET_SEC_MODE_DIRECT) ||
-				    (mode == UET_SEC_MODE_SERVER))) {
-		UET_TSS_ERR("IPv6 MODE_DIRECT requires SSI\n");
-		memset(sd, 0, sizeof(*sd));
-		return -EINVAL;
-	}
-
 	sd->rekey_mask  = DEF_REKEY_MASK;
 	sd->rekey_shift = DEF_REKEY_SHIFT;
-	sd->aoff        = is_ipv6 ? DEF_AOFF_V6 : DEF_AOFF_V4;
 	sd->coff        = (use_ssi) ? (DEF_COFF + 4) : DEF_COFF;
 	sd->alg         = UET_SEC_ALG_AES_GCM_256;
 	sd->epoch       = 1; /* FIXME: init/roll epoch */
 	sd->an          = 0;
-	memcpy(sd->key, def_key, sizeof(def_key));
+
+	/* seed both families with the default key */
+	memcpy(sd->key[UET_SEC_FAM_V4], def_key, sizeof(def_key));
+	memcpy(sd->key[UET_SEC_FAM_V6], def_key, sizeof(def_key));
+
+	/*
+	 * IPv6 with direct or client/server mode requires the SSI. Under
+	 * dual-stack this is a per-family limitation, not a fatal error: warn
+	 * and leave IPv6 security unavailable so IPv4 is unaffected.
+	 */
+	if (nic->has_ipv6 && !use_ssi &&
+	    ((mode == UET_SEC_MODE_DIRECT) || (mode == UET_SEC_MODE_SERVER)))
+		UET_TSS_WARN("IPv6 secure mode requires SSI; IPv6 security "
+			     "unavailable (IPv4 unaffected)\n");
 
 	/*
 	 * For the client side of server mode, do the KDFs now (no exchange).
@@ -777,78 +850,32 @@ static int uet_sec_init_sd(uint32_t sdi,
 	 * server and there is an exchange where the server gives each client
 	 * a key to use in direct mode which is a derivation from the server
 	 * key using the client's SSI.
+	 *
+	 * Dual-stack: derive each available family's keys independently from
+	 * that family's local address. IPv6 requires the SSI.
 	 */
 	if ((mode == UET_SEC_MODE_SERVER) && !getenv(UET_SEC_SERVER)) {
-		if (is_ipv6) {
-			memset(large_context, 0, sizeof(large_context));
-			memcpy((large_context + 4), (uint8_t *)&sd->epoch, 2);
-			memcpy((large_context + 10), local_ip->v6, 16);
+		if (nic->has_ipv4) {
+			struct uet_fa fa;
+			memset(&fa, 0, sizeof(fa));
+			fa.v4 = nic->ipv4_addr;
+			uet_sec_derive_family_keys(sd, UET_SEC_FAM_V4, &fa);
+		}
 
-			kdf_ctr_cmac_aes(sd->key[0],
-					 (UET_SEC_KEY_SIZE * 8),
-					 UET_SEC_CTR_SIZE,
-					 (uint8_t *)uet_sec_label2,
-					 strlen(uet_sec_label2), /* ignore delimiter */
-					 large_context,
-					 UET_SEC_LARGE_CTX_SIZE,
-					 derived_key,
-					 (UET_SEC_KDF_GEN_SIZE * 8));
-
-			memcpy(sd->key[0], derived_key, UET_SEC_KDF_GEN_SIZE);
-
-			kdf_ctr_cmac_aes(sd->key[1],
-					 (UET_SEC_KEY_SIZE * 8),
-					 UET_SEC_CTR_SIZE,
-					 (uint8_t *)uet_sec_label2,
-					 strlen(uet_sec_label2), /* ignore delimiter */
-					 large_context,
-					 UET_SEC_LARGE_CTX_SIZE,
-					 derived_key,
-					 (UET_SEC_KDF_GEN_SIZE * 8));
-
-			memcpy(sd->key[1], derived_key, UET_SEC_KDF_GEN_SIZE);
-		} else {
-			memset(small_context, 0, sizeof(small_context));
-			memcpy(small_context, (uint8_t *)&sd->epoch, 2);
-			/* use SSI if available, otherwise use IPv4 */
-			client_ssi = getenv(UET_SEC_SSI);
-			tmp_val = (client_ssi)
-				? htonl(strtoul(client_ssi, NULL, 10))
-				: htonl(local_ip->v4);
-			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
-
-			kdf_ctr_cmac_aes(sd->key[0],
-					 (UET_SEC_KEY_SIZE * 8),
-					 UET_SEC_CTR_SIZE,
-					 (uint8_t *)uet_sec_label2,
-					 strlen(uet_sec_label2), /* ignore delimiter */
-					 small_context,
-					 UET_SEC_SMALL_CTX_SIZE,
-					 derived_key,
-					 (UET_SEC_KDF_GEN_SIZE * 8));
-
-			memcpy(sd->key[0], derived_key, UET_SEC_KDF_GEN_SIZE);
-
-			kdf_ctr_cmac_aes(sd->key[1],
-					 (UET_SEC_KEY_SIZE * 8),
-					 UET_SEC_CTR_SIZE,
-					 (uint8_t *)uet_sec_label2,
-					 strlen(uet_sec_label2), /* ignore delimiter */
-					 small_context,
-					 UET_SEC_SMALL_CTX_SIZE,
-					 derived_key,
-					 (UET_SEC_KDF_GEN_SIZE * 8));
-
-			memcpy(sd->key[1], derived_key, UET_SEC_KDF_GEN_SIZE);
+		if (nic->has_ipv6 && use_ssi) {
+			struct uet_fa fa;
+			memset(&fa, 0, sizeof(fa));
+			memcpy(fa.v6, nic->ipv6_addr, 16);
+			uet_sec_derive_family_keys(sd, UET_SEC_FAM_V6, &fa);
 		}
 	}
 
 	return 0;
 }
 
-int uet_sec_init(struct uet_fa *local_ip, bool is_ipv6)
+int uet_sec_init(struct uet_nic *nic)
 {
-	char *sec, *sec_mode, *sec_ssi;
+	char *sec_mode, *sec_ssi;
 	int i, rc;
 
 	memset(sdkdb, 0, sizeof(sdkdb));
@@ -864,27 +891,19 @@ int uet_sec_init(struct uet_fa *local_ip, bool is_ipv6)
 
 	/* FIXME: Only using SDI=0x1 AN=0x0 for now... */
 
-	if ((sec_mode == NULL) || (strcmp(sec_mode, "direct") == 0)) {
-
-		/* IPv6 with direct mode requires the SSI */
-		if (is_ipv6 && (sec_ssi == NULL)) {
-			UET_TSS_ERR("UET_SEC_SSI required for IPv6 direct mode");
-			return -EINVAL;
-		}
+	if (strcmp(sec_mode, "direct") == 0) {
 
 		rc = uet_sec_init_sd(DEF_SDI, UET_SEC_MODE_DIRECT,
-				     (sec_ssi != NULL), false,
-				     local_ip, is_ipv6);
+				     (sec_ssi != NULL), false, nic);
 
 	} else if (strcmp(sec_mode, "cluster") == 0) {
 
 		rc = uet_sec_init_sd(DEF_SDI, UET_SEC_MODE_CLUSTER,
-				     (sec_ssi != NULL), true,
-				     local_ip, is_ipv6);
+				     (sec_ssi != NULL), true, nic);
 
 	} else if (strcmp(sec_mode, "server") == 0) {
 
-		/* this implemention requires the SSI for IPv4 and IPv6 */
+		/* this implementation requires the SSI for IPv4 and IPv6 */
 
 		if (sec_ssi == NULL) {
 			UET_TSS_ERR("UET_SEC_SSI required for server mode");
@@ -898,8 +917,7 @@ int uet_sec_init(struct uet_fa *local_ip, bool is_ipv6)
 		}
 
 		rc = uet_sec_init_sd(DEF_SDI, UET_SEC_MODE_SERVER,
-				     true, false,
-				     local_ip, is_ipv6);
+				     true, false, nic);
 
 	} else {
 

--- a/uet_sec.h
+++ b/uet_sec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Broadcom. All rights reserved. The term
+ * Copyright (c) 2024,2025,2026 Broadcom. All rights reserved. The term
  * Broadcom refers to Broadcom Limited and/or its subsidiaries.
  */
 
@@ -65,7 +65,8 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 		    uint8_t *pkt,
 		    int pkt_len,
 		    uint8_t **enc_pkt,
-		    int *enc_pkt_len);
+		    int *enc_pkt_len,
+		    bool is_ipv6);
 
 /*
  * Decryption occurs inplace. The length of the tag is returned so the
@@ -76,6 +77,10 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 		    int pkt_len,
 		    int *tag_len);
 
-int uet_sec_init(struct uet_fa *local_ip,
-		 bool is_ipv6);
+/*
+ * Initialize the security domain(s). Dual-stack: the SD holds per-family key
+ * material (keyed on each of the NIC's local v4/v6 addresses) selected per
+ * packet at enc/dec time, so a single wire SDI serves both families.
+ */
+int uet_sec_init(struct uet_nic *nic);
 


### PR DESCRIPTION
Library is no longer bound to an IP family type in uet_initialize(). Now the library is dual-stack and can handle either family type simultaneously as packets are processed. The family type is now specified on the endpoint in uet_endpoint() (i.e., verbs QP).

Fix a pre-existing TSS server-mode bug. The client pre-derived its key with the epoch in host order while the runtime uses network order, so keys never matched.

scripts/uet_test.sh now uses a longer Tx timeout for TSS runs, since the crypto path adds latency that trips the aggressive default.