### PR TITLE
uet_sec: TSS counter, stats/enforcement, SDKDB breakout, AN key rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,11 +201,13 @@ Replace `2` with the desired number of senders.
 - **UET_PDS_ACK_TYPE** - [ `ack` | `ack_cc` | `ack_ccx` ] (default=`ack`)
 - **UET_PDS_TX_TIMEOUT** - Time in milliseconds to wait for an ack before retransmitting a Tx packet (default=`5`).
 - **UET_PDS_MAX_TX_RETRIES** - Max number of times a Tx packet is retransmitted before failing (default=`5`).
+- **UET_NUM_ITERATIONS** - Override the number of message iterations the test app runs (default=`100`). Used to wall-clock-size a run (e.g., long enough to span several TSS key rotations).
 - **UET_FORCE_RUDI** - [ `0` | `1` ] (default=`0`) Force the RUDI (Reliable Unordered Delivery for Idempotent operations) PDS delivery mode for RMA read/write operations.
 - **UET_FORCE_UUD** - [ `0` | `1` ] (default=`0`) Force the UUD (Unreliable Unordered Delivery) best-effort single-packet datagram PDS delivery mode for an untagged send.
 - **UET_SEC_MODE** - [ `direct` | `cluster` | `server` ]
 - **UET_SEC_SSI** - The SSI to be used for crypto operations. This value must be unique for all instances of `uet`. If not set the source IP address will be used instead as the source identifier.
 - **UET_SEC_CLIENT_SSI** - If set, the client SSI to be used by the server side of the session. This is only valid for the `UET_SEC_MODE=server` configuration.
+- **UET_SEC_KEY_ROTATION** - [ `0` | `1` ] (default=`0`) Enable AN key rotation for TSS (an SDME stand-in test). Both peers rotate keys off the shared wall clock, so no key exchange is needed. Not supported in `server` mode. See [Key Rotation](#key-rotation).
 - **UET_PDC_CLOSE_THRESH** - Randomly close a PDC after message Tx EOM (100=1% chance to close, default=0).
 - **UET_PKT_DROP_THRESH** - Randomly drop a Tx packet before sending (100=1% chance to drop, default=0). Ignored when `UET_IMPAIRMENT_SHIM` is set.
 - **UET_IMPAIRMENT_SHIM** - Path to a TOML configuration file that enables the impairment shim. See [Impairment Shim](#impairment-shim) below.
@@ -218,9 +220,10 @@ TSS are supported and environment variables are used to select/configure
 the mode.
 
 At this stage of the implementation, only a single static Secure Domain (SD)
-is provisioned with a fixed set of cryptographic keys. No key exchanges or
-key rotations are supported. Note that automatic rekeying is enabled using the
-timestamp field in the packet security header.
+is provisioned with a fixed set of cryptographic keys. No key exchange is
+supported. Automatic rekeying is enabled using the counter (TSC) field in the
+packet security header. AN key rotation is available as a test feature
+(`UET_SEC_KEY_ROTATION`), see [Key Rotation](#key-rotation) below.
 
 - Direct mode
     - `UET_SEC_MODE=direct`
@@ -281,6 +284,27 @@ Example for `server` mode:
        UET_SEC_MODE=server \
        UET_SEC_SSI=2 \
        ./uet client 192.168.1.1
+```
+
+### Key Rotation
+
+Setting `UET_SEC_KEY_ROTATION=1` enables AN (Association Number) key
+rotation, a test stand-in for the out-of-band, SDME-driven rotation of a
+real deployment. Both peers rotate through a compiled-in pool of keys on
+a fixed interval derived from the absolute wall clock, so they stay
+synchronized without any key exchange or signaling (the peers must be
+NTP-synced). Per the TSS spec, each rotation resets the security counter
+and epoch and a fresh per-rotation key preserves IV uniqueness across the
+reset. Rotation is not supported in `server` mode.
+
+Because a rotation spans several seconds, a meaningful test must run long enough
+to cross several rotations — use `UET_NUM_ITERATIONS` to size the run. Example
+(cluster mode with rotation, on both server and client):
+
+```
+       UET_SEC_MODE=cluster
+       UET_SEC_KEY_ROTATION=1
+       UET_NUM_ITERATIONS=800
 ```
 
 ### Crypto

--- a/scripts/uet_test.sh
+++ b/scripts/uet_test.sh
@@ -25,7 +25,7 @@ fi
 
 # Valid "test", "pds", and "shim" names
 test_names=(all rma rudi uud sync_rma atomic sync_atomic tag tag_any_src unexp_untag unexp_tag defer_send defer_tag defer_tag_any_src)
-pds_names=(all sng pds pds_direct pds_cluster pds_cluster_ssi pds_server_ssi)
+pds_names=(all sng pds pds_direct pds_cluster pds_cluster_ssi pds_server_ssi pds_cluster_key_rot)
 shim_names=(rawsock xdp)
 
 # (not for sng) default ACK type: ack, ack_cc, ack_ccx
@@ -39,7 +39,7 @@ ACK_TYPE=ack_cc
 # default RTO would fire on merely-slow (not lost) packets, causing a
 # spurious-retransmit storm.
 TX_TIMEOUT=5
-TX_TIMEOUT_SEC=10
+TX_TIMEOUT_SEC=25
 TX_TIMEOUT_IMP=100
 MAX_TX_RETRIES=5
 
@@ -262,6 +262,17 @@ function pds_cluster()
     uud_pass "$UET_DEFS"
 }
 
+# Long, wall-clock-sized cluster run with AN key rotation enabled. Both
+# peers rotate keys off the shared wall clock (no SDME, no signaling), so no
+# exchange is needed. Sized via UET_NUM_ITERATIONS to span several rotations
+# and at least one key-pool wrap.
+function pds_cluster_key_rot()
+{
+    UET_DEFS="UET_PDS=pds UET_SEC_MODE=cluster UET_SEC_KEY_ROTATION=1 UET_NUM_ITERATIONS=800"
+    banner "PDS w/ SEC=cluster + AN key rotation $test"
+    run_test "$UET_DEFS $CMD_BASE $actor $app_test $peer_ip"
+}
+
 function pds_cluster_ssi()
 {
     UET_DEFS="UET_PDS=pds UET_SEC_MODE=cluster"
@@ -282,12 +293,13 @@ function pds_server_ssi()
     uud_pass "$UET_DEFS $UET_SSI_DEFS"
 }
 
-if [ $pds = all -o $pds = sng             ]; then sng;             fi
-if [ $pds = all -o $pds = pds             ]; then pds;             fi
-if [ $pds = all -o $pds = pds_direct      ]; then pds_direct;      fi
-if [ $pds = all -o $pds = pds_cluster     ]; then pds_cluster;     fi
-if [ $pds = all -o $pds = pds_cluster_ssi ]; then pds_cluster_ssi; fi
-if [ $pds = all -o $pds = pds_server_ssi  ]; then pds_server_ssi;  fi
+if [ $pds = all -o $pds = sng             ]; then sng;                 fi
+if [ $pds = all -o $pds = pds             ]; then pds;                 fi
+if [ $pds = all -o $pds = pds_direct      ]; then pds_direct;          fi
+if [ $pds = all -o $pds = pds_cluster     ]; then pds_cluster;         fi
+if [ $pds = all -o $pds = pds_cluster_ssi ]; then pds_cluster_ssi;     fi
+if [ $pds = all -o $pds = pds_server_ssi  ]; then pds_server_ssi;      fi
+if [ $pds = pds_cluster_key_rot           ]; then pds_cluster_key_rot; fi
 
 banner "Done!"
 

--- a/uet.c
+++ b/uet.c
@@ -70,6 +70,8 @@
 #include "uet_sec.h"
 
 #define UET_NUM_ITERATIONS	100
+#define UET_ITERATIONS_ENV	"UET_NUM_ITERATIONS"
+
 #define UET_MSG_SIZE		4096	/* in bytes */
 #define UET_UUD_MSG_SIZE	1024	/* UUD is single-packet only */
 #define UET_UUD_BLAST_N		100	/* datagrams per UUD blast */
@@ -317,6 +319,7 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 	struct in_addr peer_in_addr;
 	struct in6_addr peer_in6_addr;
 	struct uet_addr *addr;
+	char *env_iters;
 
 	ctx->cfg.job_id = UET_DEF_JOB_ID;
 
@@ -406,6 +409,15 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 	addr->initiator_id = UET_ADDR_DEF_INITIATOR_ID;
 
 	ctx->cfg.num_iterations = UET_NUM_ITERATIONS;
+
+	/* harness override the number of iterations executed */
+	env_iters = getenv(UET_ITERATIONS_ENV);
+	if (env_iters != NULL) {
+		int n = atoi(env_iters);
+		if (n > 0)
+			ctx->cfg.num_iterations = n;
+	}
+
 	if (ctx->cfg.uud) {
 		ctx->cfg.msg_size = UET_UUD_MSG_SIZE;
 		ctx->cfg.num_iterations = 1;

--- a/uet_api.c
+++ b/uet_api.c
@@ -2022,6 +2022,7 @@ static void uet_domain_free_all(struct uet_instance *uet)
 /* free most resources associated with uet instance */
 static void uet_finalize_core(struct uet_instance *uet)
 {
+	uet_sec_finalize();
 	uet_ep_hash_finalize(uet);
 	imp_shim_finalize();
 	uet_nic_finalize(UET_NIC(uet));

--- a/uet_sec.c
+++ b/uet_sec.c
@@ -3,6 +3,12 @@
  * Broadcom refers to Broadcom Limited and/or its subsidiaries.
  */
 
+/* Transport Security Sublayer (TSS) crypto core: per-packet security header
+ * build/refresh and AES-GCM encrypt/decrypt. The secure-domain database
+ * (SDKDB), key material, statistics, and the AN key-rotation (SDME stand-in)
+ * lives in uet_sec_sd.c.
+ */
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -15,99 +21,11 @@
 #include "kdf_ctr_cmac_aes.h"
 #include "gcm.h"
 
-#define UET_SEC_MAX_SD         8
-#define UET_SEC_FAM_V4         0
-#define UET_SEC_FAM_V6         1
-#define UET_SEC_FAM(is_ipv6)   ((is_ipv6) ? UET_SEC_FAM_V6 : UET_SEC_FAM_V4)
-#define UET_SEC_KEY_SIZE       32
-#define UET_SEC_KDF_GEN_SIZE   44
-#define UET_SEC_CTR_SIZE       8
-#define UET_SEC_SMALL_CTX_SIZE 10
-#define UET_SEC_LARGE_CTX_SIZE 26
-#define UET_SEC_IV_SIZE        12
+#define UET_SEC_IV_SIZE 12
 
-typedef enum {
-	UET_SEC_ALG_NONE        = 0,
-	UET_SEC_ALG_AES_GCM_256 = 1,
-} uet_sec_alg_t;
-
-typedef enum {
-	UET_SEC_MODE_NONE    = 0,
-	UET_SEC_MODE_DIRECT  = 1,
-	UET_SEC_MODE_CLUSTER = 2,
-	UET_SEC_MODE_SERVER  = 3,
-} uet_sec_mode_t;
-
-struct uet_sec_sd {
-	bool           enabled;
-	uint32_t       sdi;
-	uet_sec_mode_t mode;
-	bool           use_ssi;
-	bool           rekey;
-	uint64_t       rekey_mask;
-	uint8_t        rekey_shift;
-	uint16_t       coff;
-	uet_sec_alg_t  alg;
-	uint16_t       epoch;
-	uint8_t        an;
-	/* [family][an] - per-family key material (aoff derived from family) */
-	uint8_t        key[2][2][UET_SEC_KDF_GEN_SIZE];
-};
-
-static struct uet_sec_sd sdkdb[UET_SEC_MAX_SD];
-
-static char *uet_sec_label1 = "U1";
-static char *uet_sec_label2 = "U2";
-
-/************************************************************************/
-/* FIXME: Default fields used for the fixed SD... not yet configurable! */
-/************************************************************************/
-
-/* key generation: `dd if=/dev/urandom ibs=32 count=1 | xxd -i -c 8` */
-
-static uint8_t def_key[2][UET_SEC_KDF_GEN_SIZE] = {
-	{
-		0x07, 0xe9, 0x72, 0x49, 0x58, 0xd9, 0xe1, 0xf7,
-		0x10, 0xf5, 0x94, 0xe1, 0x8e, 0x11, 0xfd, 0x8d,
-		0x4a, 0x35, 0x82, 0xc2, 0x56, 0xcc, 0xfe, 0xcf,
-		0xc5, 0xeb, 0x19, 0x02, 0xe5, 0x56, 0xbe, 0xd4,
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00,
-	},
-	{
-		0xd4, 0xc3, 0xa2, 0xcf, 0xb3, 0xc1, 0x06, 0x7f,
-		0xdd, 0xcf, 0x9f, 0xe2, 0xe1, 0x42, 0x8a, 0x29,
-		0xc8, 0xd3, 0x1b, 0xfb, 0x2a, 0x97, 0x02, 0x64,
-		0x90, 0x0f, 0x16, 0xdf, 0x7c, 0x36, 0xdb, 0x6f,
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00,
-	},
-};
-
-#define DEF_SDI         1
-#define DEF_REKEY_MASK  0x0000FFFF00000000UL
-#define DEF_REKEY_SHIFT 32
 #define DEF_AOFF_V4     -12 /* AAD src/dest IPv4 (8) + entropy (4) */
 #define DEF_AOFF_V6     -36 /* AAD src/dest IPv6 (32) + entropy (4) */
 #define UET_SEC_AOFF(is_ipv6) ((is_ipv6) ? DEF_AOFF_V6 : DEF_AOFF_V4)
-#define DEF_COFF        12 /* sizeof security header, +4 if using SSI */
-
-static uint8_t fep_key[2][UET_SEC_KEY_SIZE] = {
-	{
-		0xa1, 0xbf, 0x74, 0xac, 0x7f, 0xf2, 0x35, 0x63,
-		0xec, 0x59, 0x51, 0xaf, 0x99, 0x62, 0x68, 0xf0,
-		0x02, 0xdb, 0x87, 0x82, 0x1c, 0xda, 0xab, 0x47,
-		0x1e, 0x99, 0x1b, 0xd9, 0x96, 0xc4, 0xd7, 0xf1
-	},
-	{
-		0x52, 0xf4, 0x95, 0x91, 0x76, 0xcd, 0xa4, 0x57,
-		0x20, 0x65, 0xc3, 0x0f, 0xaa, 0x48, 0xeb, 0x01,
-		0x5e, 0x62, 0x6e, 0xc8, 0x0b, 0x20, 0x0d, 0xe8,
-		0xdb, 0x1f, 0x2f, 0xfb, 0x9d, 0x4a, 0xdc, 0x27
-	},
-};
-
-/**************************************************************************/
 
 int uet_sec_build_hdr(uint32_t sdi,
 		      uint32_t ssi,
@@ -124,6 +42,7 @@ int uet_sec_build_hdr(uint32_t sdi,
 	struct uet_sec_ssi *sec_ssi;
 	uint64_t tsc;
 	uint32_t tfs;
+	uint8_t tx_an;
 	int copy_len;
 	char *client_ssi;
 
@@ -133,16 +52,22 @@ int uet_sec_build_hdr(uint32_t sdi,
 		return -EINVAL;
 	}
 
-	if (sdi >= UET_SEC_MAX_SD) {
+	sd = uet_sec_sd_get(sdi);
+	if (sd == NULL) {
+		uet_sec_port_stats.out_errored_pkts++;
 		UET_TSS_ERR("invalid SDI %u\n", sdi);
 		return -EINVAL;
 	}
 
-	sd = &sdkdb[sdi];
 	if (!sd->enabled) {
+		uet_sec_port_stats.out_errored_pkts++;
 		UET_TSS_ERR("SDI %u is not enabled\n", sdi);
 		return -EINVAL;
 	}
+
+	/* active AN + association-change bookkeeping */
+	tx_an = uet_sec_sd_tx_an(sd);
+	uet_sec_sd_tx_rotate(sd);
 
 	copy_len = (sizeof(struct ethhdr) +
 		    (is_ipv6 ? sizeof(struct ipv6hdr) :
@@ -176,14 +101,25 @@ int uet_sec_build_hdr(uint32_t sdi,
 	/* fill in the security header */
 
 	tfs = (uint32_t)((UET_PDS_TYPE_SECURITY << UET_SEC_TYPE_SHIFT) |
-			 ((sd->an << UET_SEC_AN_SHIFT) & UET_SEC_AN_MASK) |
+			 ((tx_an << UET_SEC_AN_SHIFT) & UET_SEC_AN_MASK) |
 			 ((sd->sdi << UET_SEC_SDI_SHIFT) & UET_SEC_SDI_MASK));
 	if (sd->use_ssi)
 		tfs |= (uint32_t)(UET_SEC_SP << UET_SEC_SP_SHIFT);
 
 	sec->type_flags_sdi = htonl(tfs);
 
-	uet_gettime((time_t *)&tsc);
+	/* Invoke (TSC counter) fatal limit. Once the per-SD counter reaches
+	 * the threshold it MUST NOT be reused (IV/nonce uniqueness). Drop the
+	 * packet and count it.
+	 */
+	if (sd->tx_counter >= sd->invoke_fatal_threshold) {
+		sd->stats.out_invoke_fail++;
+		UET_TSS_ERR("SDI %u invoke fatal: TSC counter exhausted\n",
+			    sd->sdi);
+		return -EINVAL;
+	}
+
+	tsc = sd->tx_counter++;
 
 	if (sd->use_ssi) {
 		if ((sd->mode == UET_SEC_MODE_SERVER) &&
@@ -236,19 +172,41 @@ int uet_sec_update_hdr_tsc(uint8_t *pkt, bool is_ipv6)
 	/* get the sdi */
 	sdi = ((tfs & UET_SEC_SDI_MASK) >> UET_SEC_SDI_SHIFT);
 
-	if (sdi >= UET_SEC_MAX_SD) {
+	/* get the SD to pull the latest epoch */
+	sd = uet_sec_sd_get(sdi);
+	if (sd == NULL) {
 		UET_TSS_ERR("invalid SDI %u\n", sdi);
 		return -EINVAL;
 	}
 
-	/* get the SD to pull the latest epoch */
-	sd = &sdkdb[sdi];
 	if (!sd->enabled) {
 		UET_TSS_ERR("SDI %u is not enabled\n", sdi);
 		return -EINVAL;
 	}
 
-	uet_gettime((time_t *)&tsc);
+	/* A retransmit is a fresh frame on the wire. With AN key rotation,
+	 * the active AN may have advanced since the original send, so
+	 * re-stamp the current AN into the header.
+	 */
+	if (sd->rotation_enabled) {
+		tfs &= ~UET_SEC_AN_MASK;
+		tfs |= (((uint32_t)uet_sec_sd_tx_an(sd) << UET_SEC_AN_SHIFT) &
+			UET_SEC_AN_MASK);
+		sec->type_flags_sdi = htonl(tfs);
+	}
+
+	/* association-change bookkeeping */
+	uet_sec_sd_tx_rotate(sd);
+
+	if (sd->tx_counter >= sd->invoke_fatal_threshold) {
+		sd->stats.out_invoke_fail++;
+		UET_TSS_ERR("SDI %u invoke fatal: TSC counter exhausted\n",
+			    sd->sdi);
+		return -EINVAL;
+	}
+
+	/* a retransmit is a new frame on the wire = new counter value */
+	tsc = sd->tx_counter++;
 
 	if (tfs & UET_SEC_SP_MASK) {
 		sec_ssi->epoch_tsc =
@@ -326,12 +284,12 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 	sdi = ((tfs & UET_SEC_SDI_MASK) >> UET_SEC_SDI_SHIFT);
 	an  = !!(tfs & UET_SEC_AN_MASK);
 
-	if (sdi >= UET_SEC_MAX_SD) {
+	sd = uet_sec_sd_get(sdi);
+	if (sd == NULL) {
 		UET_TSS_ERR("invalid SDI %u\n", sdi);
 		return -EINVAL;
 	}
 
-	sd = &sdkdb[sdi];
 	if (!sd->enabled) {
 		UET_TSS_ERR("SDI %u is not enabled\n", sdi);
 		return -EINVAL;
@@ -371,7 +329,8 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 
 	switch (sd->mode) {
 	case UET_SEC_MODE_DIRECT:
-		memcpy(derived_key, sd->key[fam][an], UET_SEC_KEY_SIZE);
+		memcpy(derived_key, uet_sec_sd_key(sd, fam, an),
+		       UET_SEC_KEY_SIZE);
 		break;
 
 	case UET_SEC_MODE_CLUSTER:
@@ -381,7 +340,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 			memcpy((large_context + 6), (uint8_t *)&rekey, 4);
 			memcpy((large_context + 10), &ipv6->saddr, 16);
 
-			kdf_ctr_cmac_aes(sd->key[fam][an],
+			kdf_ctr_cmac_aes(uet_sec_sd_key(sd, fam, an),
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label1,
@@ -397,7 +356,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 			tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
 			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
 
-			kdf_ctr_cmac_aes(sd->key[fam][an],
+			kdf_ctr_cmac_aes(uet_sec_sd_key(sd, fam, an),
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label1,
@@ -413,7 +372,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 	case UET_SEC_MODE_SERVER:
 		/* in client/server mode the client operates in direct mode */
 		if (!getenv(UET_SEC_SERVER)) {
-			memcpy(derived_key, sd->key[fam][an],
+			memcpy(derived_key, uet_sec_sd_key(sd, fam, an),
 			       UET_SEC_KDF_GEN_SIZE);
 			break;
 		}
@@ -423,7 +382,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 			memcpy((large_context + 4), (uint8_t *)&epoch, 2);
 			memcpy((large_context + 10), &ipv6->daddr, 16);
 
-			kdf_ctr_cmac_aes(sd->key[fam][an],
+			kdf_ctr_cmac_aes(uet_sec_sd_key(sd, fam, an),
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label2,
@@ -438,7 +397,7 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 			tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->daddr;
 			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
 
-			kdf_ctr_cmac_aes(sd->key[fam][sd->an],
+			kdf_ctr_cmac_aes(uet_sec_sd_key(sd, fam, an),
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label2,
@@ -499,6 +458,8 @@ int uet_sec_enc_pkt(struct uet_instance *uet,
 	*enc_pkt = enc_out;
 	*enc_pkt_len = pkt_len;
 
+	sd->stats.out_auth_pkts++;
+
 	return 0;
 }
 
@@ -523,8 +484,11 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	uint32_t tmp_val;
 	uint64_t tmp_lval;
 	uint16_t epoch;
+	uint16_t cur_epoch;
 	uint64_t tsc;
-	uint64_t counter; // 48b
+	uint64_t counter; /* 48b */
+	uint16_t pkt_epoch;
+	uint16_t age;
 	uint8_t an;
 	uint32_t sdi;
 	uint32_t tfs;
@@ -575,6 +539,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	tfs = ntohl(sec->type_flags_sdi);
 	if (((tfs & UET_SEC_TYPE_MASK) >> UET_SEC_TYPE_SHIFT) !=
 	     UET_PDS_TYPE_SECURITY) {
+		uet_sec_port_stats.in_rx_encryption_bypass_pkts++;
 		*tag_len = 0;
 		return 0;
 	}
@@ -583,19 +548,28 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	sdi = ((tfs & UET_SEC_SDI_MASK) >> UET_SEC_SDI_SHIFT);
 	an  = !!(tfs & UET_SEC_AN_MASK);
 
-	if (sdi >= UET_SEC_MAX_SD) {
+	sd = uet_sec_sd_get(sdi);
+	if (sd == NULL) {
+		uet_sec_port_stats.in_errored_pkts++;
 		UET_TSS_ERR("invalid SDI %u\n", sdi);
 		return -EINVAL;
 	}
 
-	sd = &sdkdb[sdi];
 	if (!sd->enabled) {
+		sd->stats.in_invalid_sa++;
 		UET_TSS_ERR("SDI %u is not enabled\n", sdi);
+		return -EINVAL;
+	}
+
+	/* auth-fail latch once tripped, ALL packets on this SD are dropped */
+	if (sd->domain_dropping) {
+		sd->stats.in_invalid++;
 		return -EINVAL;
 	}
 
 	/* if the SSI is being used, verify it's there in the header */
 	if (sd->use_ssi && !(tfs & UET_SEC_SP_MASK)) {
+		sd->stats.in_invalid++;
 		UET_TSS_ERR("security header is missing the SSI\n");
 		return -EINVAL;
 	}
@@ -605,6 +579,32 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 		            : ntohll(sec->epoch_tsc);
 	epoch = htons((uint16_t)((tsc & UET_SEC_EPOCH_MASK) >> UET_SEC_EPOCH_SHIFT));
 	counter = ((tsc & UET_SEC_TSC_MASK) >> UET_SEC_TSC_SHIFT);
+
+	/* Epoch-based packet rejection drops packets whose epoch is older
+	 * than the current epoch by more than rx_max_epoch_lifetime. The
+	 * epoch is only advanced by an SDME on a FEP leave/rejoin (and reset
+	 * to 0 on key rotation), so with no SDME here it is static (0). This
+	 * path is kept for spec completeness but never rejects (epoch is
+	 * always 0).
+	 */
+	if (sd->epoch_based_rejection) {
+		cur_epoch = sd->epoch;
+
+		pkt_epoch = (uint16_t)((tsc & UET_SEC_EPOCH_MASK) >>
+				       UET_SEC_EPOCH_SHIFT);
+		age = (uint16_t)(cur_epoch - pkt_epoch);
+
+		/* age < 0x8000 => pkt epoch is older (RFC-1982); reject only
+		 * if older by more than the lifetime. Same-or-newer value is
+		 * accepted.
+		 */
+		if ((age < 0x8000) && (age > sd->rx_max_epoch_lifetime)) {
+			sd->stats.in_late_pkts++;
+			UET_TSS_WARN("SDI %u late pkt: epoch %u vs current %u",
+				     sd->sdi, pkt_epoch, cur_epoch);
+			return -EINVAL;
+		}
+	}
 
 	/* generate the key needed for decrypting the packet */
 
@@ -618,7 +618,8 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 
 	switch (sd->mode) {
 	case UET_SEC_MODE_DIRECT:
-		memcpy(derived_key, sd->key[fam][an], UET_SEC_KEY_SIZE);
+		memcpy(derived_key, uet_sec_sd_key(sd, fam, an),
+		       UET_SEC_KEY_SIZE);
 		break;
 
 	case UET_SEC_MODE_CLUSTER:
@@ -628,7 +629,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 			memcpy((large_context + 6), (uint8_t *)&rekey, 4);
 			memcpy((large_context + 10), &ipv6->saddr, 16);
 
-			kdf_ctr_cmac_aes(sd->key[fam][an],
+			kdf_ctr_cmac_aes(uet_sec_sd_key(sd, fam, an),
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label1,
@@ -644,7 +645,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 			tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
 			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
 
-			kdf_ctr_cmac_aes(sd->key[fam][an],
+			kdf_ctr_cmac_aes(uet_sec_sd_key(sd, fam, an),
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label1,
@@ -660,7 +661,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 	case UET_SEC_MODE_SERVER:
 		/* in client/server mode the client operates in direct mode */
 		if (!getenv(UET_SEC_SERVER)) {
-			memcpy(derived_key, sd->key[fam][an],
+			memcpy(derived_key, uet_sec_sd_key(sd, fam, an),
 			       UET_SEC_KDF_GEN_SIZE);
 			break;
 		}
@@ -670,7 +671,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 			memcpy((large_context + 4), (uint8_t *)&epoch, 2);
 			memcpy((large_context + 10), &ipv6->saddr, 16);
 
-			kdf_ctr_cmac_aes(sd->key[fam][an],
+			kdf_ctr_cmac_aes(uet_sec_sd_key(sd, fam, an),
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label2,
@@ -685,7 +686,7 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 			tmp_val = (sd->use_ssi) ? sec_ssi->ssi : ipv4->saddr;
 			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
 
-			kdf_ctr_cmac_aes(sd->key[fam][sd->an],
+			kdf_ctr_cmac_aes(uet_sec_sd_key(sd, fam, an),
 					 (UET_SEC_KEY_SIZE * 8),
 					 UET_SEC_CTR_SIZE,
 					 (uint8_t *)uet_sec_label2,
@@ -735,197 +736,23 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 			      (pkt + clrtxt_len),
 			      (pkt + clrtxt_len));
 	if (rc != 0) {
+		sd->stats.in_auth_fail_pkts++;
 		UET_TSS_ERR("failed to decrypt packet\n");
+		/* Auth-fail threshold once exceeded, latch the domain into
+		 * dropping ALL packets for this SD!
+		 */
+		if (sd->stats.in_auth_fail_pkts > sd->auth_fail_threshold) {
+			sd->domain_dropping = true;
+			UET_TSS_ERR("SDI %u authFail: threshold exceeded, "
+				    "dropping all domain packets\n", sd->sdi);
+		}
 		return -EINVAL;
 	}
+
+	sd->stats.in_auth_pkts++;
 
 	*tag_len = UET_SEC_TAG_LEN;
 
 	return 0;
-}
-
-/*
- * Derive the client-side server-mode keys for one address family. Each
- * family's keys are derived from that family's local address (IPv4) or the
- * SSI, so a dual-stack SD derives both families' key material independently
- * into sd->key[fam][an].
- */
-static void uet_sec_derive_family_keys(struct uet_sec_sd *sd,
-				       int fam,
-				       const struct uet_fa *local_ip)
-{
-	uint8_t derived_key[UET_SEC_KDF_GEN_SIZE];
-	uint8_t small_context[UET_SEC_SMALL_CTX_SIZE];
-	uint8_t large_context[UET_SEC_LARGE_CTX_SIZE];
-	char *client_ssi;
-	uint32_t tmp_val;
-	int an;
-	uint16_t epoch = htons(sd->epoch);
-
-	for (an = 0; an < 2; an++) {
-		if (fam == UET_SEC_FAM_V6) {
-			memset(large_context, 0, sizeof(large_context));
-			memcpy((large_context + 4), (uint8_t *)&epoch, 2);
-			memcpy((large_context + 10), local_ip->v6, 16);
-
-			kdf_ctr_cmac_aes(sd->key[fam][an],
-					 (UET_SEC_KEY_SIZE * 8),
-					 UET_SEC_CTR_SIZE,
-					 (uint8_t *)uet_sec_label2,
-					 strlen(uet_sec_label2), /* ignore delimiter */
-					 large_context,
-					 UET_SEC_LARGE_CTX_SIZE,
-					 derived_key,
-					 (UET_SEC_KDF_GEN_SIZE * 8));
-		} else {
-			memset(small_context, 0, sizeof(small_context));
-			memcpy(small_context, (uint8_t *)&epoch, 2);
-			/* use SSI if available, otherwise use IPv4 */
-			client_ssi = getenv(UET_SEC_SSI);
-			tmp_val = (client_ssi)
-				? htonl(strtoul(client_ssi, NULL, 10))
-				: htonl(local_ip->v4);
-			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
-
-			kdf_ctr_cmac_aes(sd->key[fam][an],
-					 (UET_SEC_KEY_SIZE * 8),
-					 UET_SEC_CTR_SIZE,
-					 (uint8_t *)uet_sec_label2,
-					 strlen(uet_sec_label2), /* ignore delimiter */
-					 small_context,
-					 UET_SEC_SMALL_CTX_SIZE,
-					 derived_key,
-					 (UET_SEC_KDF_GEN_SIZE * 8));
-		}
-
-		memcpy(sd->key[fam][an], derived_key, UET_SEC_KDF_GEN_SIZE);
-	}
-}
-
-static int uet_sec_init_sd(uint32_t sdi,
-			   uet_sec_mode_t mode,
-			   bool use_ssi,
-			   bool rekey,
-			   struct uet_nic *nic)
-{
-	struct uet_sec_sd *sd;
-
-	if (sdi >= UET_SEC_MAX_SD) {
-		UET_TSS_ERR("invalid SDI %u\n", sdi);
-		return -EINVAL;
-	}
-
-	sd = &sdkdb[sdi];
-	memset(sd, 0, sizeof(*sd));
-
-	sd->enabled     = true;
-	sd->sdi         = sdi;
-	sd->mode        = mode;
-	sd->use_ssi     = use_ssi;
-	sd->rekey       = rekey;
-	sd->rekey_mask  = DEF_REKEY_MASK;
-	sd->rekey_shift = DEF_REKEY_SHIFT;
-	sd->coff        = (use_ssi) ? (DEF_COFF + 4) : DEF_COFF;
-	sd->alg         = UET_SEC_ALG_AES_GCM_256;
-	sd->epoch       = 1; /* FIXME: init/roll epoch */
-	sd->an          = 0;
-
-	/* seed both families with the default key */
-	memcpy(sd->key[UET_SEC_FAM_V4], def_key, sizeof(def_key));
-	memcpy(sd->key[UET_SEC_FAM_V6], def_key, sizeof(def_key));
-
-	/*
-	 * IPv6 with direct or client/server mode requires the SSI. Under
-	 * dual-stack this is a per-family limitation, not a fatal error: warn
-	 * and leave IPv6 security unavailable so IPv4 is unaffected.
-	 */
-	if (nic->has_ipv6 && !use_ssi &&
-	    ((mode == UET_SEC_MODE_DIRECT) || (mode == UET_SEC_MODE_SERVER)))
-		UET_TSS_WARN("IPv6 secure mode requires SSI; IPv6 security "
-			     "unavailable (IPv4 unaffected)\n");
-
-	/*
-	 * For the client side of server mode, do the KDFs now (no exchange).
-	 * Normally for client/server mode the server key is hidden on the
-	 * server and there is an exchange where the server gives each client
-	 * a key to use in direct mode which is a derivation from the server
-	 * key using the client's SSI.
-	 *
-	 * Dual-stack: derive each available family's keys independently from
-	 * that family's local address. IPv6 requires the SSI.
-	 */
-	if ((mode == UET_SEC_MODE_SERVER) && !getenv(UET_SEC_SERVER)) {
-		if (nic->has_ipv4) {
-			struct uet_fa fa;
-			memset(&fa, 0, sizeof(fa));
-			fa.v4 = nic->ipv4_addr;
-			uet_sec_derive_family_keys(sd, UET_SEC_FAM_V4, &fa);
-		}
-
-		if (nic->has_ipv6 && use_ssi) {
-			struct uet_fa fa;
-			memset(&fa, 0, sizeof(fa));
-			memcpy(fa.v6, nic->ipv6_addr, 16);
-			uet_sec_derive_family_keys(sd, UET_SEC_FAM_V6, &fa);
-		}
-	}
-
-	return 0;
-}
-
-int uet_sec_init(struct uet_nic *nic)
-{
-	char *sec_mode, *sec_ssi;
-	int i, rc;
-
-	memset(sdkdb, 0, sizeof(sdkdb));
-
-	for (i = 0; i < UET_SEC_MAX_SD; i++)
-		sdkdb[i].enabled = false;
-
-	sec_mode = getenv(UET_SEC_MODE);
-	sec_ssi  = getenv(UET_SEC_SSI);
-
-	if (sec_mode == NULL)
-		return 0;
-
-	/* FIXME: Only using SDI=0x1 AN=0x0 for now... */
-
-	if (strcmp(sec_mode, "direct") == 0) {
-
-		rc = uet_sec_init_sd(DEF_SDI, UET_SEC_MODE_DIRECT,
-				     (sec_ssi != NULL), false, nic);
-
-	} else if (strcmp(sec_mode, "cluster") == 0) {
-
-		rc = uet_sec_init_sd(DEF_SDI, UET_SEC_MODE_CLUSTER,
-				     (sec_ssi != NULL), true, nic);
-
-	} else if (strcmp(sec_mode, "server") == 0) {
-
-		/* this implementation requires the SSI for IPv4 and IPv6 */
-
-		if (sec_ssi == NULL) {
-			UET_TSS_ERR("UET_SEC_SSI required for server mode");
-			return -EINVAL;
-		}
-
-		if (getenv(UET_SEC_SERVER) && !getenv(UET_SEC_CLIENT_SSI)) {
-			UET_TSS_ERR("UET_SEC_CLIENT_SSI required on server "
-				    "for server mode");
-			return -EINVAL;
-		}
-
-		rc = uet_sec_init_sd(DEF_SDI, UET_SEC_MODE_SERVER,
-				     true, false, nic);
-
-	} else {
-
-		UET_TSS_ERR("invalid UET_SEC_MODE environment variable");
-		return -EINVAL;
-
-	}
-
-	return rc;
 }
 

--- a/uet_sec.h
+++ b/uet_sec.h
@@ -7,12 +7,7 @@
 
 #include "uet_api_private.h"
 #include "uet_util.h"
-
-#define UET_SEC_MODE       "UET_SEC_MODE"
-#define UET_SEC_SSI        "UET_SEC_SSI"
-
-#define UET_SEC_SERVER     "UET_SEC_SERVER"
-#define UET_SEC_CLIENT_SSI "UET_SEC_CLIENT_SSI"
+#include "uet_sec_sd.h"
 
 #define UET_SEC_MAX_HDR_LEN sizeof(struct uet_sec_ssi)
 #define UET_SEC_TAG_LEN     16
@@ -76,11 +71,3 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 		    uint8_t *pkt,
 		    int pkt_len,
 		    int *tag_len);
-
-/*
- * Initialize the security domain(s). Dual-stack: the SD holds per-family key
- * material (keyed on each of the NIC's local v4/v6 addresses) selected per
- * packet at enc/dec time, so a single wire SDI serves both families.
- */
-int uet_sec_init(struct uet_nic *nic);
-

--- a/uet_sec_sd.c
+++ b/uet_sec_sd.c
@@ -1,0 +1,582 @@
+/*
+ * Copyright (c) 2024,2025,2026 Broadcom. All rights reserved. The term
+ * Broadcom refers to Broadcom Limited and/or its subsidiaries.
+ */
+
+/* Secure-domain database (SDKDB) management — the reference app's SDME
+ * stand-in. Owns the SD table, key material, per-SD/port statistics, and the
+ * AN key-rotation scheduler (SDMI stand-in). The per-packet crypto core
+ * lives in uet_sec.c.
+ */
+
+/*
+ * AN key-rotation design (the SDME stand-in)...
+ *
+ * A real deployment rotates per-SD keys out-of-band via an SDME. Here it is
+ * faked with a scheme driven entirely by the shared wall clock, so both peers
+ * rotate in lockstep with zero signaling and no dependence on process start
+ * time. It is gated per run using the UET_SEC_KEY_ROTATION environment
+ * variable, otherwise it's off.
+ *
+ * Rotation index is calculated using the absolute wall-clock time chopped
+ * into fixed UET_SEC_ROT_INTERVAL_MS buckets numbered from the Unix epoch:
+ *
+ *     uet_gettime(&now_ms)
+ *     rot = (now_ms / UET_SEC_ROT_INTERVAL_MS)
+ *
+ * rot ticks up by 1 every interval and both peers compute the same value from
+ * their NTP-synced clocks. Everything derives from it (N = UET_SEC_ROT_N):
+ *
+ *     active AN  = (rot & 1)          the 1-bit AN on the wire
+ *     pool slot  = (rot & (N - 1))    which of the N compiled in pool keys
+ *     generation = (rot / N)          how many full wraps through the pool
+ *
+ * Fresh key every rotation. The pool holds only N keys so a key slot recurs
+ * every N rotations. The counter/epoch is reset to 0 on each rotation, so
+ * reusing a key slot's raw bytes would replay (key, IV) pairs which leads
+ * to AES-GCM nonce reuse. Bad! The effective key is therefore folded in with
+ * the generation:
+ *
+ *     effective_key = (pool[slot] XOR wrap_mix(generation))
+ *
+ * wrap_mix() is deterministic and distinct per generation, so each recurrence
+ * of a slot is a different key and no (key, IV) pair ever repeats.
+ *
+ * Make-before-break. Clocks are not perfectly aligned, so near a boundary a
+ * peer may still be sending with the previous AN or already with the next
+ * one. The packet's AN/key is resolved against the local clock to pick rot,
+ * rot-1 (previous key, kept for UET_SEC_ROT_GUARD_MS), or rot+1 (next
+ * key), covering skew in both directions.
+ *
+ * TX bookkeeping. The Tx rotate function watches rot and, on each boundary,
+ * resets the counter and epoch to 0. The epoch is only ever advanced by an
+ * SDME on a FEP leave/rejoin (not modeled here), so it stays fixed at 0.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "uet_pkt_hdr.h"
+#include "uet_log.h"
+#include "uet_util.h"
+#include "uet_sec_sd.h"
+#include "kdf_ctr_cmac_aes.h"
+
+static struct uet_sec_sd sdkdb[UET_SEC_MAX_SD];
+struct uet_sec_port_stats uet_sec_port_stats;
+
+char *uet_sec_label1 = "U1";
+char *uet_sec_label2 = "U2";
+
+/************************************************************************/
+/* FIXME: Default fields used for the fixed SD... not yet configurable! */
+/************************************************************************/
+
+/* key generation: `dd if=/dev/urandom ibs=32 count=1 | xxd -i -c 8` */
+
+/* The key pool. Slots 0/1 are the original two AN keys (used directly and
+ * indexed by AN, when rotation is off). Slots 2/3 extend the pool to
+ * UET_SEC_ROT_N so the AN key-rotation (SDME stand-in) has 4 keys to cycle
+ * through.
+ */
+static uint8_t def_key[UET_SEC_ROT_N][UET_SEC_KDF_GEN_SIZE] = {
+	{
+		0x07, 0xe9, 0x72, 0x49, 0x58, 0xd9, 0xe1, 0xf7,
+		0x10, 0xf5, 0x94, 0xe1, 0x8e, 0x11, 0xfd, 0x8d,
+		0x4a, 0x35, 0x82, 0xc2, 0x56, 0xcc, 0xfe, 0xcf,
+		0xc5, 0xeb, 0x19, 0x02, 0xe5, 0x56, 0xbe, 0xd4,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	},
+	{
+		0xd4, 0xc3, 0xa2, 0xcf, 0xb3, 0xc1, 0x06, 0x7f,
+		0xdd, 0xcf, 0x9f, 0xe2, 0xe1, 0x42, 0x8a, 0x29,
+		0xc8, 0xd3, 0x1b, 0xfb, 0x2a, 0x97, 0x02, 0x64,
+		0x90, 0x0f, 0x16, 0xdf, 0x7c, 0x36, 0xdb, 0x6f,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	},
+	{
+		0x3b, 0x8f, 0x0d, 0x6a, 0xe4, 0x27, 0x91, 0xac,
+		0x55, 0x1e, 0xc0, 0x74, 0x2d, 0xb9, 0x66, 0x08,
+		0xf1, 0x4c, 0xaa, 0x93, 0x70, 0xd5, 0x3e, 0x82,
+		0x19, 0xbb, 0x6f, 0x24, 0xce, 0x07, 0x41, 0x98,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	},
+	{
+		0xa7, 0x62, 0xf5, 0x11, 0x8c, 0x4b, 0x30, 0xde,
+		0x09, 0x9a, 0x77, 0xe3, 0x5f, 0x21, 0xb8, 0xc6,
+		0x74, 0x0e, 0xd2, 0x46, 0x99, 0x2b, 0xa5, 0x18,
+		0xed, 0x53, 0x81, 0x6c, 0x3a, 0xf0, 0x27, 0xbd,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	},
+};
+
+/* Per-generation wrap-mix constant. When a pool slot recurs (every
+ * UET_SEC_ROT_N rotations) its raw bytes would repeat. Folding in a
+ * generation-derived mix built from this constant yields fresh key material
+ * on every reuse. Compiled in, so both peers derive the identical effective
+ * key.
+ */
+static const uint8_t uet_sec_wrap_const[UET_SEC_KEY_SIZE] = {
+	0x9e, 0x37, 0x79, 0xb9, 0x7f, 0x4a, 0x7c, 0x15,
+	0xf3, 0x9c, 0xc0, 0x60, 0x5c, 0xed, 0xc8, 0x34,
+	0x10, 0x82, 0x27, 0x6b, 0xf3, 0xa2, 0x72, 0x51,
+	0xec, 0xdd, 0x74, 0x35, 0x21, 0xf8, 0x8e, 0xa3,
+};
+
+#define DEF_SDI         1
+/* Derive a new (implicit) rekey every 2^DEF_REKEY_SHIFT = 256 packets so the
+ * automatic KDF rekey is exercised between the (much slower) AN key rotations.
+ */
+#define DEF_REKEY_MASK  0x000000000000FF00UL
+#define DEF_REKEY_SHIFT 8
+#define DEF_COFF        12 /* sizeof security header, +4 if using SSI */
+
+#define DEF_RX_MAX_EPOCH_LIFETIME  16
+#define DEF_AUTH_FAIL_THRESHOLD    1000
+#define DEF_INVOKE_FATAL_THRESHOLD UET_SEC_TSC_MASK /* 48-bit counter max */
+
+static uint8_t fep_key[2][UET_SEC_KEY_SIZE] = {
+	{
+		0xa1, 0xbf, 0x74, 0xac, 0x7f, 0xf2, 0x35, 0x63,
+		0xec, 0x59, 0x51, 0xaf, 0x99, 0x62, 0x68, 0xf0,
+		0x02, 0xdb, 0x87, 0x82, 0x1c, 0xda, 0xab, 0x47,
+		0x1e, 0x99, 0x1b, 0xd9, 0x96, 0xc4, 0xd7, 0xf1
+	},
+	{
+		0x52, 0xf4, 0x95, 0x91, 0x76, 0xcd, 0xa4, 0x57,
+		0x20, 0x65, 0xc3, 0x0f, 0xaa, 0x48, 0xeb, 0x01,
+		0x5e, 0x62, 0x6e, 0xc8, 0x0b, 0x20, 0x0d, 0xe8,
+		0xdb, 0x1f, 0x2f, 0xfb, 0x9d, 0x4a, 0xdc, 0x27
+	},
+};
+
+/**************************************************************************/
+
+struct uet_sec_sd *uet_sec_sd_get(uint32_t sdi)
+{
+	if (sdi >= UET_SEC_MAX_SD)
+		return NULL;
+
+	return &sdkdb[sdi];
+}
+
+/* Current absolute rotation index (bucket number), and optionally the ms
+ * elapsed time into that bucket. This is just division/modulo, the quotient
+ * is the rotation index, the remainder is how far we are into the interval
+ * (used by the make-before-break window).
+ */
+static uint64_t uet_sec_rot_now(uint64_t *into_ms)
+{
+	time_t now_ms = 0;
+	uint64_t rot;
+
+	uet_gettime(&now_ms); /* absolute wall-clock ms (CLOCK_REALTIME) */
+
+	/* bucket index, which UET_SEC_ROT_INTERVAL_MS window we are in now */
+	rot = ((uint64_t)now_ms / UET_SEC_ROT_INTERVAL_MS);
+
+	if (into_ms != NULL) {
+		/* time ms into the current window */
+		*into_ms = ((uint64_t)now_ms -
+			    (rot * UET_SEC_ROT_INTERVAL_MS));
+	}
+
+	return rot;
+}
+
+/* Generation-derived 32-byte wrap mix: deterministic (same gen + compiled in
+ * key constant on both peers) and distinct per generation. A recurring pool
+ * slot produces different key material each cycle. Every byte of gen is
+ * folded in so consecutive generations differ.
+ */
+static void uet_sec_wrap_mix(uint64_t gen,
+			     uint8_t *mix)
+{
+	int i;
+
+	for (i = 0; i < UET_SEC_KEY_SIZE; i++) {
+		mix[i] = /* fixed whitening constant */
+			 (uet_sec_wrap_const[i] ^
+			 /* spread gen's 8 bytes over the mix */
+			  (uint8_t)(gen >> ((i & 7) * 8)) ^
+			 /* per-byte ramp, flips on every gen++ */
+			  (uint8_t)(gen + (uint64_t)i));
+	}
+}
+
+uint8_t uet_sec_sd_tx_an(struct uet_sec_sd *sd)
+{
+	if (!sd->rotation_enabled)
+		return sd->an;
+
+	/* active association number is the low bit of the rotation index */
+	return (uint8_t)(uet_sec_rot_now(NULL) & 1);
+}
+
+void uet_sec_sd_tx_rotate(struct uet_sec_sd *sd)
+{
+	uint64_t rot;
+
+	if (!sd->rotation_enabled)
+		return;
+
+	rot = uet_sec_rot_now(NULL);
+
+	/* edge-detect a bucket change since the last Tx packet */
+	if (rot != sd->tx_rot) {
+		/* crossed a rotation boundary = AN/key change */
+		sd->tx_rot     = rot;
+		sd->tx_counter = 0;
+		sd->epoch      = 0;
+	}
+}
+
+/* Generate one effective key, effective_key = pool[slot] XOR wrap_mix(gen),
+ * into eff_key[*][which] for both families (slot = r mod N, gen = r / N). The
+ * wrap mix is gen-only so it is computed once and applied to both families.
+ */
+static void uet_sec_sd_gen_key(struct uet_sec_sd *sd,
+			       int64_t r,
+			       int which)
+{
+	uint8_t mix[UET_SEC_KEY_SIZE];
+	int slot = (int)(r & (UET_SEC_ROT_N - 1));
+	uint64_t gen = (uint64_t)(r / UET_SEC_ROT_N);
+	int fam, i;
+
+	uet_sec_wrap_mix(gen, mix);
+
+	for (fam = 0; fam < 2; fam++) {
+		memcpy(sd->eff_key[fam][which], sd->key[fam][slot],
+		       UET_SEC_KDF_GEN_SIZE);
+		for (i = 0; i < UET_SEC_KEY_SIZE; i++)
+			sd->eff_key[fam][which][i] ^= mix[i];
+	}
+}
+
+/* Refresh the previous/current/next effective-key window for rotation 'rot'.
+ * Common case (rot advanced by one): shift the window down (prev<-cur,
+ * cur<-next) and generate only the new 'next'. First build or a multi-bucket
+ * gap rebuilds all three. Runs only when rot changes (~once per interval).
+ */
+static void uet_sec_sd_refresh_keys(struct uet_sec_sd *sd, uint64_t rot)
+{
+	int fam;
+
+	if (rot == (sd->cache_rot + 1)) {
+		for (fam = 0; fam < 2; fam++) {
+			memcpy(sd->eff_key[fam][UET_SEC_KEY_PREV],
+			       sd->eff_key[fam][UET_SEC_KEY_CUR],
+			       UET_SEC_KDF_GEN_SIZE);
+			memcpy(sd->eff_key[fam][UET_SEC_KEY_CUR],
+			       sd->eff_key[fam][UET_SEC_KEY_NEXT],
+			       UET_SEC_KDF_GEN_SIZE);
+		}
+		uet_sec_sd_gen_key(sd, (int64_t)rot + 1, UET_SEC_KEY_NEXT);
+	} else {
+		uet_sec_sd_gen_key(sd, (int64_t)rot - 1, UET_SEC_KEY_PREV);
+		uet_sec_sd_gen_key(sd, (int64_t)rot,     UET_SEC_KEY_CUR);
+		uet_sec_sd_gen_key(sd, (int64_t)rot + 1, UET_SEC_KEY_NEXT);
+	}
+
+	sd->cache_rot = rot;
+}
+
+uint8_t *uet_sec_sd_key(struct uet_sec_sd *sd,
+			int fam,
+			uint8_t an)
+{
+	uint64_t rot, into;
+	int which;
+
+	if (!sd->rotation_enabled)
+		return sd->key[fam][an];
+
+	rot = uet_sec_rot_now(&into);
+
+	/* (re)build the effective-key window only when the rotation advances */
+	if (rot != sd->cache_rot)
+		uet_sec_sd_refresh_keys(sd, rot);
+
+	/* Make-before-break selection. The active slot (an=rot&1) uses the
+	 * current key. The non-active slot uses the retiring previous key
+	 * during the guard window (a skew-behind peer), then the pre-loaded
+	 * next key (a skew-ahead peer). Returns a pointer into the cache.
+	 */
+	if (an == (uint8_t)(rot & 1))
+		which = UET_SEC_KEY_CUR;  /* AN matches our bucket */
+	else if (into < UET_SEC_ROT_GUARD_MS)
+		which = UET_SEC_KEY_PREV; /* just after a boundary */
+	else
+		which = UET_SEC_KEY_NEXT; /* peer rotated ahead */
+
+	return sd->eff_key[fam][which];
+}
+
+/* Derive the client-side server-mode keys for one address family. Each
+ * family's keys are derived from that family's local address (IPv4) or the
+ * SSI, so a dual-stack SD derives both families' key material independently
+ * into sd->key[fam][an].
+ */
+static void uet_sec_derive_family_keys(struct uet_sec_sd *sd,
+				       int fam,
+				       const struct uet_fa *local_ip)
+{
+	uint8_t derived_key[UET_SEC_KDF_GEN_SIZE];
+	uint8_t small_context[UET_SEC_SMALL_CTX_SIZE];
+	uint8_t large_context[UET_SEC_LARGE_CTX_SIZE];
+	char *client_ssi;
+	uint32_t tmp_val;
+	int an;
+	uint16_t epoch = htons(sd->epoch);
+
+	for (an = 0; an < 2; an++) {
+		if (fam == UET_SEC_FAM_V6) {
+			memset(large_context, 0, sizeof(large_context));
+			memcpy((large_context + 4), (uint8_t *)&epoch, 2);
+			memcpy((large_context + 10), local_ip->v6, 16);
+
+			kdf_ctr_cmac_aes(sd->key[fam][an],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label2,
+					 strlen(uet_sec_label2), /* ignore delimiter */
+					 large_context,
+					 UET_SEC_LARGE_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+		} else {
+			memset(small_context, 0, sizeof(small_context));
+			memcpy(small_context, (uint8_t *)&epoch, 2);
+			/* use SSI if available, otherwise use IPv4 */
+			client_ssi = getenv(UET_SEC_SSI);
+			tmp_val = (client_ssi)
+				? htonl(strtoul(client_ssi, NULL, 10))
+				: htonl(local_ip->v4);
+			memcpy((small_context + 6), (uint8_t *)&tmp_val, 4);
+
+			kdf_ctr_cmac_aes(sd->key[fam][an],
+					 (UET_SEC_KEY_SIZE * 8),
+					 UET_SEC_CTR_SIZE,
+					 (uint8_t *)uet_sec_label2,
+					 strlen(uet_sec_label2), /* ignore delimiter */
+					 small_context,
+					 UET_SEC_SMALL_CTX_SIZE,
+					 derived_key,
+					 (UET_SEC_KDF_GEN_SIZE * 8));
+		}
+
+		memcpy(sd->key[fam][an], derived_key, UET_SEC_KDF_GEN_SIZE);
+	}
+}
+
+static int uet_sec_init_sd(uint32_t sdi,
+			   uet_sec_mode_t mode,
+			   bool use_ssi,
+			   bool rekey,
+			   struct uet_nic *nic)
+{
+	struct uet_sec_sd *sd;
+
+	sd = uet_sec_sd_get(sdi);
+	if (sd == NULL) {
+		UET_TSS_ERR("invalid SDI %u\n", sdi);
+		return -EINVAL;
+	}
+
+	memset(sd, 0, sizeof(*sd));
+
+	sd->enabled     = true;
+	sd->sdi         = sdi;
+	sd->mode        = mode;
+	sd->use_ssi     = use_ssi;
+	sd->rekey       = rekey;
+	sd->rekey_mask  = DEF_REKEY_MASK;
+	sd->rekey_shift = DEF_REKEY_SHIFT;
+	sd->coff        = (use_ssi) ? (DEF_COFF + 4) : DEF_COFF;
+	sd->alg         = UET_SEC_ALG_AES_GCM_256;
+	sd->epoch       = 0;
+	sd->an          = 0;
+	sd->tx_counter  = 0;
+
+	sd->epoch_based_rejection  = true; /* fixed as default */
+	sd->rx_max_epoch_lifetime  = DEF_RX_MAX_EPOCH_LIFETIME;
+	sd->auth_fail_threshold    = DEF_AUTH_FAIL_THRESHOLD;
+	sd->invoke_fatal_threshold = DEF_INVOKE_FATAL_THRESHOLD;
+	sd->domain_dropping        = false;
+
+	/* AN key rotation is gated per run. Both peers rotate off the shared
+	 * wall clock (no signaling). Not supported in server mode (its client
+	 * keys are KDF-derived).
+	 */
+
+	if ((getenv(UET_SEC_KEY_ROTATION) != NULL) &&
+	    (mode == UET_SEC_MODE_SERVER)) {
+		UET_TSS_ERR("SDI %u AN key rotation not supported in "
+			     "server mode", sdi);
+		return -EINVAL;
+	}
+
+	sd->rotation_enabled = (getenv(UET_SEC_KEY_ROTATION) != NULL);
+	sd->tx_rot = 0;
+
+	if (sd->rotation_enabled) {
+		/* seed tx_rot with the current rotation index */
+		sd->tx_rot = uet_sec_rot_now(NULL);
+
+		UET_TSS_INFO("SDI %u AN key rotation enabled "
+			     "(%u keys, %u ms interval, %u ms guard)",
+			     sdi, UET_SEC_ROT_N, UET_SEC_ROT_INTERVAL_MS,
+			     UET_SEC_ROT_GUARD_MS);
+	}
+
+	/* seed both families with the default key pool */
+	memcpy(sd->key[UET_SEC_FAM_V4], def_key, sizeof(def_key));
+	memcpy(sd->key[UET_SEC_FAM_V6], def_key, sizeof(def_key));
+
+	/* IPv6 with direct or client/server mode requires the SSI. Under
+	 * dual-stack this is a per-family limitation, not a fatal error: warn
+	 * and leave IPv6 security unavailable so IPv4 is unaffected.
+	 */
+	if (nic->has_ipv6 && !use_ssi &&
+	    ((mode == UET_SEC_MODE_DIRECT) || (mode == UET_SEC_MODE_SERVER)))
+		UET_TSS_WARN("IPv6 secure mode requires SSI; IPv6 security "
+			     "unavailable (IPv4 unaffected)\n");
+
+	/* For the client side of server mode, do the KDFs now (no exchange).
+	 * Normally for client/server mode the server key is hidden on the
+	 * server and there is an exchange where the server gives each client
+	 * a key to use in direct mode which is a derivation from the server
+	 * key using the client's SSI.
+	 *
+	 * Dual-stack: derive each available family's keys independently from
+	 * that family's local address. IPv6 requires the SSI.
+	 */
+	if ((mode == UET_SEC_MODE_SERVER) && !getenv(UET_SEC_SERVER)) {
+		if (nic->has_ipv4) {
+			struct uet_fa fa;
+			memset(&fa, 0, sizeof(fa));
+			fa.v4 = nic->ipv4_addr;
+			uet_sec_derive_family_keys(sd, UET_SEC_FAM_V4, &fa);
+		}
+
+		if (nic->has_ipv6 && use_ssi) {
+			struct uet_fa fa;
+			memset(&fa, 0, sizeof(fa));
+			memcpy(fa.v6, nic->ipv6_addr, 16);
+			uet_sec_derive_family_keys(sd, UET_SEC_FAM_V6, &fa);
+		}
+	}
+
+	return 0;
+}
+
+int uet_sec_init(struct uet_nic *nic)
+{
+	char *sec_mode, *sec_ssi;
+	int i, rc;
+
+	memset(sdkdb, 0, sizeof(sdkdb));
+	memset(&uet_sec_port_stats, 0, sizeof(uet_sec_port_stats));
+
+	for (i = 0; i < UET_SEC_MAX_SD; i++)
+		sdkdb[i].enabled = false;
+
+	sec_mode = getenv(UET_SEC_MODE);
+	sec_ssi  = getenv(UET_SEC_SSI);
+
+	if (sec_mode == NULL)
+		return 0;
+
+	if (strcmp(sec_mode, "direct") == 0) {
+
+		rc = uet_sec_init_sd(DEF_SDI, UET_SEC_MODE_DIRECT,
+				     (sec_ssi != NULL), false, nic);
+
+	} else if (strcmp(sec_mode, "cluster") == 0) {
+
+		rc = uet_sec_init_sd(DEF_SDI, UET_SEC_MODE_CLUSTER,
+				     (sec_ssi != NULL), true, nic);
+
+	} else if (strcmp(sec_mode, "server") == 0) {
+
+		/* this implementation requires the SSI for IPv4 and IPv6 */
+
+		if (sec_ssi == NULL) {
+			UET_TSS_ERR("UET_SEC_SSI required for server mode");
+			return -EINVAL;
+		}
+
+		if (getenv(UET_SEC_SERVER) && !getenv(UET_SEC_CLIENT_SSI)) {
+			UET_TSS_ERR("UET_SEC_CLIENT_SSI required on server "
+				    "for server mode");
+			return -EINVAL;
+		}
+
+		rc = uet_sec_init_sd(DEF_SDI, UET_SEC_MODE_SERVER,
+				     true, false, nic);
+
+	} else {
+
+		UET_TSS_ERR("invalid UET_SEC_MODE environment variable");
+		return -EINVAL;
+
+	}
+
+	return rc;
+}
+
+void uet_sec_dump_stats(void)
+{
+	struct uet_sec_sd *sd;
+	uint32_t sdi;
+
+	for (sdi = 0; sdi < UET_SEC_MAX_SD; sdi++) {
+		sd = &sdkdb[sdi];
+		if (!sd->enabled)
+			continue;
+
+		UET_TSS_INFO("SDI %u stats:", sdi);
+		UET_TSS_INFO("    %-30s : %llu", "in_auth_pkts",
+			     (unsigned long long)sd->stats.in_auth_pkts);
+		UET_TSS_INFO("    %-30s : %llu", "in_auth_fail_pkts",
+			     (unsigned long long)sd->stats.in_auth_fail_pkts);
+		UET_TSS_INFO("    %-30s : %llu", "in_invalid",
+			     (unsigned long long)sd->stats.in_invalid);
+		UET_TSS_INFO("    %-30s : %llu", "in_invalid_sa",
+			     (unsigned long long)sd->stats.in_invalid_sa);
+		UET_TSS_INFO("    %-30s : %llu", "in_late_pkts",
+			     (unsigned long long)sd->stats.in_late_pkts);
+		UET_TSS_INFO("    %-30s : %llu", "out_invoke_fail",
+			     (unsigned long long)sd->stats.out_invoke_fail);
+		UET_TSS_INFO("    %-30s : %llu", "out_auth_pkts",
+			     (unsigned long long)sd->stats.out_auth_pkts);
+		UET_TSS_INFO("    %-30s : %llu", "in_binding_failure_pkts",
+			     (unsigned long long)sd->stats.in_binding_failure_pkts);
+		UET_TSS_INFO("    %-30s : %s", "domain_dropping",
+			     sd->domain_dropping ? "yes" : "no");
+	}
+
+	UET_TSS_INFO("PORT stats:");
+	UET_TSS_INFO("    %-30s : %llu", "in_errored_pkts",
+		     (unsigned long long)uet_sec_port_stats.in_errored_pkts);
+	UET_TSS_INFO("    %-30s : %llu", "out_errored_pkts",
+		     (unsigned long long)uet_sec_port_stats.out_errored_pkts);
+	UET_TSS_INFO("    %-30s : %llu", "in_rx_encryption_bypass_pkts",
+		     (unsigned long long)uet_sec_port_stats.in_rx_encryption_bypass_pkts);
+	UET_TSS_INFO("    %-30s : %llu", "out_rx_encryption_bypass_pkts",
+		     (unsigned long long)uet_sec_port_stats.out_rx_encryption_bypass_pkts);
+}
+
+void uet_sec_finalize(void)
+{
+	uet_sec_dump_stats();
+}
+

--- a/uet_sec_sd.h
+++ b/uet_sec_sd.h
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2024,2025,2026 Broadcom. All rights reserved. The term
+ * Broadcom refers to Broadcom Limited and/or its subsidiaries.
+ */
+
+#ifndef UET_SEC_SD_H
+#define UET_SEC_SD_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "uet_api_private.h"
+
+/* Secure-domain configuration env vars (SDME stand-in inputs). */
+#define UET_SEC_MODE       "UET_SEC_MODE"
+#define UET_SEC_SSI        "UET_SEC_SSI"
+#define UET_SEC_SERVER     "UET_SEC_SERVER"
+#define UET_SEC_CLIENT_SSI "UET_SEC_CLIENT_SSI"
+
+/* Secure-domain database (SDKDB) and its lifecycle.
+ *
+ * This module is the reference app's stand-in for an SDME (Security Domain
+ * Management Entity): it owns the SD table, the key material, the per-SD/port
+ * statistics, and the AN key-rotation scheduler. Real deployments drive all of
+ * this out of band; here it is compiled in and (for rotation) wall-clock
+ * driven. The spec-defined per-packet crypto core (header build, encrypt,
+ * decrypt) lives in uet_sec.c and consumes the services declared below.
+ */
+
+#define UET_SEC_MAX_SD         8
+#define UET_SEC_FAM_V4         0
+#define UET_SEC_FAM_V6         1
+#define UET_SEC_FAM(is_ipv6)   ((is_ipv6) ? UET_SEC_FAM_V6 : UET_SEC_FAM_V4)
+#define UET_SEC_KEY_SIZE       32
+#define UET_SEC_KDF_GEN_SIZE   44
+#define UET_SEC_CTR_SIZE       8
+#define UET_SEC_SMALL_CTX_SIZE 10
+#define UET_SEC_LARGE_CTX_SIZE 26
+
+/* AN key rotation: wall-clock driven (SDME stand-in!)
+ *
+ * Gated per run via an env knob so the existing short secured tests are
+ * unaffected. Both peers derive the rotation index from the absolute wall
+ * clock time, so they stay synchronized with zero signaling and no
+ * dependence on process start time.
+ */
+#define UET_SEC_KEY_ROTATION    "UET_SEC_KEY_ROTATION" /* env gate */
+#define UET_SEC_ROT_N           4     /* rotating key pool (power of 2) */
+#define UET_SEC_ROT_INTERVAL_MS 10000 /* rotation interval (wall clock) */
+#define UET_SEC_ROT_GUARD_MS    2000  /* make-before-break guard window */
+
+/* For key rotation, at any rotation only three effective keys are live,
+ * previous/current/next (r = rot-1/rot/rot+1). The SD caches exactly these,
+ * indexed by this enum.
+ */
+enum {
+	UET_SEC_KEY_PREV = 0,
+	UET_SEC_KEY_CUR,
+	UET_SEC_KEY_NEXT,
+	UET_SEC_KEY_SLOTS
+};
+
+typedef enum {
+	UET_SEC_ALG_NONE        = 0,
+	UET_SEC_ALG_AES_GCM_256 = 1,
+} uet_sec_alg_t;
+
+typedef enum {
+	UET_SEC_MODE_NONE    = 0,
+	UET_SEC_MODE_DIRECT  = 1,
+	UET_SEC_MODE_CLUSTER = 2,
+	UET_SEC_MODE_SERVER  = 3,
+} uet_sec_mode_t;
+
+struct uet_sec_sd_stats {
+	uint64_t in_auth_pkts;
+	uint64_t in_auth_fail_pkts;
+	uint64_t in_invalid;
+	uint64_t in_invalid_sa;
+	uint64_t in_late_pkts;
+	uint64_t out_invoke_fail;
+	uint64_t out_auth_pkts;
+	uint64_t in_binding_failure_pkts;
+};
+
+struct uet_sec_port_stats {
+	uint64_t in_errored_pkts;
+	uint64_t out_errored_pkts;
+	uint64_t in_rx_encryption_bypass_pkts;
+	uint64_t out_rx_encryption_bypass_pkts;
+};
+
+struct uet_sec_sd {
+	bool           enabled;
+	uint32_t       sdi;
+	uet_sec_mode_t mode;
+	bool           use_ssi;
+	bool           rekey;
+	uint64_t       rekey_mask;
+	uint8_t        rekey_shift;
+	uint16_t       coff;
+	uet_sec_alg_t  alg;
+	/* Key epoch: starts at 0, reset to 0 on key rotation, only advanced
+	 * by an SDME on a FEP leave/rejoin.
+	 * NOTE: No SDME or rejoin modeled, it stays 0 for the whole run.
+	 */
+	uint16_t       epoch;
+	uint8_t        an;
+	/* Strictly-increasing 48b packet Tx counter. Reset to 0 on an
+	 * association (AN/key) change — see uet_sec_sd_tx_rotate.
+	 */
+	uint64_t       tx_counter;
+	/* Epoch-based rejection
+	 * NOTE: Kept for spec completeness but dormant here as the epoch
+	 * is static (0).
+	 */
+	bool           epoch_based_rejection;
+	uint16_t       rx_max_epoch_lifetime;
+	/* Invoke/auth-fail limits. The domain_dropping field latches once
+	 * in_auth_fail_pkts exceeds auth_fail_threshold, after which ALL
+	 * packets for the SD are dropped.
+	 */
+	uint64_t       invoke_fatal_threshold;
+	uint64_t       auth_fail_threshold;
+	bool           domain_dropping;
+	struct uet_sec_sd_stats stats; /* per-SD stats */
+	/* AN key rotation (SDME stand-in). When enabled, the active AN, the
+	 * epoch/counter, and the key are all derived from the shared
+	 * wall clock.
+	 */
+	bool           rotation_enabled;
+	uint64_t       tx_rot;
+	/* [family-ipv4/ipv6][slot] key pool.
+	 * NOTE: Non-rotation uses slots 0/1 (indexed by AN). Rotation cycles
+	 * over all UET_SEC_ROT_N slots off the wall clock.
+	 */
+	uint8_t        key[2][UET_SEC_ROT_N][UET_SEC_KDF_GEN_SIZE];
+	/* Effective-key cache. When key rotation is enabled, eff_key holds
+	 * the previous/current/next effective keys per address family, valid
+	 * for cache_rot. When rot advances by one, the keys shift down and
+	 * only the new 'next' is generated. cache_rot == 0 means unbuilt.
+	 */
+	uint64_t       cache_rot;
+	uint8_t        eff_key[2][UET_SEC_KEY_SLOTS][UET_SEC_KDF_GEN_SIZE];
+};
+
+/* KDF labels — shared by the crypto core (enc/dec) and server-mode key
+ * derivation.
+ */
+extern char *uet_sec_label1;
+extern char *uet_sec_label2;
+
+/* Per-port stats. Defined by this module and incremented from the crypto
+ * core for bad-SDI / encryption-bypass events.
+ */
+extern struct uet_sec_port_stats uet_sec_port_stats;
+
+/* Initialize the security domain(s). Dual-stack: the SD holds per-family key
+ * material (keyed on each of the NIC's local v4/v6 addresses) selected per
+ * packet at enc/dec time, so a single wire SDI serves both families.
+ */
+int uet_sec_init(struct uet_nic *nic);
+
+/* Teardown the security domain(s). */
+void uet_sec_finalize(void);
+
+/* Dump per-SD and per-port security counters. */
+void uet_sec_dump_stats(void);
+
+/* SDKDB lookup: returns the SD for an sdi, or NULL if out of range. */
+struct uet_sec_sd *uet_sec_sd_get(uint32_t sdi);
+
+/* Active Tx AN right now: clock-derived when rotation is on, else sd->an. */
+uint8_t uet_sec_sd_tx_an(struct uet_sec_sd *sd);
+
+/* Tx-side association-change bookkeeping. On a rotation boundary (AN/key
+ * change) this resets the per-packet counter and epoch to 0. No-op when
+ * rotation is off. Call once per transmitted packet before reading the
+ * counter/epoch.
+ */
+void uet_sec_sd_tx_rotate(struct uet_sec_sd *sd);
+
+/* Effective key for (family, an). When rotation is on, selects the pool slot
+ * from the shared clock + an (make-before-break, both skew directions) and
+ * folds in the per-generation wrap mix; otherwise returns sd->key[fam][an].
+ * The returned pointer is valid until the next call (single-threaded path).
+ */
+uint8_t *uet_sec_sd_key(struct uet_sec_sd *sd, int fam, uint8_t an);
+
+#endif /* UET_SEC_SD_H */
+


### PR DESCRIPTION
- TSC per-packet counter: strictly-increasing per-SD counter replaces the wall-clock TSC so no two packets share an IV under one key.
- Per-SD/port stats dumped at teardown, epoch-based rejection, auth-fail domain-drop latch, invoke-fatal drop. Epoch is always 0, reset on rotation per (only an SDME would advance it with FEP leave/rejoin).
- Split the SDKDB, keys, stats, and lifecycle out of uet_sec.c into a new uet_sec_sd.c/.h, uet_sec.c keeps the crypto core.
- Wall-clock AN key rotation (no signaling): 4-key pool, per-generation wrap-mix, make-before-break prev/cur/next key cache. Gated by the UET_SEC_KEY_ROTATION env var.
- Test harness: new pds_cluster_key_rot pds target, UET_NUM_ITERATIONS override, secured Tx timeout 10 -> 25 ms to handle crypto latency.