### PR TITLE
Added support for UUD to the PDS layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ There are two PDS implementations available which can be selected using
 the `UET_PDS` environment variable. The first PDS implementation is a simple
 stop-and-go ROD transport that is sufficient to enable development of other
 layers. The second PDS implementation is fully featured transport based on the
-UET PDS Specification.
+UET PDS Specification. It supports the RUD, ROD, RUDI, and UUD delivery modes
+(see [Delivery Modes](#delivery-modes) below).
 
 There are currently two implementations of the NIC shim interface APIs:
 - Raw Ethernet socket
@@ -55,6 +56,28 @@ There are currently two implementations of the NIC shim interface APIs:
 
 Testing is performed using a simple top-level program that performs ping-pong
 message data transfer operations between a client and a server (see `uet.c`).
+
+### Delivery Modes
+
+The `pds` backend (`UET_PDS=pds`) supports all four UET PDS delivery modes:
+
+- **RUD** - Reliable Unordered Delivery. The default for unordered operations.
+- **ROD** - Reliable Ordered Delivery. Selected when the endpoint is configured
+  for message ordering.
+- **RUDI** - Reliable Unordered Delivery for Idempotent operations. A
+  connectionless mode: no PDC, non-sequential per-packet ids, one response per
+  request (no ACK), and all reliability state at the initiator (per-packet RTO).
+  Used for idempotent RMA. Selected by setting `UET_FORCE_RUDI=1` on the `rma`
+  command and it requires the target memory region to be `IDEMPOTENT_SAFE` as
+  well as the peer advertising support for the HPC profile.
+- **UUD** - Unreliable Unordered Delivery. A connectionless, best-effort
+  single-packet datagram send (no PDC, no ACK, no retransmit - fire and forget).
+  Selected by setting `UET_FORCE_UUD=1` on the `uud` command.
+
+RUDI and UUD are only available on the `pds` backend as the `sng` backend rejects
+them. Both are exercised by the test harness via the `rudi` and `uud` test
+names, and are folded into the `all` sweep on every `pds`-capable configuration
+(see `scripts/uet_test.sh`).
 
 ### Congestion Control
 
@@ -178,6 +201,8 @@ Replace `2` with the desired number of senders.
 - **UET_PDS_ACK_TYPE** - [ `ack` | `ack_cc` | `ack_ccx` ] (default=`ack`)
 - **UET_PDS_TX_TIMEOUT** - Time in milliseconds to wait for an ack before retransmitting a Tx packet (default=`5`).
 - **UET_PDS_MAX_TX_RETRIES** - Max number of times a Tx packet is retransmitted before failing (default=`5`).
+- **UET_FORCE_RUDI** - [ `0` | `1` ] (default=`0`) Force the RUDI (Reliable Unordered Delivery for Idempotent operations) PDS delivery mode for RMA read/write operations.
+- **UET_FORCE_UUD** - [ `0` | `1` ] (default=`0`) Force the UUD (Unreliable Unordered Delivery) best-effort single-packet datagram PDS delivery mode for an untagged send.
 - **UET_SEC_MODE** - [ `direct` | `cluster` | `server` ]
 - **UET_SEC_SSI** - The SSI to be used for crypto operations. This value must be unique for all instances of `uet`. If not set the source IP address will be used instead as the source identifier.
 - **UET_SEC_CLIENT_SSI** - If set, the client SSI to be used by the server side of the session. This is only valid for the `UET_SEC_MODE=server` configuration.

--- a/imp_shim/imp_shim_rudi.toml
+++ b/imp_shim/imp_shim_rudi.toml
@@ -1,0 +1,21 @@
+
+# Impairment Shim config for RUDI loss/RTO testing.
+#
+# Enable via: UET_IMPAIRMENT_SHIM=/path/to/imp_shim_rudi.toml
+#
+# DROP-ONLY (no reordering): a single plane, no delay, so packets are dropped
+# but never reordered. This isolates the retransmit/RTO test from out-of-order
+# effects (heavy reordering stresses the RUD read path's PSN window separately).
+#
+# ~5% Tx drop forces the RUDI initiator per-packet RTO to retransmit and the RUD
+# read path to recover. A dropped RUDI response makes the initiator retransmit
+# the request, which the stateless target re-applies (idempotent).
+[config]
+num_planes = 1
+random_enq = false
+# drop_rate in hundredths of a percent. ~1-2% exercises the RUDI RTO/idempotency
+# well; >=5% storms the RUD completion path (pre-existing RUD-under-heavy-loss).
+drop_rate = 100
+# 0 = no delay / no reordering
+delay_max = 0
+

--- a/imp_shim/imp_shim_uud.toml
+++ b/imp_shim/imp_shim_uud.toml
@@ -1,0 +1,19 @@
+
+# Impairment Shim config for UUD best-effort / fire-and-forget testing.
+#
+# Enable via: UET_IMPAIRMENT_SHIM=/path/to/imp_shim_uud.toml
+#
+# DROP-ONLY (no reordering): a single plane, no delay. UUD has NO reliability
+# (no ACK, no RTO, no retransmit), so a dropped datagram is simply LOST with no
+# recovery. The UUD test tolerates this under impairment (best-effort): the
+# server reports received < sent and the run still passes, proving the
+# fire-and-forget contract.
+[config]
+num_planes = 1
+random_enq = false
+# drop_rate in hundredths of a percent. ~2% drop reliably loses a handful of
+# datagrams out of a 100-datagram blast without swamping the run.
+drop_rate = 200
+# 0 = no delay / no reordering
+delay_max = 0
+

--- a/scripts/uet_test.sh
+++ b/scripts/uet_test.sh
@@ -24,7 +24,7 @@ if [ -z "$LIBFABRIC" ]; then
 fi
 
 # Valid "test", "pds", and "shim" names
-test_names=(all rma rudi sync_rma atomic sync_atomic tag tag_any_src unexp_untag unexp_tag defer_send defer_tag defer_tag_any_src)
+test_names=(all rma rudi uud sync_rma atomic sync_atomic tag tag_any_src unexp_untag unexp_tag defer_send defer_tag defer_tag_any_src)
 pds_names=(all sng pds pds_direct pds_cluster pds_cluster_ssi pds_server_ssi)
 shim_names=(rawsock xdp)
 
@@ -144,14 +144,20 @@ if [ $valid_shim -eq 0 ]; then
     usage
 fi
 
-# RUDI is a delivery mode, not a distinct app test. The 'rudi' test runs the
-# existing 'rma' write/read exchange but forces the RUDI delivery mode via
-# UET_FORCE_RUDI. It requires the 'pds' backend (sng rejects RUDI).
 app_test=$test
 FORCE_RUDI=""
+FORCE_UUD=""
 if [ "$test" = rudi ]; then
+    # RUDI is a delivery mode, not a distinct app test. The 'rudi' test runs
+    # the existing 'rma' write/read exchange but forces the RUDI delivery mode
+    # via UET_FORCE_RUDI. It requires the 'pds' backend (sng rejects RUDI).
     app_test=rma
     FORCE_RUDI="UET_FORCE_RUDI=1"
+elif [ "$test" = uud ]; then
+    # UUD is a best-effort single-packet datagram send. The 'uud' app test
+    # runs the untagged send exchange forcing the UUD delivery mode via
+    # UET_FORCE_UUD. It requires the 'pds' backend (sng rejects UUD).
+    FORCE_UUD="UET_FORCE_UUD=1"
 fi
 
 banner()
@@ -175,7 +181,7 @@ if [ -n "$UET_IMPAIRMENT_SHIM" ]; then
     IMP_SHIM="UET_IMPAIRMENT_SHIM=${UET_IMPAIRMENT_SHIM}"
 fi
 
-CMD_BASE="LD_LIBRARY_PATH=${LIBFABRIC}:. UET_IFNAME=${iface} UET_NIC_SHIM=${shim} UET_PDS_ACK_TYPE=${ACK_TYPE} UET_PDS_MAX_TX_RETRIES=${MAX_TX_RETRIES} ${FORCE_RUDI} ${IMP_SHIM} ./${app_name}"
+CMD_BASE="LD_LIBRARY_PATH=${LIBFABRIC}:. UET_IFNAME=${iface} UET_NIC_SHIM=${shim} UET_PDS_ACK_TYPE=${ACK_TYPE} UET_PDS_MAX_TX_RETRIES=${MAX_TX_RETRIES} ${FORCE_RUDI} ${FORCE_UUD} ${IMP_SHIM} ./${app_name}"
 
 function run_test()
 {
@@ -208,6 +214,16 @@ function rudi_pass()
     run_test "$1 UET_FORCE_RUDI=1 $CMD_BASE $actor rma $peer_ip"
 }
 
+# When the full 'all' suite runs on a reliable PDS backend, also exercise the
+# UUD delivery mode. A forced UUD single-packet best-effort datagram send. UUD
+# needs the UUD PDS engine. This cannot be run using the sng backend.
+function uud_pass()
+{
+    [ "$test" = all ] || return 0
+    banner "UUD (forced) $1"
+    run_test "$1 UET_FORCE_UUD=1 $CMD_BASE $actor uud $peer_ip"
+}
+
 function sng()
 {
     UET_DEFS="UET_PDS=sng"
@@ -221,6 +237,7 @@ function pds()
     banner "PDS $test"
     run_test "$UET_DEFS $CMD_BASE $actor $app_test $peer_ip"
     rudi_pass "$UET_DEFS"
+    uud_pass "$UET_DEFS"
 }
 
 function pds_direct()
@@ -233,6 +250,7 @@ function pds_direct()
     banner "PDS w/ SEC=direct $test"
     run_test "$UET_DEFS $CMD_BASE $actor $app_test $peer_ip"
     rudi_pass "$UET_DEFS"
+    uud_pass "$UET_DEFS"
 }
 
 function pds_cluster()
@@ -241,6 +259,7 @@ function pds_cluster()
     banner "PDS w/ SEC=cluster $test"
     run_test "$UET_DEFS $CMD_BASE $actor $app_test $peer_ip"
     rudi_pass "$UET_DEFS"
+    uud_pass "$UET_DEFS"
 }
 
 function pds_cluster_ssi()
@@ -250,6 +269,7 @@ function pds_cluster_ssi()
     banner "PDS w/ SEC=cluster (SSI) $test"
     run_test "$UET_DEFS $UET_SSI_DEFS $CMD_BASE $actor $app_test $peer_ip"
     rudi_pass "$UET_DEFS $UET_SSI_DEFS"
+    uud_pass "$UET_DEFS $UET_SSI_DEFS"
 }
 
 function pds_server_ssi()
@@ -259,6 +279,7 @@ function pds_server_ssi()
     banner "PDS w/ SEC=server (SSI) $test"
     run_test "$UET_DEFS $UET_SSI_DEFS $CMD_BASE $actor $app_test $peer_ip"
     rudi_pass "$UET_DEFS $UET_SSI_DEFS"
+    uud_pass "$UET_DEFS $UET_SSI_DEFS"
 }
 
 if [ $pds = all -o $pds = sng             ]; then sng;             fi

--- a/uet.c
+++ b/uet.c
@@ -71,6 +71,11 @@
 
 #define UET_NUM_ITERATIONS	100
 #define UET_MSG_SIZE		4096	/* in bytes */
+#define UET_UUD_MSG_SIZE	1024	/* UUD is single-packet only */
+#define UET_UUD_BLAST_N		100	/* datagrams per UUD blast */
+#define UET_UUD_RX_TIMEOUT_MS	500	/* per-datagram bounded wait */
+#define UET_UUD_FIRST_TIMEOUT_MS 30000	/* server wait for 1st datagram */
+#define UET_UUD_DRAIN_QUIET	6	/* empty windows => blast is over */
 #define UET_MIN_ATOMIC_MSG_SIZE 24
 #define UET_NUM_BUFS		((size_t) 8)
 #define UET_DEFAULT_TAG		((uint64_t) 1)
@@ -103,7 +108,7 @@ typedef enum {
 void UET_USAGE(char *cmd)
 {
 	fprintf(stdout,
-	        "Usage: %s <server|client> <command> <remote IPv4 addr>\n"
+	        "Usage: %s <server|client> <command> <remote IPv4/v6 addr>\n"
 	         "  <command>: rma\n"
 	         "             sync_rma\n"
 	         "             untag\n"
@@ -115,7 +120,14 @@ void UET_USAGE(char *cmd)
 	         "             defer_tag\n"
 	         "             defer_tag_any_src\n"
 	         "             atomic\n"
-	         "             sync_atomic\n",
+	         "             sync_atomic\n"
+	         "             uud\n"
+	         "\n"
+	         "  PDS delivery-mode overrides (env vars, require UET_PDS=pds):\n"
+	         "    UET_FORCE_RUDI=1  force RUDI (reliable unordered, idempotent)\n"
+	         "                      on the 'rma' command\n"
+	         "    UET_FORCE_UUD=1   force UUD (unreliable datagram, best-effort)\n"
+	         "                      on the 'uud' command\n",
 	         cmd);
 }
 
@@ -127,6 +139,7 @@ struct uet_cfg {
 	bool tag_any_src;          /* true => tagged buffers match any source */
 	bool rma;                               /* true => use rma operations */
 	bool rudi;                              /* true => RMA data over RUDI */
+	bool uud;                           /* true => untagged send over UUD */
 	bool sync_rma;               /* true => use sync group rma operations */
 	bool atomic;                         /* true => use atomic operations */
 	bool sync_atomic;         /* true => use sync group atomic operations */
@@ -328,6 +341,12 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 	 */
 	ctx->cfg.rudi = (getenv("UET_FORCE_RUDI") != NULL);
 
+	/* When UUD is forced (using UET_FORCE_UUD), the untagged send rides
+	 * the best-effort datagram mode. UUD is single-packet only, so the
+	 * message size is capped to a single packet.
+	 */
+	ctx->cfg.uud = (getenv("UET_FORCE_UUD") != NULL);
+
 	if (argc == 4) {
 		if (strcmp(argv[2], "tag") != 0) {
 			if ((strcmp(argv[2], "rma") != 0) &&
@@ -387,7 +406,10 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 	addr->initiator_id = UET_ADDR_DEF_INITIATOR_ID;
 
 	ctx->cfg.num_iterations = UET_NUM_ITERATIONS;
-	if (ctx->cfg.dsend_test) {
+	if (ctx->cfg.uud) {
+		ctx->cfg.msg_size = UET_UUD_MSG_SIZE;
+		ctx->cfg.num_iterations = 1;
+	} else if (ctx->cfg.dsend_test) {
 		if (ctx->cfg.tag)
 			ctx->cfg.msg_size = UET_TAG_RENDEZVOUS_SIZE * 2;
 		else
@@ -803,6 +825,41 @@ static uet_rc_t uet_compl_wait(uet_cq_handle_t cq_handle,
 	}
 
 	return UET_SUCCESS_RC;
+}
+
+/*
+ * Bounded CQ poll: returns 1 if a completion was read, 0 on timeout, -1 on
+ * error. Unlike uet_compl_wait() this never blocks forever. Needed for UUD,
+ * where a lost datagram means a completion that will never arrive.
+ */
+static int uet_uud_poll(uet_cq_handle_t cq_handle,
+			struct fi_cq_data_entry *cq_entry,
+			int timeout_ms)
+{
+	struct fi_cq_err_entry err_entry;
+	time_t start, now;
+	ssize_t rc;
+
+	uet_gettime(&start);
+	while (1) {
+		rc = uet_cq_read(cq_handle, cq_entry, 1);
+		if (rc == 1)
+			return 1;
+
+		if (rc < 0) {
+			if (rc == -FI_EAVAIL)
+				uet_cq_readerr(cq_handle, &err_entry);
+
+			UET_ERR("uet_cq_read (uud): %s", fi_strerror(-rc));
+
+			return -1;
+		}
+
+		uet_gettime(&now);
+
+		if ((now - start) >= timeout_ms)
+			return 0;
+	}
 }
 
 /*
@@ -1806,6 +1863,163 @@ static uet_rc_t uet_msg_client_unexpected(struct uet_context *ctx)
 }
 
 /*
+ * UUD datagram test (best-effort, single-packet). A flow-controlled lock-step
+ * ping-pong: the client sends one untagged datagram and waits (bounded) for
+ * the server to echo it, before sending the next. Keeping a single datagram
+ * in flight means the server always has a receive posted (no unexpected
+ * message overrun) and paces the sender without any ACK/RTO. On a clean
+ * network every datagram round-trips. Under impairment a datagram may be
+ * LOST with no recovery. The bounded wait times out, the loss is counted, and
+ * both sides re-sync on the next datagram.
+ */
+static uet_rc_t uet_uud_client(struct uet_context *ctx)
+{
+	struct fi_cq_data_entry cq_entry;
+	bool impaired = false;
+	bool rx_posted = false;
+	int ok = 0, lost = 0, i;
+	ssize_t ret;
+	int got;
+
+	impaired = (getenv("UET_IMPAIRMENT_SHIM") != NULL);
+
+	for (i = 0; i < UET_UUD_BLAST_N; i++) {
+		/* One receive outstanding for the echo. Reposted only after
+		 * it is consumed so a lost echo leaves it to catch the next
+		 * one.
+		 */
+		if (!rx_posted) {
+			ret = uet_recv(ctx->ep_handle, UET_JOB_ID_ANY,
+				       ctx->rx_msg, ctx->cfg.msg_size,
+				       UET_NULL_HANDLE, UET_NULL_HANDLE, NULL);
+			if (ret < 0) {
+				UET_ERR("uet_recv (uud): %s", fi_strerror(-ret));
+				return UET_ERR_RC;
+			}
+
+			rx_posted = true;
+		}
+
+		ret = uet_send(ctx->ep_handle, ctx->cfg.job_id, ctx->tx_msg,
+			       ctx->cfg.msg_size, UET_NULL_HANDLE,
+			       ctx->peer_addr_handle, NULL);
+		if (ret < 0) {
+			UET_ERR("uet_send (uud): %s", fi_strerror(-ret));
+			return UET_ERR_RC;
+		}
+
+		/* UUD tx completes immediately (fire and forget) */
+		if (uet_compl_wait(ctx->tx_cq_handle, &cq_entry) !=
+		    UET_SUCCESS_RC) {
+			UET_ERR("uet_compl_wait (uud tx)");
+			return UET_ERR_RC;
+		}
+
+		/* Bounded wait for the echo. If missed then this datagram
+		 * was lost with no recovery.
+		 */
+		got = uet_uud_poll(ctx->rx_cq_handle, &cq_entry,
+				   UET_UUD_RX_TIMEOUT_MS);
+		if (got < 0)
+			return UET_ERR_RC;
+
+		if (got == 1) {
+			ok++;
+			rx_posted = false;   /* echo consumed the recv */
+		} else {
+			lost++;              /* recv stays posted; re-syncs */
+		}
+	}
+
+	printf("UUD client: %d/%d datagrams round-tripped (%d lost)\n",
+	       ok, UET_UUD_BLAST_N, lost);
+
+	/* On a clean network every datagram MUST round-trip. Under impairment,
+	 * loss is expected (fire-and-forget, no recovery) and is best effort.
+	 */
+	if (lost && !impaired) {
+		UET_ERR("UUD clean: %d datagrams lost with no impairment", lost);
+		return UET_ERR_RC;
+	}
+
+	return UET_SUCCESS_RC;
+}
+
+static uet_rc_t uet_uud_server(struct uet_context *ctx)
+{
+	struct fi_cq_data_entry cq_entry;
+	bool rx_posted = false;
+	int ok = 0, quiet = 0, tmo;
+	ssize_t ret;
+	int got;
+
+	/* Drain until all datagrams are received or the sender goes quiet.
+	 * Uses two-phase timing. Wait a long time for the FIRST datagram
+	 * then short quiet windows to detect the end of the blast.
+	 */
+	while ((ok < UET_UUD_BLAST_N) && (quiet < UET_UUD_DRAIN_QUIET)) {
+		if (!rx_posted) {
+			ret = uet_recv(ctx->ep_handle, UET_JOB_ID_ANY,
+				       ctx->rx_msg, ctx->cfg.msg_size,
+				       UET_NULL_HANDLE, UET_NULL_HANDLE, NULL);
+			if (ret < 0) {
+				UET_ERR("uet_recv (uud): %s", fi_strerror(-ret));
+				return UET_ERR_RC;
+			}
+
+			rx_posted = true;
+		}
+
+		tmo = (ok == 0) ? UET_UUD_FIRST_TIMEOUT_MS
+				: UET_UUD_RX_TIMEOUT_MS;
+
+		got = uet_uud_poll(ctx->rx_cq_handle, &cq_entry, tmo);
+		if (got < 0)
+			return UET_ERR_RC;
+
+		if (got == 0) {
+			quiet++;             /* recv stays posted */
+			continue;
+		}
+
+		quiet = 0;
+		rx_posted = false;
+
+		if (cq_entry.len != ctx->cfg.msg_size) {
+			UET_ERR("UUD: bad datagram size = %lu", cq_entry.len);
+			return UET_ERR_RC;
+		}
+
+		if (uet_validate_msg(ctx, ctx->rx_msg) != UET_SUCCESS_RC) {
+			UET_ERR("UUD: bad datagram data");
+			return UET_ERR_RC;
+		}
+
+		ok++;
+
+		/* echo the datagram back over UUD (fire and forget) */
+		ret = uet_send(ctx->ep_handle, ctx->cfg.job_id, ctx->tx_msg,
+			       ctx->cfg.msg_size, UET_NULL_HANDLE,
+			       ctx->peer_addr_handle, NULL);
+		if (ret < 0) {
+			UET_ERR("uet_send (uud echo): %s", fi_strerror(-ret));
+			return UET_ERR_RC;
+		}
+
+		if (uet_compl_wait(ctx->tx_cq_handle, &cq_entry) !=
+		    UET_SUCCESS_RC) {
+			UET_ERR("uet_compl_wait (uud echo tx)");
+			return UET_ERR_RC;
+		}
+	}
+
+	printf("UUD server: %d/%d datagrams received and echoed\n",
+	       ok, UET_UUD_BLAST_N);
+
+	return UET_SUCCESS_RC;
+}
+
+/*
  * perform client message data transfer as follows:
  *   - send message to server
  *   - wait for message to be echoed back
@@ -2106,9 +2320,13 @@ static int uet_run(int argc, char *argv[], struct uet_context *ctx)
 
 	for (use_iov = 0; use_iov <= 1; use_iov++) {
 		pds = getenv(UET_PDS);
-		/* TODO: IOV support for SNG mode */
-		if (((pds == NULL) || (strcmp(pds, "sng") == 0)) &&
-				      (use_iov == 1)) {
+		/* TODO: IOV support for SNG mode.
+		 * TODO: IOV support for UUD mode.
+		 */
+		if (((pds == NULL) ||
+		     (strcmp(pds, "sng") == 0) ||
+		     ctx->cfg.uud) &&
+		    (use_iov == 1)) {
 			continue;
 		}
 
@@ -2135,7 +2353,11 @@ static int uet_run(int argc, char *argv[], struct uet_context *ctx)
 		for (iteration = 0; iteration < ctx->cfg.num_iterations;
 		     iteration++) {
 			if (ctx->cfg.client) {
-				if (ctx->cfg.rma) {
+				if (ctx->cfg.uud) {
+					rc = uet_uud_client(ctx);
+					if (rc != UET_SUCCESS_RC)
+						goto exit;
+				} else if (ctx->cfg.rma) {
 					rc = uet_rma_client(ctx);
 					if (rc != UET_SUCCESS_RC)
 						goto exit;
@@ -2161,7 +2383,11 @@ static int uet_run(int argc, char *argv[], struct uet_context *ctx)
 						goto exit;
 				}
 			} else { /* server */
-				if (ctx->cfg.rma) {
+				if (ctx->cfg.uud) {
+					rc = uet_uud_server(ctx);
+					if (rc != UET_SUCCESS_RC)
+						goto exit;
+				} else if (ctx->cfg.rma) {
 					rc = uet_rma_server(ctx);
 					if (rc != UET_SUCCESS_RC)
 						goto exit;
@@ -2409,6 +2635,24 @@ int main(int argc, char *argv[])
 		test_argv[2] = "sync_atomic";
 		test_argv[3] = ip;
 		test_argv[4] = NULL;
+		memset(ctx, 0, sizeof(struct uet_context));
+
+		rc = uet_run(test_argc, test_argv, ctx);
+		if (rc != UET_SUCCESS_RC)
+			exit(rc);
+	}
+
+	/* UUD is standalone (not in 'all'): it needs UET_FORCE_UUD + the pds
+	 * backend and is a best-effort single-packet datagram send.
+	 */
+	if (strcmp(test, "uud") == 0) {
+		printf("\nUUD Datagram Test\n");
+		printf(  "=================\n");
+		test_argc = 3;
+		test_argv[0] = cmd;
+		test_argv[1] = c_s;
+		test_argv[2] = ip;
+		test_argv[3] = NULL;
 		memset(ctx, 0, sizeof(struct uet_context));
 
 		rc = uet_run(test_argc, test_argv, ctx);

--- a/uet_api.c
+++ b/uet_api.c
@@ -3175,28 +3175,32 @@ static uet_ses_rc_t uet_rx_req_pkt(
 			}
 		}
 	} else { /* first packet of message */
-		/* check that generation is enabled */
-		if (tagged) {
-			ep_gen_disabled = uet_ep->tagged_gen_disabled;
-			ep_gen = (uint32_t) uet_ep->tagged_gen;
-		} else {
-			ep_gen_disabled = uet_ep->untagged_gen_disabled;
-			ep_gen = (uint32_t) uet_ep->untagged_gen;
-		}
-		if (ep_gen_disabled) {
-			UET_API_ERR("RX: Disabled Generation");
-			return (uet_rx_msg_err(uet_ep, pp, rx_desc,
-					UET_RC_DISABLED_GEN));
-		}
+		/* UUD is connectionless and has no generation semantics */
+		if (pp->pds_type != UET_PDS_TYPE_UUD_REQ) {
+			/* check that generation is enabled */
+			if (tagged) {
+				ep_gen_disabled = uet_ep->tagged_gen_disabled;
+				ep_gen = (uint32_t) uet_ep->tagged_gen;
+			} else {
+				ep_gen_disabled = uet_ep->untagged_gen_disabled;
+				ep_gen = (uint32_t) uet_ep->untagged_gen;
+			}
 
-		/* check for correct generation */
-		rx_gen = (uint32_t)((ntohl(ses->cmn.ri_gen_job_id) &
-				     UET_SES_REQ_RI_GEN_MASK) >>
-				    UET_SES_REQ_RI_GEN_SHIFT);
-		if (rx_gen != ep_gen) {
-			UET_API_ERR("RX: Bad Generation");
-			return (uet_rx_msg_err(uet_ep, pp, rx_desc,
-					UET_RC_BAD_GENERATION));
+			if (ep_gen_disabled) {
+				UET_API_ERR("RX: Disabled Generation");
+				return (uet_rx_msg_err(uet_ep, pp, rx_desc,
+						       UET_RC_DISABLED_GEN));
+			}
+
+			/* check for correct generation */
+			rx_gen = (uint32_t)((ntohl(ses->cmn.ri_gen_job_id) &
+					     UET_SES_REQ_RI_GEN_MASK) >>
+					    UET_SES_REQ_RI_GEN_SHIFT);
+			if (rx_gen != ep_gen) {
+				UET_API_ERR("RX: Bad Generation");
+				return (uet_rx_msg_err(uet_ep, pp, rx_desc,
+						       UET_RC_BAD_GENERATION));
+			}
 		}
 
 		/* find buffer */
@@ -3250,8 +3254,13 @@ static uet_ses_rc_t uet_rx_req_pkt(
 							      false, NULL);
 				if (ses_rc == UET_RC_NO_MATCH)
 					UET_API_ERR("RX: Unexpected Message");
-				if (uet_get_pds_mode(uet_ep, false) ==
-				    UET_PDS_MODE_ROD)
+				/* UUD is stateless and an unexpected datagram
+				 * is simply dropped (best effort). Generation
+				 * is always disabled.
+				 */
+				if ((uet_get_pds_mode(uet_ep, false) ==
+				     UET_PDS_MODE_ROD) &&
+				    (pp->pds_type != UET_PDS_TYPE_UUD_REQ))
 					uet_ep->untagged_gen_disabled = true;
 				return (uet_rx_msg_err(uet_ep, pp, rx_desc,
 						       ses_rc));
@@ -5350,6 +5359,14 @@ static ssize_t uet_send_req_api_common(
 	    (remote_key & UET_MR_KEY_IDEMPOTENT_SAFE) &&
 	    (av_entry->addr->fep_cap & UET_FEP_CAP_HPC))
 		tx_desc->pds_mode = UET_PDS_MODE_RUDI;
+
+	/* force UUD when UET_FORCE_UUD is set for a single-packet untagged
+	 * SEND
+	 */
+	if ((send_req_api == UET_SEND_API) &&
+	    getenv("UET_FORCE_UUD") &&
+	    (msg_len <= uet_ep->uet_domain->uet->max_payload_len))
+		tx_desc->pds_mode = UET_PDS_MODE_UUD;
 
 	if (tx_desc->pds_mode == UET_PDS_MODE_ROD)
 		tx_desc->seq_num = uet_alloc_av_msg_seq_num(av_entry);

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -22,6 +22,7 @@
 #include "uet_pkt_hdr.h"
 #include "uet_sec.h"
 #include "uet_pds_rudi.h"
+#include "uet_pds_uud.h"
 #include "imp_shim.h"
 #include "bitmap.h"
 #include "crc32c.h"
@@ -1346,6 +1347,15 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 					   pds_info, msg_id, next_hdr, ses,
 					   ses_len, pkt, pkt_len, dma_rdy);
 
+	/* UUD is connectionless: hand off to the UUD engine before any PDC
+	 * assignment. None of the PDC/PSN/ACK machinery below applies.
+	 */
+	if (mode == UET_PDS_MODE_UUD)
+		return uet_pds_uud_tx_pkt(tx_pkt_handle, pkt_cnt, uet_ep,
+					  dst_addr_handle, mode, flags,
+					  pds_info, msg_id, next_hdr, ses,
+					  ses_len, pkt, pkt_len, dma_rdy);
+
 	switch (mode) {
 	case UET_PDS_MODE_RUD:
 		pds_pkt_type = UET_PDS_TYPE_RUD_REQ;
@@ -1950,10 +1960,11 @@ int uet_pds_msg_cmpl_ind(struct uet_ep *uet_ep,
 	struct uet_pdc *pdc;
 	int rc;
 
-	/* RUDI is connectionless so no PDC/msgid state to complete. SES
-	 * calls this for every READ_REQ completion, including RUDI reads.
+	/* RUDI and UUD are connectionless so there is no PDC/msgid state to
+	 * complete. SES calls this for every READ_REQ completion (RUDI) and
+	 * has no PDC for UUD datagrams.
 	 */
-	if (mode == UET_PDS_MODE_RUDI)
+	if ((mode == UET_PDS_MODE_RUDI) || (mode == UET_PDS_MODE_UUD))
 		return 0;
 
 	pdc = uet_pdsm_get_msgid_pdc(msg_id);
@@ -3279,6 +3290,12 @@ int uet_pds_progress_rx(struct uet_instance *uet)
 	if ((pp.pds_type == UET_PDS_TYPE_RUDI_REQ) ||
 	    (pp.pds_type == UET_PDS_TYPE_RUDI_RESP))
 		return uet_pds_rudi_rx(uet, &pp, pkt, pkt_len);
+
+	/* UUD is connectionless and demuxed here by pds_type. The UUD
+	 * engine takes ownership of pkt.
+	 */
+	if (pp.pds_type == UET_PDS_TYPE_UUD_REQ)
+		return uet_pds_uud_rx(uet, &pp, pkt, pkt_len);
 
 	if (pkt_is_ack) {
 

--- a/uet_pds_uud.c
+++ b/uet_pds_uud.c
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2026, Broadcom. All rights reserved. The term
+ * Broadcom refers to Broadcom Limited and/or its subsidiaries.
+ */
+
+/* UUD (Unreliable Unordered Delivery) engine */
+
+/*
+ * UUD + TSS: REPLAY PROTECTION IS **NOT** SUPPORTED! UUD is connectionless
+ * with no PDC/PSN state, so there is no anti-replay window. Packets may be
+ * lost/replayed/duplicated.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <arpa/inet.h>
+
+#include "uet_api.h"
+#include "uet_api_private.h"
+#include "uet_pds.h"
+#include "uet_pds_uud.h"
+#include "uet_util.h"
+#include "uet_log.h"
+#include "uet_pkt_hdr.h"
+#include "uet_sec.h"
+#include "uet_nic.h"
+#include "imp_shim.h"
+#include "crc32c.h"
+
+#define UET_UUD_ENTROPY 0x5555
+
+/* scratch structure for building/transmitting one UUD datagram. */
+struct uet_uud_pkt {
+	uint8_t  *pkt_buf; /* full buffer (incl sec headroom) */
+	int       pkt_buf_len;
+	uint8_t  *pkt; /* start of eth frame (cleartext) */
+	int       pkt_len; /* cleartext frame len (no crc/tag) */
+	bool      sec_enabled;
+	uint32_t  sdi;
+	uint32_t  ssi;
+	bool      is_ipv6;
+};
+
+/* FIXME: get the security SDI/SSI, same source as uet_pdsm_get_sdi()! */
+static void uet_uud_get_sec(bool *sec_enabled, uint32_t *sdi, uint32_t *ssi)
+{
+	char *sec_ssi;
+
+	*sec_enabled = !!getenv(UET_SEC_MODE);
+	*sdi = 1; /* fixed SDI, matches the PDC path */
+	*ssi = 0;
+
+	sec_ssi = getenv(UET_SEC_SSI);
+	if (sec_ssi)
+		*ssi = strtoul(sec_ssi, NULL, 10);
+}
+
+/* Apply CRC (no security) or security header + encryption, then transmit the
+ * frame once. PDC-free; there is no retransmit so no cleartext copy is kept.
+ */
+static int uet_uud_send(struct uet_instance *uet, struct uet_uud_pkt *up)
+{
+	struct uet_parsed_pkt pp;
+	uint8_t *out;
+	int out_len;
+	uint8_t *crc_start;
+	uint32_t crc;
+	uint8_t *new_pkt;
+	int new_pkt_len;
+	uint8_t *enc_pkt;
+	int enc_pkt_len;
+	uint8_t *enc_ip;
+	int rc;
+
+	if (!up->sec_enabled) {
+		rc = uet_parse_pkt(uet, up->pkt, up->pkt_len, &pp);
+		if (rc != 0)
+			return rc;
+
+		/* CRC covers from the IP src addr through the payload */
+		crc_start = (pp.is_ipv6) ? ((uint8_t *)pp.ip + 8)
+					 : ((uint8_t *)pp.ip + 12);
+		crc = crc32c(crc_start,
+			     (pp.pkt_len - (crc_start - (uint8_t *)pp.eth)));
+		memcpy((up->pkt + up->pkt_len), &crc, CRC_LEN);
+
+		out = up->pkt;
+		out_len = up->pkt_len + CRC_LEN;
+
+		if (imp_shim_is_enabled())
+			return imp_shim_tx_pkt(UET_NIC(uet), out, pp.ip, out_len);
+
+		return uet_nic_tx_pkt(UET_NIC(uet), out, pp.ip, out_len);
+	}
+
+	/* security enabled */
+	rc = uet_sec_build_hdr(up->sdi, up->ssi, up->pkt_buf, up->pkt_buf_len,
+			       up->pkt, up->pkt_len, &new_pkt, &new_pkt_len,
+			       up->is_ipv6);
+	if (rc != 0)
+		return rc;
+
+	up->pkt = new_pkt;
+	up->pkt_len = (new_pkt_len + UET_SEC_TAG_LEN);
+
+	rc = uet_parse_pkt(uet, up->pkt, up->pkt_len, &pp);
+	if (rc != 0)
+		return rc;
+
+	if (pp.is_ipv6) {
+		uet_update_ipv6_pl(pp.ip,
+				   (up->pkt_len - uet->nic.l2_hdr_size -
+				    sizeof(struct ipv6hdr)));
+	} else {
+		uet_update_ipv4_tl(pp.ip,
+				   (up->pkt_len - uet->nic.l2_hdr_size));
+	}
+
+	rc = uet_sec_enc_pkt(uet, up->pkt_buf, up->pkt_buf_len, up->pkt,
+			     up->pkt_len, &enc_pkt, &enc_pkt_len, up->is_ipv6);
+	if (rc != 0)
+		return rc;
+
+	/* the IP header sits at a fixed offset in the encrypted frame */
+	enc_ip = enc_pkt + sizeof(struct ethhdr);
+
+	if (imp_shim_is_enabled())
+		return imp_shim_tx_pkt(UET_NIC(uet), enc_pkt, enc_ip,
+				       enc_pkt_len);
+
+	return uet_nic_tx_pkt(UET_NIC(uet), enc_pkt, enc_ip, enc_pkt_len);
+}
+
+/* Build a UUD datagram frame (eth/ip/entropy/UUD/SES/payload) into a freshly
+ * allocated buffer.
+ */
+static int uet_uud_build_frame(struct uet_instance *uet,
+			       uint8_t tos,
+			       const uint8_t *dst_mac,
+			       const struct uet_fa *dst_fa,
+			       bool is_ipv6, bool sec_enabled,
+			       uet_pds_next_hdr_t next_hdr,
+			       void *ses, size_t ses_len,
+			       void *payload, size_t payload_len,
+			       struct uet_uud_pkt *up)
+{
+	struct uet_entropy *entropy_hdr;
+	struct uet_pds_uud_req *uud_hdr;
+	void *ses_hdr, *pl;
+	size_t ip_hdr_size;
+	int hdr_len;
+	uint16_t tnf;
+	struct uet_fa src_ip;
+
+	ip_hdr_size = (is_ipv6) ? sizeof(struct ipv6hdr)
+				: sizeof(struct iphdr);
+
+	memset(&src_ip, 0, sizeof(src_ip));
+
+	if (is_ipv6)
+		memcpy(src_ip.v6, uet->nic.ipv6_addr, 16);
+	else
+		src_ip.v4 = uet->nic.ipv4_addr;
+
+	up->pkt_buf_len = (uet->nic.max_pkt_size * ((sec_enabled) ? 2 : 1));
+	up->pkt_buf = calloc(1, up->pkt_buf_len);
+	if (up->pkt_buf == NULL) {
+		UET_PDS_ERR("UUD: failed to alloc packet buffer");
+		return -ENOMEM;
+	}
+
+	/* reserve head space for the security header if needed */
+	up->pkt = (sec_enabled) ? (up->pkt_buf + UET_SEC_MAX_HDR_LEN)
+				: up->pkt_buf;
+
+	uet_build_eth_hdr((struct ethhdr *)up->pkt, (uint8_t *)dst_mac,
+			  uet->nic.mac_addr, is_ipv6);
+
+	entropy_hdr = (struct uet_entropy *)(up->pkt + sizeof(struct ethhdr) +
+					     ip_hdr_size);
+	uud_hdr = (struct uet_pds_uud_req *)(up->pkt + sizeof(struct ethhdr) +
+					     ip_hdr_size +
+					     sizeof(struct uet_entropy));
+	ses_hdr = (uud_hdr + 1);
+	pl = ((uint8_t *)ses_hdr + ses_len);
+
+	hdr_len = (sizeof(struct ethhdr) +
+		   ip_hdr_size +
+		   sizeof(struct uet_entropy) +
+		   sizeof(struct uet_pds_uud_req) +
+		   ses_len);
+
+	up->pkt_len = (hdr_len + payload_len);
+
+	/* fill in the entropy */
+	entropy_hdr->entropy = htons(UET_UUD_ENTROPY);
+	entropy_hdr->rsvd = 0;
+
+	/* fill in the UUD header */
+	tnf = ((UET_PDS_TYPE_UUD_REQ << UET_PDS_TYPE_SHIFT) |
+	       (next_hdr << UET_PDS_NEXT_HDR_SHIFT));
+	uud_hdr->prlg.type_next_flags = htons(tnf);
+	uud_hdr->rsvd = 0;
+
+	/* fill in the SES header */
+	if (ses_len)
+		memcpy(ses_hdr, ses, ses_len);
+
+	/* fill in the payload */
+	if (payload_len)
+		memcpy(pl, payload, payload_len);
+
+	/* IP header (crc_en=true only when security is disabled) */
+	if (is_ipv6) {
+		uet_build_ipv6_hdr(uet,
+				   (struct ipv6hdr *)(up->pkt +
+						      sizeof(struct ethhdr)),
+				   dst_fa->v6, src_ip.v6,
+				   (up->pkt_len - uet->nic.l2_hdr_size -
+				    ip_hdr_size),
+				   tos, !sec_enabled);
+	} else {
+		uet_build_ipv4_hdr(uet,
+				   (struct iphdr *)(up->pkt +
+						    sizeof(struct ethhdr)),
+				   htonl(dst_fa->v4), htonl(src_ip.v4),
+				   (up->pkt_len - uet->nic.l2_hdr_size),
+				   tos, !sec_enabled);
+	}
+
+	return 0;
+}
+
+int uet_pds_uud_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
+		       uint64_t pkt_cnt,
+		       struct uet_ep *uet_ep,
+		       uet_addr_handle_t dst_addr_handle,
+		       uet_pds_mode_t mode,
+		       uet_pds_tx_flags_t flags,
+		       struct uet_pds_info *pds_info,
+		       uint16_t msg_id,
+		       uet_pds_next_hdr_t next_hdr,
+		       void *ses,
+		       size_t ses_len,
+		       void *pkt,
+		       size_t pkt_len,
+		       bool dma_rdy)
+{
+	struct uet_instance *uet = uet_ep->uet_domain->uet;
+	struct uet_av_entry *av = (struct uet_av_entry *)dst_addr_handle;
+	bool is_ipv6 = uet_addr_is_ipv6(av->addr);
+	struct uet_uud_pkt up;
+	bool sec_enabled;
+	uint32_t sdi, ssi;
+	int rc;
+
+	/* UUD is a datagram send only with no return-data (read) path */
+	if (pds_info) {
+		UET_PDS_ERR("UUD: return-data path not supported (send only)");
+		return -ENOSYS;
+	}
+
+	uet_uud_get_sec(&sec_enabled, &sdi, &ssi);
+
+	memset(&up, 0, sizeof(up));
+	up.sec_enabled = sec_enabled;
+	up.sdi         = sdi;
+	up.ssi         = ssi;
+	up.is_ipv6     = is_ipv6;
+
+	rc = uet_uud_build_frame(uet, uet_ep->msg_ip_tos, av->nh_mac_addr,
+				 &av->addr->fa, is_ipv6, sec_enabled, next_hdr,
+				 ses, ses_len, pkt, pkt_len, &up);
+	if (rc != 0)
+		return rc;
+
+	rc = uet_uud_send(uet, &up);
+
+	UET_PDS_DBG("UUD TX REQ msg_id %u len %d%s (rc %d)",
+		    msg_id, up.pkt_len, (sec_enabled) ? " (sec)" : "", rc);
+
+	free(up.pkt_buf);
+
+	if (rc != 0)
+		return rc;
+
+	/* Fire-and-forget: no response will arrive, so complete the SES tx
+	 * descriptor immediately. rx_rsp() with a NULL response packet just
+	 * decrements unack_pkts (the "implicitly acknowledged" path).
+	 */
+	uet->pds.upcall.rx_rsp(tx_pkt_handle, NULL);
+
+	return 0;
+}
+
+int uet_pds_uud_rx(struct uet_instance *uet,
+		   struct uet_parsed_pkt *pp,
+		   uint8_t *pkt,
+		   size_t pkt_len)
+{
+	struct uet_pds_info pds_info;
+	uet_pds_next_hdr_t rsp_next_hdr;
+	uint8_t rsp_ses_hdr[sizeof(struct uet_ses_rsp_d)];
+	size_t rsp_ses_hdr_len;
+	bool ses_nack = false, gtd_del = false;
+	int rc;
+
+	/*
+	 * Note: rx_req writes a response SES header to the rsp_ses_hdr
+	 * buffer without any payload. No response is ever sent for a UUD
+	 * request so the buffer is just a local sink.
+	 */
+
+	memset(&pds_info, 0, sizeof(pds_info));
+
+	/* Deliver the untagged single-packet send to a posted receive. SES
+	 * generates the rx completion inline.
+	 */
+	rc = uet->pds.upcall.rx_req((uet_pkt_handle_t)pp, uet, pp, &pds_info,
+				    &rsp_next_hdr, rsp_ses_hdr, &rsp_ses_hdr_len,
+				    &ses_nack, &gtd_del);
+	if (rc != 0)
+		UET_PDS_ERR("UUD: SES rx_req failed (rc %d)", rc);
+
+	UET_PDS_DBG("UUD RX REQ delivered (no response)");
+
+	free(pkt);
+
+	return rc;
+}

--- a/uet_pds_uud.h
+++ b/uet_pds_uud.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, Broadcom. All rights reserved. The term
+ * Broadcom refers to Broadcom Limited and/or its subsidiaries.
+ */
+
+/*
+ * UUD (Unreliable Unordered Delivery) engine. UUD is a connectionless
+ * best-effort datagram mode with no PDC, no PSN, no ACK, no response, no
+ * retransmit, etc. A single-packet untagged send is transmitted once (fire and
+ * forget). The initiator completes immediately on transmit and the target
+ * delivers the payload to a posted receive and sends no response. This UUD
+ * engine bypasses the PDS PDC control plane entirely.
+ */
+
+#ifndef _UET_PDS_UUD_H_
+#define _UET_PDS_UUD_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "uet_pds.h"
+#include "uet_util.h"
+
+struct uet_ep;
+struct uet_instance;
+
+/* Transmit one UUD datagram (mode=UUD path of uet_pds_tx_pkt). Same arguments
+ * as the PDS engine's tx_pkt() downcall. Completes at the initiator on
+ * transmit (no response is expected).
+ */
+int uet_pds_uud_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
+		       uint64_t pkt_cnt,
+		       struct uet_ep *uet_ep,
+		       uet_addr_handle_t dst_addr_handle,
+		       uet_pds_mode_t mode,
+		       uet_pds_tx_flags_t flags,
+		       struct uet_pds_info *pds_info,
+		       uint16_t msg_id,
+		       uet_pds_next_hdr_t next_hdr,
+		       void *ses,
+		       size_t ses_len,
+		       void *pkt,
+		       size_t pkt_len,
+		       bool dma_rdy);
+
+/* Process a received UUD packet. Dispatched from the PDS engine's
+ * uet_pds_progress_rx(). Delivers the untagged send and sends no response.
+ * Takes full ownership of the packet!
+ */
+int uet_pds_uud_rx(struct uet_instance *uet, struct uet_parsed_pkt *pp,
+		   uint8_t *pkt, size_t pkt_len);
+
+#endif /* _UET_PDS_UUD_H_ */

--- a/util/uet_pkt_chk.c
+++ b/util/uet_pkt_chk.c
@@ -61,9 +61,10 @@ static bool uet_pds_pkt_type_valid(uint8_t *pkt,
 		pds_req = true;
 		break;
 	case UET_PDS_TYPE_UUD_REQ:
-		/* TODO: unsupported */
-		UET_PDS_WARN("UUD_REQ packets not supported");
-		return false;
+		/* UUD is connectionless and demuxed by pds_type in
+		 * uet_pds_progress_rx(). Simply accept it here.
+		 */
+		return true;
 	case UET_PDS_TYPE_ACK:
 	case UET_PDS_TYPE_ACK_CC:
 	case UET_PDS_TYPE_ACK_CCX:

--- a/util/uet_util.c
+++ b/util/uet_util.c
@@ -1196,8 +1196,8 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 		}
 		break;
 	case UET_PDS_TYPE_UUD_REQ:
-		/* TODO: support for parsing UUD */
-		return -EINVAL;
+		pp->pds_len = sizeof(struct uet_pds_uud_req);
+		break;
 	case UET_PDS_TYPE_ACK:
 	case UET_PDS_TYPE_ACK_CC:
 	case UET_PDS_TYPE_ACK_CCX:


### PR DESCRIPTION
- uet_pds_uud.h/.c: new UUD engine (build/send frame, CRC + TSS, rx delivery)
- uet_pds.c: tx/rx/msg_cmpl hooks for mode UUD
- uet_api.c: UET_FORCE_UUD to force single-packet SES with UUD mode
- util/: parse and accept UUD_REQ packets
- uet.c: flow-controlled best-effort 'uud' UUD datagram test
- scripts/uet_test.sh: add 'uud' test, run it in test=all on pds backends
- README updated and new impairment shim configs