### PR TITLE
Added support for RUDI to the PDS layer

### DIFF
--- a/scripts/uet_test.sh
+++ b/scripts/uet_test.sh
@@ -24,7 +24,7 @@ if [ -z "$LIBFABRIC" ]; then
 fi
 
 # Valid "test", "pds", and "shim" names
-test_names=(all rma sync_rma atomic sync_atomic tag tag_any_src unexp_untag unexp_tag defer_send defer_tag defer_tag_any_src)
+test_names=(all rma rudi sync_rma atomic sync_atomic tag tag_any_src unexp_untag unexp_tag defer_send defer_tag defer_tag_any_src)
 pds_names=(all sng pds pds_direct pds_cluster pds_cluster_ssi pds_server_ssi)
 shim_names=(rawsock xdp)
 
@@ -34,9 +34,13 @@ ACK_TYPE=ack_cc
 # (not for sng) default Tx timeout (in millisecs) and max Tx retries.
 # Security (TSS) runs use a longer timeout because the crypto path adds
 # per-packet latency that can trip the aggressive default and cause
-# spurious retransmits.
+# spurious retransmits. Impairment-shim runs use a longer timeout still: the
+# shim's userspace Tx queue/thread adds enough round-trip latency that the
+# default RTO would fire on merely-slow (not lost) packets, causing a
+# spurious-retransmit storm.
 TX_TIMEOUT=5
 TX_TIMEOUT_SEC=10
+TX_TIMEOUT_IMP=100
 MAX_TX_RETRIES=5
 
 function usage()
@@ -140,6 +144,16 @@ if [ $valid_shim -eq 0 ]; then
     usage
 fi
 
+# RUDI is a delivery mode, not a distinct app test. The 'rudi' test runs the
+# existing 'rma' write/read exchange but forces the RUDI delivery mode via
+# UET_FORCE_RUDI. It requires the 'pds' backend (sng rejects RUDI).
+app_test=$test
+FORCE_RUDI=""
+if [ "$test" = rudi ]; then
+    app_test=rma
+    FORCE_RUDI="UET_FORCE_RUDI=1"
+fi
+
 banner()
 {
     echo ""
@@ -161,15 +175,21 @@ if [ -n "$UET_IMPAIRMENT_SHIM" ]; then
     IMP_SHIM="UET_IMPAIRMENT_SHIM=${UET_IMPAIRMENT_SHIM}"
 fi
 
-CMD_BASE="LD_LIBRARY_PATH=${LIBFABRIC}:. UET_IFNAME=${iface} UET_NIC_SHIM=${shim} UET_PDS_ACK_TYPE=${ACK_TYPE} UET_PDS_MAX_TX_RETRIES=${MAX_TX_RETRIES} ${IMP_SHIM} ./${app_name}"
+CMD_BASE="LD_LIBRARY_PATH=${LIBFABRIC}:. UET_IFNAME=${iface} UET_NIC_SHIM=${shim} UET_PDS_ACK_TYPE=${ACK_TYPE} UET_PDS_MAX_TX_RETRIES=${MAX_TX_RETRIES} ${FORCE_RUDI} ${IMP_SHIM} ./${app_name}"
 
 function run_test()
 {
     # TSS runs (UET_SEC_MODE set) use a longer Tx timeout since the crypto
-    # path adds per-packet latency.
+    # path adds per-packet latency. Impairment-shim runs use a longer one
+    # still (shim queue/thread latency); it dominates, so check it last.
     local timeout=$TX_TIMEOUT
+
     if [[ "$1" == *UET_SEC_MODE* ]]; then
         timeout=$TX_TIMEOUT_SEC
+    fi
+
+    if [[ "$1" == *UET_IMPAIRMENT_SHIM* ]]; then
+        timeout=$TX_TIMEOUT_IMP
     fi
 
     local cmd="UET_PDS_TX_TIMEOUT=$timeout $1"
@@ -177,18 +197,30 @@ function run_test()
     eval sudo $cmd || { rc=$?; echo -e "\nERROR: Test failed!\n"; exit $rc; }
 }
 
+# When the full 'all' suite runs on a reliable PDS backend, also exercise
+# the RUDI delivery mode. A forced RUDI RMA WRITE/READ pass used the
+# RUDI PDS engine and an IDEMPOTENT_SAFE MR. This cannot be run using the
+# sng backend.
+function rudi_pass()
+{
+    [ "$test" = all ] || return 0
+    banner "RUDI (forced) $1"
+    run_test "$1 UET_FORCE_RUDI=1 $CMD_BASE $actor rma $peer_ip"
+}
+
 function sng()
 {
     UET_DEFS="UET_PDS=sng"
     banner "SNG $test"
-    run_test "$UET_DEFS $CMD_BASE $actor $test $peer_ip"
+    run_test "$UET_DEFS $CMD_BASE $actor $app_test $peer_ip"
 }
 
 function pds()
 {
     UET_DEFS="UET_PDS=pds"
     banner "PDS $test"
-    run_test "$UET_DEFS $CMD_BASE $actor $test $peer_ip"
+    run_test "$UET_DEFS $CMD_BASE $actor $app_test $peer_ip"
+    rudi_pass "$UET_DEFS"
 }
 
 function pds_direct()
@@ -199,14 +231,16 @@ function pds_direct()
         UET_DEFS="$UET_DEFS UET_SEC_SSI=$ssi"
     fi
     banner "PDS w/ SEC=direct $test"
-    run_test "$UET_DEFS $CMD_BASE $actor $test $peer_ip"
+    run_test "$UET_DEFS $CMD_BASE $actor $app_test $peer_ip"
+    rudi_pass "$UET_DEFS"
 }
 
 function pds_cluster()
 {
     UET_DEFS="UET_PDS=pds UET_SEC_MODE=cluster"
     banner "PDS w/ SEC=cluster $test"
-    run_test "$UET_DEFS $CMD_BASE $actor $test $peer_ip"
+    run_test "$UET_DEFS $CMD_BASE $actor $app_test $peer_ip"
+    rudi_pass "$UET_DEFS"
 }
 
 function pds_cluster_ssi()
@@ -214,7 +248,8 @@ function pds_cluster_ssi()
     UET_DEFS="UET_PDS=pds UET_SEC_MODE=cluster"
     UET_SSI_DEFS="UET_SEC_SSI=$ssi"
     banner "PDS w/ SEC=cluster (SSI) $test"
-    run_test "$UET_DEFS $UET_SSI_DEFS $CMD_BASE $actor $test $peer_ip"
+    run_test "$UET_DEFS $UET_SSI_DEFS $CMD_BASE $actor $app_test $peer_ip"
+    rudi_pass "$UET_DEFS $UET_SSI_DEFS"
 }
 
 function pds_server_ssi()
@@ -222,7 +257,8 @@ function pds_server_ssi()
     UET_DEFS="UET_PDS=pds UET_SEC_MODE=server"
     UET_SSI_DEFS="UET_SEC_SSI=$ssi UET_SEC_CLIENT_SSI=$CLI_SSI"
     banner "PDS w/ SEC=server (SSI) $test"
-    run_test "$UET_DEFS $UET_SSI_DEFS $CMD_BASE $actor $test $peer_ip"
+    run_test "$UET_DEFS $UET_SSI_DEFS $CMD_BASE $actor $app_test $peer_ip"
+    rudi_pass "$UET_DEFS $UET_SSI_DEFS"
 }
 
 if [ $pds = all -o $pds = sng             ]; then sng;             fi

--- a/uet.c
+++ b/uet.c
@@ -126,12 +126,13 @@ struct uet_cfg {
 	bool tag;                              /* true => use tagged messages */
 	bool tag_any_src;          /* true => tagged buffers match any source */
 	bool rma;                               /* true => use rma operations */
+	bool rudi;                              /* true => RMA data over RUDI */
 	bool sync_rma;               /* true => use sync group rma operations */
 	bool atomic;                         /* true => use atomic operations */
 	bool sync_atomic;         /* true => use sync group atomic operations */
 	bool unexpected_msg_test;  /* true => this is unexpected message test */
-	bool dsend_test;			/* true => this is dsend test */
-	bool iov_test;				     /* true => test uses iov */
+	bool dsend_test;                        /* true => this is dsend test */
+	bool iov_test;                               /* true => test uses iov */
 	int num_iterations;                 /* number of messages to exchange */
 	size_t msg_size;                         /* size of messages in bytes */
 	char *peer_ip_addr_string;             /* peer ip addr in string form */
@@ -321,6 +322,12 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 
 	ctx->cfg.prog_name = argv[0];
 
+	/* When RUDI is forced (using UET_FORCE_RUDI), RMA carries the bulk
+	 * data over RUDI (idempotent DDP) and once that completes, signals
+	 * completion with a separate WRITE w/ Imm over RUD.
+	 */
+	ctx->cfg.rudi = (getenv("UET_FORCE_RUDI") != NULL);
+
 	if (argc == 4) {
 		if (strcmp(argv[2], "tag") != 0) {
 			if ((strcmp(argv[2], "rma") != 0) &&
@@ -371,7 +378,8 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 		       UET_ADDR_RELATIVE_MODE |
 		       (ctx->cfg.is_ipv6 ? UET_ADDR_IPV6 : UET_ADDR_IPV4) |
 		       UET_ADDR_BIG_MSG_SIZE);
-	addr->fep_cap = UET_FEP_CAP_AI_FULL;
+	/* advertise HPC profile so the peer may select RUDI (MUST for HPC) */
+	addr->fep_cap = (UET_FEP_CAP_AI_FULL | UET_FEP_CAP_HPC);
 	memcpy(&addr->fa, &ctx->cfg.peer_ip_addr, sizeof(struct uet_fa));
 	addr->pid_on_fep = UET_ADDR_DEF_PID_ON_FEP;
 	addr->num_indices = 1;
@@ -577,11 +585,17 @@ static uet_rc_t uet_init_transport(struct uet_context *ctx)
 
 		ctx->info->domain_attr->mr_mode |= FI_MR_PROV_KEY;
 
+		/* RUDI targets the MR for idempotent RMA so mark it as
+		 * IDEMPOTENT_SAFE. The provider still assigns the key but
+		 * preserves this flag.
+		 */
 		ret = uet_mr_reg(ctx->domain_handle, ctx->mr_buf,
 				 ctx->cfg.msg_size,
 				 FI_WRITE | FI_REMOTE_WRITE |
 				 FI_READ  | FI_REMOTE_READ | FI_ATOMIC,
-				 UET_MR_KEY_NONE, UET_FLAGS_NONE, context,
+				 ctx->cfg.rudi ? UET_MR_KEY_IDEMPOTENT_SAFE :
+						 UET_MR_KEY_NONE,
+				 UET_FLAGS_NONE, context,
 				 &ctx->mr_handle);
 		if (ret) {
 			UET_ERR("uet_mr_reg: %s", fi_strerror(-ret));
@@ -902,6 +916,72 @@ static uet_rc_t uet_rma_server_ctrl_exchange(struct uet_context *ctx)
 	return UET_SUCCESS_RC;
 }
 
+static uet_rc_t uet_rma_write_data(struct uet_context *ctx, uint64_t *imm_data)
+{
+	struct fi_cq_data_entry cq_entry;
+	ssize_t ret;
+
+	/* For RUDI the bulk data is written over RUDI. Once that completes,
+	 * a separate zero-length WRITE-with-immediate over RUD delivers
+	 * the target completion. Otherwise a single write-with-immediate
+	 * carries both data and immediate.
+	 */
+	if (ctx->cfg.rudi) {
+		/* bulk data over RUDI (no immediate) */
+		ret = uet_write(ctx->ep_handle, ctx->cfg.job_id, ctx->mr_buf,
+				ctx->cfg.msg_size, NULL, ctx->mr_handle,
+				ctx->peer_addr_handle,
+				ctx->remote_mr.rma_buf_addr,
+				ctx->remote_mr.key, NULL);
+		if (ret < 0) {
+			UET_ERR("uet_write (RUDI data): %s", fi_strerror(-ret));
+			return UET_ERR_RC;
+		}
+
+		if (uet_compl_wait(ctx->tx_cq_handle, &cq_entry) !=
+		    UET_SUCCESS_RC) {
+			UET_ERR("uet_compl_wait (RUDI data)");
+			return UET_ERR_RC;
+		}
+
+		/* signal over RUD (zero-length write-with-immediate) */
+		ret = uet_write(ctx->ep_handle, ctx->cfg.job_id, ctx->mr_buf,
+				0, imm_data, ctx->mr_handle,
+				ctx->peer_addr_handle,
+				ctx->remote_mr.rma_buf_addr,
+				ctx->remote_mr.key, NULL);
+		if (ret < 0) {
+			UET_ERR("uet_write (RUD imm): %s", fi_strerror(-ret));
+			return UET_ERR_RC;
+		}
+
+		if (uet_compl_wait(ctx->tx_cq_handle, &cq_entry) !=
+		    UET_SUCCESS_RC) {
+			UET_ERR("uet_compl_wait (RUD imm)");
+			return UET_ERR_RC;
+		}
+
+		return UET_SUCCESS_RC;
+	}
+
+	/* single write-with-immediate (data + target completion) */
+	ret = uet_write(ctx->ep_handle, ctx->cfg.job_id, ctx->mr_buf,
+			ctx->cfg.msg_size, imm_data, ctx->mr_handle,
+			ctx->peer_addr_handle, ctx->remote_mr.rma_buf_addr,
+			ctx->remote_mr.key, NULL);
+	if (ret < 0) {
+		UET_ERR("uet_write: %s", fi_strerror(-ret));
+		return UET_ERR_RC;
+	}
+
+	if (uet_compl_wait(ctx->tx_cq_handle, &cq_entry) != UET_SUCCESS_RC) {
+		UET_ERR("uet_compl_wait");
+		return UET_ERR_RC;
+	}
+
+	return UET_SUCCESS_RC;
+}
+
 /*
  * perform client RMA data transfer exchange as follows:
  *   - read data from server RMA buffer
@@ -938,19 +1018,8 @@ static uet_rc_t uet_rma_client(struct uet_context *ctx)
 		return UET_ERR_RC;
 	}
 
-	ret = uet_write(ctx->ep_handle, ctx->cfg.job_id, ctx->mr_buf,
-			ctx->cfg.msg_size, &imm_data, ctx->mr_handle,
-			ctx->peer_addr_handle, ctx->remote_mr.rma_buf_addr,
-			ctx->remote_mr.key, context);
-	if (ret < 0) {
-		UET_ERR("uet_write: %s", fi_strerror(-ret));
+	if (uet_rma_write_data(ctx, &imm_data) != UET_SUCCESS_RC)
 		return UET_ERR_RC;
-	}
-
-	if (uet_compl_wait(ctx->tx_cq_handle, &cq_entry) != UET_SUCCESS_RC) {
-		UET_ERR("uet_compl_wait");
-		return UET_ERR_RC;
-	}
 
 	if (uet_compl_wait(ctx->rx_cq_handle, &cq_entry) != UET_SUCCESS_RC) {
 		UET_ERR("uet_compl_wait");
@@ -995,19 +1064,8 @@ static uet_rc_t uet_rma_server(struct uet_context *ctx)
 		return UET_ERR_RC;
 	}
 
-	ret = uet_write(ctx->ep_handle, ctx->cfg.job_id, ctx->mr_buf,
-			ctx->cfg.msg_size, &imm_data, ctx->mr_handle,
-			ctx->peer_addr_handle, ctx->remote_mr.rma_buf_addr,
-			ctx->remote_mr.key, context);
-	if (ret < 0) {
-		UET_ERR("uet_write: %s", fi_strerror(-ret));
+	if (uet_rma_write_data(ctx, &imm_data) != UET_SUCCESS_RC)
 		return UET_ERR_RC;
-	}
-
-	if (uet_compl_wait(ctx->tx_cq_handle, &cq_entry) != UET_SUCCESS_RC) {
-		UET_ERR("uet_compl_wait");
-		return UET_ERR_RC;
-	}
 
 	return UET_SUCCESS_RC;
 }

--- a/uet_addr.h
+++ b/uet_addr.h
@@ -48,9 +48,10 @@ struct uet_addr {
 #define UET_FEP_CAP_AI_MIN	(1 << 0)
 #define UET_FEP_CAP_AI_FULL	(1 << 1)
 #define UET_FEP_CAP_HPC		(1 << 2)
-#define UET_FEP_CAP_REORDER	(1 << 6)
+	/* bits 3-6 reserved, MUST be 0 */
 #define UET_FEP_CAP_OPT_NM_SEM	(1 << 7)
-	uint8_t fep_cap;
+	/* bits 8-15 reserved, MUST be 0 */
+	uint16_t fep_cap;
 	struct uet_fa fa;
 	uint16_t pid_on_fep;
 	uint16_t start_index;

--- a/uet_api.c
+++ b/uet_api.c
@@ -87,7 +87,8 @@ static void uet_init_uet_addr(struct uet_addr *uet_addr,
 	else
 		uet_addr->flags |= UET_ADDR_IPV4;
 
-	uet_addr->fep_cap = UET_FEP_CAP_AI_FULL;
+	/* advertise HPC profile so peers may select RUDI (MUST for HPC) */
+	uet_addr->fep_cap = (UET_FEP_CAP_AI_FULL | UET_FEP_CAP_HPC);
 
 	memcpy(&uet_addr->fa, ip_addr, sizeof(struct uet_fa));
 }
@@ -2477,6 +2478,15 @@ static uet_ses_rc_t uet_rx_rd_req_pkt(
 		return UET_RC_PERM_VIOLATION;
 	}
 
+	/* A RUDI read may only source from an IDEMPOTENT_SAFE memory region
+	 * RUD/ROD reads are unaffected.
+	 */
+	if ((pp->pds_type == UET_PDS_TYPE_RUDI_REQ) &&
+	    !(mr_desc->full_key & UET_MR_KEY_IDEMPOTENT_SAFE)) {
+		UET_API_ERR("RX: RUDI Read: MR not IDEMPOTENT_SAFE");
+		return UET_RC_OP_VIOLATION;
+	}
+
 	/* validate requested data is within memory region */
 	if ((buf_off + pp->ses_payload_len) > mr_desc->buf_desc.len) {
 		UET_API_ERR("RX: Read Req: Invalid Buffer Offset");
@@ -2485,7 +2495,8 @@ static uet_ses_rc_t uet_rx_rd_req_pkt(
 
 	/* check if data is to be carried in ack */
 	max_ack_data = uet_ep->uet_domain->uet->pds.max_ack_data;
-	if ((uet_ep->uet_domain->uet->max_payload_len == max_ack_data) ||
+	if ((pp->pds_type == UET_PDS_TYPE_RUDI_REQ) ||
+	    (uet_ep->uet_domain->uet->max_payload_len == max_ack_data) ||
 	    (req_len <= max_ack_data)) {
 		ack_d_info->valid = true;
 		ack_d_info->payload_len = pp->ses_payload_len;
@@ -3032,6 +3043,7 @@ static uet_ses_rc_t uet_rx_req_pkt(
 	struct uet_rx_desc *rx_desc;
 	struct uet_rx_msg_key msg_key;
 	struct uet_tag_initiator_key tag_key, tag_only_key;
+	struct uet_mr_desc *mr_desc;
 
 	ses = (struct uet_ses_req_std *) pp->ses;
 
@@ -3042,6 +3054,60 @@ static uet_ses_rc_t uet_rx_req_pkt(
 		start_off = ntohll(ses->buf_off);
 	else
 		start_off = 0;
+
+	/* RUDI write: RUDI maintains NO SES state and NO message completion
+	 * at the target. Each packet is placed directly into memory
+	 * (idempotent, out of order) and answered with one response. Bypass
+	 * the RUD message reassembly which relies on the PDC de-duplicating
+	 * and therefore cannot tolerate the duplicate chunks that RUDI's
+	 * no-dedup and retransmit produce. A duplicate chunk simply re-writes
+	 * the same bytes (harmless), and there is no per-message state to
+	 * corrupt or leave dangling. Message completion is at the initiator
+	 * (after all RUDI responses received for a message).
+	 */
+	if (write && (pp->pds_type == UET_PDS_TYPE_RUDI_REQ)) {
+		if (ses->cmn.ver_flags & UET_SES_REQ_FLAG_SOM) {
+			buf_off = start_off;
+		} else {
+			payload_len_msg_off = ntohll(ses->payload_len_msg_off);
+			buf_off = (start_off +
+				   ((payload_len_msg_off &
+				     UET_SES_REQ_STD_MSG_OFF_MASK) >>
+				    UET_SES_REQ_STD_MSG_OFF_SHIFT));
+		}
+
+		mr_desc = uet_get_mr_desc(uet_ep, pp);
+		if (mr_desc == NULL) {
+			UET_API_ERR("RX: RUDI Write: Invalid Key");
+			return UET_RC_BAD_MKEY;
+		}
+
+		if (!(mr_desc->access & FI_REMOTE_WRITE)) {
+			UET_API_ERR("RX: RUDI Write: No Remote Write Permission");
+			return UET_RC_PERM_VIOLATION;
+		}
+
+		/*
+		 * RUDI may only target an IDEMPOTENT_SAFE memory region (spec
+		 * Table 2-16): a RUDI packet can be applied to memory more than
+		 * once (retransmit/replay), so the target MR must be marked safe
+		 * for idempotent operations.
+		 */
+		if (!(mr_desc->full_key & UET_MR_KEY_IDEMPOTENT_SAFE)) {
+			UET_API_ERR("RX: RUDI Write: MR not IDEMPOTENT_SAFE");
+			return UET_RC_OP_VIOLATION;
+		}
+
+		if ((buf_off + pp->ses_payload_len) > mr_desc->buf_desc.len) {
+			UET_API_ERR("RX: RUDI Write: Invalid Buffer Offset");
+			return UET_RC_BAD_ADDR;
+		}
+
+		buf_ptr = (void *)(((size_t) mr_desc->buf_desc.buf) + buf_off);
+		memcpy(buf_ptr, pp->payload, pp->ses_payload_len);
+
+		return UET_RC_OK; /* caller will emit one RUDI response */
+	}
 
 	/* get rx descriptor for message */
 	ses_rc = uet_get_rx_desc(uet_ep, pp, write, sync, UET_RC_OK, &msg_key,
@@ -5276,6 +5342,15 @@ static ssize_t uet_send_req_api_common(
 	tx_desc->backoff_min = UET_INITIAL_BACKOFF_MIN;
 	tx_desc->backoff_max = UET_INITIAL_BACKOFF_MAX;
 	tx_desc->pds_mode = uet_get_pds_mode(uet_ep, rma_op);
+
+	/* force RUDI when UET_FORCE_RUDI is set only for WRITE/READ */
+	if ((((send_req_api == UET_WRITE_API) && (imm_data == NULL)) ||
+	     (send_req_api == UET_READ_API)) &&
+	    getenv("UET_FORCE_RUDI") &&
+	    (remote_key & UET_MR_KEY_IDEMPOTENT_SAFE) &&
+	    (av_entry->addr->fep_cap & UET_FEP_CAP_HPC))
+		tx_desc->pds_mode = UET_PDS_MODE_RUDI;
+
 	if (tx_desc->pds_mode == UET_PDS_MODE_ROD)
 		tx_desc->seq_num = uet_alloc_av_msg_seq_num(av_entry);
 	uet_gettime(&tx_desc->tx_time);
@@ -7408,6 +7483,16 @@ int uet_mr_regattr(uet_domain_handle_t domain_handle, uint32_t job_id,
 int uet_mr_bind_cntr(uet_mr_handle_t mr_handle, uint64_t flags,
 		     uet_cntr_handle_t *cntr_handle)
 {
+	struct uet_mr_desc *mr_desc = (struct uet_mr_desc *) mr_handle;
+
+	/* A completion counter MUST NOT be bound to a memory region marked
+	 * IDEMPOTENT_SAFE. RUDI keeps no target state and may deliver an
+	 * idempotent op more than once, so a bound counter would over-count.
+	 * Fail the bind.
+	 */
+	if (mr_desc && (mr_desc->full_key & UET_MR_KEY_IDEMPOTENT_SAFE))
+		return -FI_EINVAL;
+
 	return -FI_ENOSYS;
 }
 

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -21,6 +21,7 @@
 #include "uet_pkt_chk.h"
 #include "uet_pkt_hdr.h"
 #include "uet_sec.h"
+#include "uet_pds_rudi.h"
 #include "imp_shim.h"
 #include "bitmap.h"
 #include "crc32c.h"
@@ -1231,6 +1232,9 @@ int uet_pds_initialize(struct uet_instance *uet)
 		dlist_insert_tail(&pdc->node, &pds_state.pdc_free_head);
 	}
 
+	/* initialize the connectionless RUDI engine */
+	uet_pds_rudi_init();
+
 	/* good to go... */
 	pds_state.ready = true;
 
@@ -1274,6 +1278,9 @@ void uet_pds_finalize(struct uet_instance *uet)
 		if (pdc->rx_bm)
 			bm_destroy(pdc->rx_bm);
 	}
+
+	/* free any outstanding RUDI requests */
+	uet_pds_rudi_finalize();
 
 	/* wipe out all existing state */
 	memset(&pds_state, 0, sizeof(struct uet_pds_state));
@@ -1329,6 +1336,15 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 
 	uet = uet_ep->uet_domain->uet;
 	av_entry = (struct uet_av_entry *)dst_addr_handle;
+
+	/* RUDI is connectionless: hand off to the RUDI engine before any PDC
+	 * assignment. None of the PDC/PSN/ACK machinery below applies.
+	 */
+	if (mode == UET_PDS_MODE_RUDI)
+		return uet_pds_rudi_tx_pkt(tx_pkt_handle, pkt_cnt, uet_ep,
+					   dst_addr_handle, mode, flags,
+					   pds_info, msg_id, next_hdr, ses,
+					   ses_len, pkt, pkt_len, dma_rdy);
 
 	switch (mode) {
 	case UET_PDS_MODE_RUD:
@@ -1882,6 +1898,11 @@ int uet_pds_progress_tx(struct uet_ep *uet_ep,
 
 	uet = uet_ep->uet_domain->uet;
 
+	/* drive RUDI initiator reliability (per-packet RTO) */
+	rc = uet_pds_rudi_progress_tx(uet_ep, err_pkt_handle);
+	if (rc != 0)
+		return rc;
+
 	/* TODO:
 	 * [x] walk the allocated PDC list
 	 *     [x] walk the tx_pkt_list (sorted in tx time order, oldest first)
@@ -1928,6 +1949,12 @@ int uet_pds_msg_cmpl_ind(struct uet_ep *uet_ep,
 {
 	struct uet_pdc *pdc;
 	int rc;
+
+	/* RUDI is connectionless so no PDC/msgid state to complete. SES
+	 * calls this for every READ_REQ completion, including RUDI reads.
+	 */
+	if (mode == UET_PDS_MODE_RUDI)
+		return 0;
 
 	pdc = uet_pdsm_get_msgid_pdc(msg_id);
 	if (pdc == NULL)
@@ -3245,6 +3272,13 @@ int uet_pds_progress_rx(struct uet_instance *uet)
 	}
 
 	uet_pds_pkt_dbg(uet, &pp, false, "RX PACKET");
+
+	/* RUDI is connectionless and demuxed here by pds_type. The RUDI
+	 * engine takes ownership of pkt.
+	 */
+	if ((pp.pds_type == UET_PDS_TYPE_RUDI_REQ) ||
+	    (pp.pds_type == UET_PDS_TYPE_RUDI_RESP))
+		return uet_pds_rudi_rx(uet, &pp, pkt, pkt_len);
 
 	if (pkt_is_ack) {
 

--- a/uet_pds_rudi.c
+++ b/uet_pds_rudi.c
@@ -1,0 +1,578 @@
+/*
+ * Copyright (c) 2026, Broadcom. All rights reserved. The term
+ * Broadcom refers to Broadcom Limited and/or its subsidiaries.
+ */
+
+/* RUDI (Reliable Unordered Delivery for Idempotent operations) engine */
+
+/*
+ * RUDI + TSS: REPLAY PROTECTION IS **NOT** SUPPORTED! RUDI is connectionless
+ * with no PDC/PSN state, so there is no anti-replay window. Packets may be
+ * replayed/duplicated. This is only "safe" because RUDI is used exclusively
+ * for idempotent operations (the target MR must be IDEMPOTENT_SAFE).
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <arpa/inet.h>
+
+#include <ofi_list.h>
+#include <uthash.h>
+
+#include "uet_api.h"
+#include "uet_api_private.h"
+#include "uet_pds.h"
+#include "uet_pds_rudi.h"
+#include "uet_util.h"
+#include "uet_log.h"
+#include "uet_pkt_hdr.h"
+#include "uet_sec.h"
+#include "uet_nic.h"
+#include "imp_shim.h"
+#include "crc32c.h"
+
+#define UET_RUDI_ENTROPY 0x4242
+
+/* Per outstanding RUDI request (initiator side). Holds the built cleartext
+ * frame for retransmit. On the security path the cleartext lives in the lower
+ * half of pkt_buf (see uet_sec_enc_pkt) and only the TSC is refreshed on
+ * retransmission.
+ */
+struct uet_rudi_out_pkt {
+	UT_hash_handle     hh; /* rudi.out_ht lookup by pkt_id */
+	struct dlist_entry node; /* rudi.rto_list (tx-time ordered) */
+	uint32_t           pkt_id; /* wire RUDI packet id (hash key) */
+	uet_pkt_handle_t   tx_pkt_handle; /* SES handle, for rx_rsp upcall */
+	uint16_t           msg_id;
+	struct uet_ep     *uet_ep;
+	uint8_t           *pkt_buf; /* full buffer (incl sec headroom) */
+	int                pkt_buf_len;
+	uint8_t           *pkt; /* start of eth frame (cleartext) */
+	int                pkt_len; /* cleartext frame len (no crc/tag) */
+	bool               sec_enabled;
+	uint32_t           sdi;
+	uint32_t           ssi;
+	bool               is_ipv6;
+	bool               sec_hdr_built; /* sec header injected into pkt */
+	int                tx_retry_cnt;
+	time_t             tx_time;
+};
+
+/* Outstanding RUDI requests are held in two structures kept in sync:
+ *   out_ht   - uthash keyed by pkt_id, for response matching (rx_rsp).
+ *   rto_list - tx-time ordered (oldest at head) so the RTO walk can stop at
+ *              the first not-yet-timed-out entry (progress_tx). A
+ *              retransmitted packet gets a fresh tx_time and moves to the
+ *              tail.
+ */
+static struct {
+	struct uet_rudi_out_pkt *out_ht; /* uthash head (by pkt_id) */
+	struct dlist_entry       rto_list; /* tx-time ordered list */
+	uint32_t                 next_pkt_id; /* locally-unique id allocator */
+} rudi;
+
+void uet_pds_rudi_init(void)
+{
+	rudi.out_ht = NULL;
+	dlist_init(&rudi.rto_list);
+
+	/* The pkt_id is not a sequence number. Any locally-unique value is
+	 * valid. Simple implementation here uses a monotonic counter.
+	 */
+	rudi.next_pkt_id = 1;
+}
+
+void uet_pds_rudi_finalize(void)
+{
+	struct uet_rudi_out_pkt *rp, *tmp;
+
+	HASH_ITER(hh, rudi.out_ht, rp, tmp) {
+		HASH_DEL(rudi.out_ht, rp);
+		dlist_remove(&rp->node);
+		free(rp->pkt_buf);
+		free(rp);
+	}
+}
+
+/* FIXME: get the security SDI/SSI, same source as uet_pdsm_get_sdi()! */
+static void uet_rudi_get_sec(bool *sec_enabled, uint32_t *sdi, uint32_t *ssi)
+{
+	char *sec_ssi;
+
+	*sec_enabled = !!getenv(UET_SEC_MODE);
+	*sdi = 1; /* fixed SDI, matches the PDC path */
+	*ssi = 0;
+
+	sec_ssi = getenv(UET_SEC_SSI);
+	if (sec_ssi)
+		*ssi = strtoul(sec_ssi, NULL, 10);
+}
+
+/* Apply CRC (no security) or security header + encryption, then transmit the
+ * frame. Mirrors uet_pds_sec_tx_pkt() but is PDC-free.
+ */
+static int uet_rudi_send(struct uet_instance *uet,
+			 struct uet_rudi_out_pkt *rp,
+			 bool is_rtx)
+{
+	struct uet_parsed_pkt pp;
+	uint8_t *out;
+	int out_len;
+	uint8_t *crc_start;
+	uint32_t crc;
+	uint8_t *new_pkt;
+	int new_pkt_len;
+	uint8_t *enc_pkt;
+	int enc_pkt_len;
+	uint8_t *enc_ip;
+	int rc;
+
+	if (!rp->sec_enabled) {
+		rc = uet_parse_pkt(uet, rp->pkt, rp->pkt_len, &pp);
+		if (rc != 0)
+			return rc;
+
+		/* CRC covers from the IP src addr through the payload */
+		crc_start = (pp.is_ipv6) ? ((uint8_t *)pp.ip + 8)
+					 : ((uint8_t *)pp.ip + 12);
+		crc = crc32c(crc_start,
+			     (pp.pkt_len - (crc_start - (uint8_t *)pp.eth)));
+		memcpy((rp->pkt + rp->pkt_len), &crc, CRC_LEN);
+
+		out = rp->pkt;
+		out_len = rp->pkt_len + CRC_LEN;
+		uet_gettime(&rp->tx_time);
+
+		if (imp_shim_is_enabled())
+			return imp_shim_tx_pkt(UET_NIC(uet), out, pp.ip, out_len);
+
+		return uet_nic_tx_pkt(UET_NIC(uet), out, pp.ip, out_len);
+	}
+
+	/* security enabled */
+	if (is_rtx) {
+		/* refresh only the TSC and re-encrypt from the cleartext copy */
+		rc = uet_sec_update_hdr_tsc(rp->pkt, rp->is_ipv6);
+		if (rc != 0)
+			return rc;
+	} else if (!rp->sec_hdr_built) {
+		rc = uet_sec_build_hdr(rp->sdi, rp->ssi, rp->pkt_buf,
+				       rp->pkt_buf_len, rp->pkt, rp->pkt_len,
+				       &new_pkt, &new_pkt_len, rp->is_ipv6);
+		if (rc != 0)
+			return rc;
+
+		rp->pkt = new_pkt;
+		rp->pkt_len = (new_pkt_len + UET_SEC_TAG_LEN);
+		rp->sec_hdr_built = true;
+
+		/* fix IP length after security header injection */
+		rc = uet_parse_pkt(uet, rp->pkt, rp->pkt_len, &pp);
+		if (rc != 0)
+			return rc;
+
+		if (pp.is_ipv6) {
+			uet_update_ipv6_pl(pp.ip,
+					   (rp->pkt_len -
+					    uet->nic.l2_hdr_size -
+					    sizeof(struct ipv6hdr)));
+		} else {
+			uet_update_ipv4_tl(pp.ip,
+					   (rp->pkt_len -
+					    uet->nic.l2_hdr_size));
+		}
+	}
+
+	rc = uet_sec_enc_pkt(uet, rp->pkt_buf, rp->pkt_buf_len, rp->pkt,
+			     rp->pkt_len, &enc_pkt, &enc_pkt_len, rp->is_ipv6);
+	if (rc != 0)
+		return rc;
+
+	uet_gettime(&rp->tx_time);
+
+	/* get a pointre to the IP header in the encrypted packet */
+	enc_ip = enc_pkt + sizeof(struct ethhdr);
+
+	if (imp_shim_is_enabled())
+		return imp_shim_tx_pkt(UET_NIC(uet), enc_pkt, enc_ip,
+				       enc_pkt_len);
+
+	return uet_nic_tx_pkt(UET_NIC(uet), enc_pkt, enc_ip,
+			      enc_pkt_len);
+}
+
+/* Build a RUDI frame (request or response). Allocates a new pkt_buf and fills
+ * in the cleartext packet (eth/ip/entropy/RUDI/SES/payload).
+ */
+static int uet_rudi_build_frame(struct uet_instance *uet,
+				uint8_t tos,
+				const uint8_t *dst_mac,
+				const struct uet_fa *dst_fa,
+				bool is_ipv6, bool sec_enabled,
+				uet_pds_pkt_type_t pds_type,
+				uet_pds_next_hdr_t next_hdr,
+				uint32_t pkt_id,
+				void *ses, size_t ses_len,
+				void *payload, size_t payload_len,
+				struct uet_rudi_out_pkt *rp)
+{
+	struct uet_entropy *entropy_hdr;
+	struct uet_pds_rudi_req *rudi_hdr;
+	void *ses_hdr, *pl;
+	size_t ip_hdr_size;
+	int hdr_len;
+	uint16_t tnf;
+	struct uet_fa src_ip;
+
+	ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr)
+				: sizeof(struct iphdr);
+
+	memset(&src_ip, 0, sizeof(src_ip));
+
+	if (is_ipv6)
+		memcpy(src_ip.v6, uet->nic.ipv6_addr, 16);
+	else
+		src_ip.v4 = uet->nic.ipv4_addr;
+
+	rp->pkt_buf_len = (uet->nic.max_pkt_size * ((sec_enabled) ? 2 : 1));
+	rp->pkt_buf = calloc(1, rp->pkt_buf_len);
+	if (rp->pkt_buf == NULL) {
+		UET_PDS_ERR("RUDI: failed to alloc packet buffer");
+		return -ENOMEM;
+	}
+
+	/* reserve head space for the security header if needed */
+	rp->pkt = (sec_enabled) ? (rp->pkt_buf + UET_SEC_MAX_HDR_LEN)
+				: rp->pkt_buf;
+
+	uet_build_eth_hdr((struct ethhdr *)rp->pkt, (uint8_t *)dst_mac,
+			  uet->nic.mac_addr, is_ipv6);
+
+	entropy_hdr = (struct uet_entropy *)(rp->pkt + sizeof(struct ethhdr) +
+					     ip_hdr_size);
+	rudi_hdr = (struct uet_pds_rudi_req *)(rp->pkt + sizeof(struct ethhdr) +
+					       ip_hdr_size +
+					       sizeof(struct uet_entropy));
+	ses_hdr = (rudi_hdr + 1);
+	pl = ((uint8_t *)ses_hdr + ses_len);
+
+	hdr_len = (sizeof(struct ethhdr) +
+		   ip_hdr_size +
+		   sizeof(struct uet_entropy) +
+		   sizeof(struct uet_pds_rudi_req) +
+		   ses_len);
+
+	rp->pkt_len = (hdr_len + payload_len);
+
+	/* fill in the entropy */
+	entropy_hdr->entropy = htons(UET_RUDI_ENTROPY);
+	entropy_hdr->rsvd = 0;
+
+	/* fill in the RUDI header */
+	tnf = ((pds_type << UET_PDS_TYPE_SHIFT) |
+	       (next_hdr << UET_PDS_NEXT_HDR_SHIFT));
+	rudi_hdr->prlg.type_next_flags = htons(tnf);
+	rudi_hdr->rsvd = 0;
+	rudi_hdr->pkt_id = htonl(pkt_id);
+
+	/* fill in the SES header */
+	if (ses_len)
+		memcpy(ses_hdr, ses, ses_len);
+
+	/* fill in the payload */
+	if (payload_len)
+		memcpy(pl, payload, payload_len);
+
+	/* IP header (crc_en=true only when security is disabled) */
+	if (is_ipv6) {
+		uet_build_ipv6_hdr(uet,
+				   (struct ipv6hdr *)(rp->pkt +
+						      sizeof(struct ethhdr)),
+				   dst_fa->v6, src_ip.v6,
+				   (rp->pkt_len - uet->nic.l2_hdr_size -
+				    ip_hdr_size),
+				   tos, !sec_enabled);
+	} else {
+		uet_build_ipv4_hdr(uet,
+				   (struct iphdr *)(rp->pkt +
+						    sizeof(struct ethhdr)),
+				   htonl(dst_fa->v4), htonl(src_ip.v4),
+				   (rp->pkt_len - uet->nic.l2_hdr_size),
+				   tos, !sec_enabled);
+	}
+
+	return 0;
+}
+
+int uet_pds_rudi_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
+			uint64_t pkt_cnt,
+			struct uet_ep *uet_ep,
+			uet_addr_handle_t dst_addr_handle,
+			uet_pds_mode_t mode,
+			uet_pds_tx_flags_t flags,
+			struct uet_pds_info *pds_info,
+			uint16_t msg_id,
+			uet_pds_next_hdr_t next_hdr,
+			void *ses,
+			size_t ses_len,
+			void *pkt,
+			size_t pkt_len,
+			bool dma_rdy)
+{
+	struct uet_instance *uet = uet_ep->uet_domain->uet;
+	struct uet_av_entry *av = (struct uet_av_entry *)dst_addr_handle;
+	bool is_ipv6 = uet_addr_is_ipv6(av->addr);
+	struct uet_rudi_out_pkt *rp;
+	bool sec_enabled;
+	uint32_t sdi, ssi, pkt_id;
+	int rc;
+
+        /* RUDI has no PDC and no SES-driven return-data path. A RUDI read is
+         * answered inline by the stateless responder (uet_rudi_rx_req builds
+         * the data-carrying RUDI response), never via pds_info.
+         */
+        if (pds_info) {
+		UET_PDS_ERR("RUDI: pds_info return-data path not used by RUDI");
+		return -ENOSYS;
+	}
+
+	uet_rudi_get_sec(&sec_enabled, &sdi, &ssi);
+
+	rp = calloc(1, sizeof(*rp));
+	if (rp == NULL)
+		return -ENOMEM;
+
+	pkt_id = rudi.next_pkt_id++;
+
+	rc = uet_rudi_build_frame(uet, uet_ep->msg_ip_tos, av->nh_mac_addr,
+				  &av->addr->fa, is_ipv6, sec_enabled,
+				  UET_PDS_TYPE_RUDI_REQ, next_hdr, pkt_id,
+				  ses, ses_len, pkt, pkt_len, rp);
+	if (rc != 0) {
+		free(rp);
+		return rc;
+	}
+
+	rp->pkt_id        = pkt_id;
+	rp->tx_pkt_handle = tx_pkt_handle;
+	rp->msg_id        = msg_id;
+	rp->uet_ep        = uet_ep;
+	rp->sec_enabled   = sec_enabled;
+	rp->sdi           = sdi;
+	rp->ssi           = ssi;
+	rp->is_ipv6       = is_ipv6;
+	rp->tx_retry_cnt  = 0;
+
+	rc = uet_rudi_send(uet, rp, false);
+	if (rc != 0) {
+		free(rp->pkt_buf);
+		free(rp);
+		return rc;
+	}
+
+	UET_PDS_DBG("RUDI TX REQ pkt_id %u msg_id %u len %d%s",
+		    pkt_id, msg_id, rp->pkt_len,
+		    (sec_enabled) ? " (sec)" : "");
+
+	/* track for response matching (hash) + per-packet RTO (dlist) */
+	HASH_ADD(hh, rudi.out_ht, pkt_id, sizeof(rp->pkt_id), rp);
+	dlist_insert_tail(&rp->node, &rudi.rto_list);
+
+	return 0;
+}
+
+/* Target: RUDI request received -> SES processing -> one RUDI response */
+static int uet_rudi_rx_req(struct uet_instance *uet,
+			   struct uet_parsed_pkt *pp)
+{
+	struct uet_pds_info pds_info;
+	uet_pds_next_hdr_t rsp_next_hdr;
+	void *rsp_ses_hdr;
+	size_t rsp_ses_hdr_len;
+	bool sec_enabled, ses_nack = false, gtd_del = false;
+	uint32_t sdi, ssi;
+	struct uet_rudi_out_pkt rsp;
+	struct uet_fa dst_fa;
+	uint8_t *dst_mac;
+	struct ethhdr *eth;
+	int rc;
+
+        /* Sized to hold a full read-response chunk inline. A RUDI read
+         * request is answered by one data-carrying RUDI response and the
+	 * chunk is up to max_payload_len bytes. A write response carries
+	 * no data and this just over-allocates for it.
+         */
+        rsp_ses_hdr = calloc(1, (sizeof(struct uet_ses_rsp_d) +
+				 uet->max_payload_len));
+	if (rsp_ses_hdr == NULL)
+		return -ENOMEM;
+
+	/* RUDI has no PDC; pds_info is unused for the (write) response. */
+	memset(&pds_info, 0, sizeof(pds_info));
+
+	rc = uet->pds.upcall.rx_req((uet_pkt_handle_t)pp, uet, pp,
+				    &pds_info, &rsp_next_hdr, rsp_ses_hdr,
+				    &rsp_ses_hdr_len, &ses_nack, &gtd_del);
+	if (rc != 0) {
+		UET_PDS_ERR("RUDI: SES rx_req failed (pkt_id %u rc %d)",
+			    pp->pds_rudi_pkt_id, rc);
+		free(rsp_ses_hdr);
+		return rc;
+	}
+
+	if (ses_nack) {
+		/*
+		 * FIXME: send a RUDI NACK. For now, not responding causes the
+		 * initiator's RTO to retransmit the request.
+		 */
+		UET_PDS_WARN("RUDI: SES NACK for pkt_id %u (no response sent)",
+			     pp->pds_rudi_pkt_id);
+		free(rsp_ses_hdr);
+		return 0;
+	}
+
+	uet_rudi_get_sec(&sec_enabled, &sdi, &ssi);
+
+	/* build the RUDI response back to the initiator echoing pkt_id */
+
+	eth = (struct ethhdr *)pp->eth;
+	dst_mac = eth->h_source;
+
+	memset(&dst_fa, 0, sizeof(dst_fa));
+	if (pp->is_ipv6)
+		memcpy(dst_fa.v6, &((struct ipv6hdr *)pp->ip)->saddr, 16);
+	else
+		dst_fa.v4 = ntohl(((struct iphdr *)pp->ip)->saddr);
+
+	/* FIXME: RUDI responses should use the DSCP controll codepoint */
+	memset(&rsp, 0, sizeof(rsp));
+	rc = uet_rudi_build_frame(uet, uet->default_msg_ip_tos, dst_mac,
+				  &dst_fa, pp->is_ipv6, sec_enabled,
+				  UET_PDS_TYPE_RUDI_RESP, rsp_next_hdr,
+				  pp->pds_rudi_pkt_id, rsp_ses_hdr,
+				  rsp_ses_hdr_len, NULL, 0, &rsp);
+	if (rc != 0) {
+		free(rsp_ses_hdr);
+		return rc;
+	}
+
+	rsp.sec_enabled = sec_enabled;
+	rsp.sdi = sdi;
+	rsp.ssi = ssi;
+	rsp.is_ipv6 = pp->is_ipv6;
+
+	rc = uet_rudi_send(uet, &rsp, false);
+
+	UET_PDS_DBG("RUDI TX RSP pkt_id %u len %d%s (rc %d)",
+		    pp->pds_rudi_pkt_id, rsp.pkt_len,
+		    (sec_enabled) ? " (sec)" : "", rc);
+
+	free(rsp.pkt_buf);
+	free(rsp_ses_hdr);
+
+	return rc;
+}
+
+/* Initiator: RUDI response received -> match pkt_id -> SES completion */
+static int uet_rudi_rx_rsp(struct uet_instance *uet,
+			   struct uet_parsed_pkt *pp)
+{
+	struct uet_rudi_out_pkt *rp;
+	uint32_t pkt_id = pp->pds_rudi_pkt_id;
+
+	HASH_FIND(hh, rudi.out_ht, &pkt_id, sizeof(pkt_id), rp);
+	if (rp == NULL) {
+		/* no match: dup/late response, idempotent safely ignored */
+		UET_PDS_DBG("RUDI RX RSP pkt_id %u unmatched (duplicate) -- ignored",
+			    pkt_id);
+		return 0;
+	}
+
+	UET_PDS_DBG("RUDI RX RSP pkt_id %u -> complete", rp->pkt_id);
+
+	/* SES completion for this packet (decrements unack_pkts) */
+	uet->pds.upcall.rx_rsp(rp->tx_pkt_handle, pp);
+
+	HASH_DEL(rudi.out_ht, rp);
+	dlist_remove(&rp->node);
+	free(rp->pkt_buf);
+	free(rp);
+
+	return 0;
+}
+
+int uet_pds_rudi_rx(struct uet_instance *uet,
+		    struct uet_parsed_pkt *pp,
+		    uint8_t *pkt,
+		    size_t pkt_len)
+{
+	int rc;
+
+	if (pp->pds_type == UET_PDS_TYPE_RUDI_REQ)
+		rc = uet_rudi_rx_req(uet, pp);
+	else
+		rc = uet_rudi_rx_rsp(uet, pp);
+
+	free(pkt);
+
+	return rc;
+}
+
+int uet_pds_rudi_progress_tx(struct uet_ep *uet_ep,
+			     uet_pkt_handle_t *err_pkt_handle)
+{
+	struct uet_instance *uet = uet_ep->uet_domain->uet;
+	struct uet_rudi_out_pkt *rp;
+	struct dlist_entry *tmp;
+	time_t now;
+	int rc;
+
+	uet_gettime(&now);
+
+	/* rto_list is ordered oldest-first, so stop at the first entry that
+	 * has not yet timed out. A retransmitted entry gets a fresh tx_time
+	 * and is moved to the tail to preserve the ordering.
+	 */
+	dlist_foreach_container_safe(&rudi.rto_list, struct uet_rudi_out_pkt,
+				     rp, node, tmp) {
+		if ((now - rp->tx_time) < uet->pds.tx_timeout)
+			break;
+
+		if (rp->tx_retry_cnt >= uet->pds.max_tx_retries) {
+			UET_PDS_ERR("RUDI: pkt_id %u exceeded max retries",
+				    rp->pkt_id);
+
+			if (err_pkt_handle)
+				*err_pkt_handle = rp->tx_pkt_handle;
+
+			uet->pds.upcall.pds_err(rp->tx_pkt_handle,
+						UET_PDS_ERR_NONE);
+
+			HASH_DEL(rudi.out_ht, rp);
+			dlist_remove(&rp->node);
+			free(rp->pkt_buf);
+			free(rp);
+
+			return -EPROTO;
+		}
+
+		rp->tx_retry_cnt++;
+
+		UET_PDS_DBG("RUDI: RTO retransmit pkt_id %u (retry %d)",
+			    rp->pkt_id, rp->tx_retry_cnt);
+
+		/* move to the tail, uet_rudi_send() refreshes tx_time */
+		dlist_remove(&rp->node);
+		dlist_insert_tail(&rp->node, &rudi.rto_list);
+
+		rc = uet_rudi_send(uet, rp, true);
+		if (rc != 0)
+			return rc;
+	}
+
+	return 0;
+}
+

--- a/uet_pds_rudi.h
+++ b/uet_pds_rudi.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, Broadcom. All rights reserved. The term
+ * Broadcom refers to Broadcom Limited and/or its subsidiaries.
+ */
+
+/*
+ * RUDI (Reliable Unordered Delivery for Idempotent operations) engine. RUDI
+ * is a connectionless PDS delivery mode with no PDC, no PSN, etc. Each
+ * request carries a non-sequential 32-bit pkt_id and is answered by exactly
+ * one RUDI response (not an ACK). All reliability state lives at the
+ * initiator (a per-packet RTO) and the target is stateless. This RUDI engine
+ * bypasses the PDS PDC control plane entirely.
+ */
+
+#ifndef _UET_PDS_RUDI_H_
+#define _UET_PDS_RUDI_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "uet_pds.h"
+#include "uet_util.h"
+
+struct uet_ep;
+struct uet_instance;
+
+/* initialize/free the RUDI engine's outstanding-request state */
+void uet_pds_rudi_init(void);
+void uet_pds_rudi_finalize(void);
+
+/* Initiate a RUDI request transmit (mode=RUDI path of uet_pds_tx_pkt). Same
+ * arguments as the PDS engine's tx_pkt() downcall.
+ */
+int uet_pds_rudi_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
+			uint64_t pkt_cnt,
+			struct uet_ep *uet_ep,
+			uet_addr_handle_t dst_addr_handle,
+			uet_pds_mode_t mode,
+			uet_pds_tx_flags_t flags,
+			struct uet_pds_info *pds_info,
+			uint16_t msg_id,
+			uet_pds_next_hdr_t next_hdr,
+			void *ses,
+			size_t ses_len,
+			void *pkt,
+			size_t pkt_len,
+			bool dma_rdy);
+
+/* Progress RUDI engine intitiator side reliability. Driven from the PDS
+ * engine's uet_pds_progress_tx().
+ */
+int uet_pds_rudi_progress_tx(struct uet_ep *uet_ep,
+			     uet_pkt_handle_t *err_pkt_handle);
+
+/* Process a received RUDI packet (REQ or RSP). Dispatched from the PDS
+ * engine's uet_pds_progress_rx(). Takes full ownership of the packet!
+ */
+int uet_pds_rudi_rx(struct uet_instance *uet, struct uet_parsed_pkt *pp,
+		    uint8_t *pkt, size_t pkt_len);
+
+#endif /* _UET_PDS_RUDI_H_ */

--- a/util/uet_pkt_chk.c
+++ b/util/uet_pkt_chk.c
@@ -78,9 +78,10 @@ static bool uet_pds_pkt_type_valid(uint8_t *pkt,
 		return true;
 	case UET_PDS_TYPE_RUDI_REQ:
 	case UET_PDS_TYPE_RUDI_RESP:
-		/* TODO: unsupported */
-		UET_PDS_WARN("RUDI packets not supported");
-		return false;
+		/* RUDI is connectionless and demuxed by pds_type in
+		 * uet_pds_progress_rx(). Simply accept it here.
+		 */
+		return true;
 	default:
 		return false;
 	}

--- a/util/uet_util.c
+++ b/util/uet_util.c
@@ -1015,6 +1015,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 	struct uet_pds_ack_ccx *pds_ack_ccx;
 	struct uet_pds_nack *pds_nack;
 	struct uet_pds_ctrl *pds_ctrl;
+	struct uet_pds_rudi_req *pds_rudi;
 	struct uet_ses_req_std *ses_req;
 	struct uet_ses_rsp *ses_rsp;
 	struct uet_ses_rsp_d *ses_rsp_d;
@@ -1264,8 +1265,10 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 		return 0;
 	case UET_PDS_TYPE_RUDI_REQ:
 	case UET_PDS_TYPE_RUDI_RESP:
-		/* TODO: support for parsing RUDI */
-		return -EINVAL;
+		pds_rudi = (struct uet_pds_rudi_req *)pp->pds;
+		pp->pds_len = sizeof(struct uet_pds_rudi_req);
+		pp->pds_rudi_pkt_id = ntohl(pds_rudi->pkt_id);
+		break;
 	default:
 		goto err_exit;
 	}

--- a/util/uet_util.h
+++ b/util/uet_util.h
@@ -88,6 +88,7 @@ struct uet_parsed_pkt {
 	uint8_t pds_flags;
 	uint32_t pds_cack_psn;
 	uint32_t pds_psn;
+	uint32_t pds_rudi_pkt_id;
 	uint16_t pds_spdcid;
 	uint16_t pds_dpdcid;
 	uint8_t pds_cc_type;


### PR DESCRIPTION
- uet_pds_rudi.h/.c: new RUDI engine (tx/rx, pkt_id hash, RTO, CRC + TSS)
- uet_pds.c: init/finalize, tx handoff, RTO progress, rx demux by pds_type
- uet_api.c: force RUDI on UET_FORCE_RUDI env var, data MR is allocated as IDEMPOTENT_SAFE, FEP advertises HPC profile, RUDI write/read does DDP
- uet_addr.h: fep_cap -> uint16_t; drop unused REORDER bit
- util/: parse and accept RUDI packets
- uet.c: RMA over RUDI (data via RUDI, completion via a zero-len RUD write-imm)
- scripts/uet_test.sh: add 'rudi' test, run it in test=all on pds backends