### PR TITLE
pds: enforce PSN tracking and peer MPR flow control

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Replace `2` with the desired number of senders.
 - **UET_PDS_TX_TIMEOUT** - Time in milliseconds to wait for an ack before retransmitting a Tx packet (default=`5`).
 - **UET_PDS_MAX_TX_RETRIES** - Max number of times a Tx packet is retransmitted before failing (default=`5`).
 - **UET_NUM_ITERATIONS** - Override the number of message iterations the test app runs (default=`100`). Used to wall-clock-size a run (e.g., long enough to span several TSS key rotations).
+- **UET_MSG_SIZE** - Override the message size used by the test app (default=`4096`).
 - **UET_FORCE_RUDI** - [ `0` | `1` ] (default=`0`) Force the RUDI (Reliable Unordered Delivery for Idempotent operations) PDS delivery mode for RMA read/write operations.
 - **UET_FORCE_UUD** - [ `0` | `1` ] (default=`0`) Force the UUD (Unreliable Unordered Delivery) best-effort single-packet datagram PDS delivery mode for an untagged send.
 - **UET_SEC_MODE** - [ `direct` | `cluster` | `server` ]

--- a/tests/util/test_bitmap.c
+++ b/tests/util/test_bitmap.c
@@ -111,10 +111,10 @@ static void test_set_get_unset(void)
 		return;
 
 	/* set a handful of bits across both 64-bit words */
-	bm_set(bm, 0, PA);
-	bm_set(bm, 63, PB);
-	bm_set(bm, 64, PC);
-	bm_set(bm, 127, PA);
+	CHECK(bm_set(bm, 0, PA) == true);
+	CHECK(bm_set(bm, 63, PB) == true);
+	CHECK(bm_set(bm, 64, PC) == true);
+	CHECK(bm_set(bm, 127, PA) == true);
 	CHECK_EQ(bm_count(bm), 4);
 
 	/* bm_get returns the bit state and hands back the stored pointer */
@@ -140,10 +140,10 @@ static void test_set_get_unset(void)
 	CHECK(data == NULL);
 	CHECK_EQ(bm_count(bm), 3);
 
-	/* out-of-range / negative indices are silently ignored, no crash */
-	bm_set(bm, -1, PA);
-	bm_set(bm, 128, PA);
-	bm_set(bm, 100000, PA);
+	/* out-of-range / negative indices are rejected without changing state */
+	CHECK(bm_set(bm, -1, PA) == false);
+	CHECK(bm_set(bm, 128, PA) == false);
+	CHECK(bm_set(bm, 100000, PA) == false);
 	CHECK_EQ(bm_count(bm), 3);
 	CHECK(bm_get(bm, -1, NULL) == false);
 	CHECK(bm_get(bm, 128, NULL) == false);

--- a/uet.c
+++ b/uet.c
@@ -72,7 +72,8 @@
 #define UET_NUM_ITERATIONS	100
 #define UET_ITERATIONS_ENV	"UET_NUM_ITERATIONS"
 
-#define UET_MSG_SIZE		4096	/* in bytes */
+#define UET_DEFAULT_MSG_SIZE	4096	/* in bytes */
+#define UET_MSG_SIZE_ENV	"UET_MSG_SIZE"
 #define UET_UUD_MSG_SIZE	1024	/* UUD is single-packet only */
 #define UET_UUD_BLAST_N		100	/* datagrams per UUD blast */
 #define UET_UUD_RX_TIMEOUT_MS	500	/* per-datagram bounded wait */
@@ -320,6 +321,7 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 	struct in6_addr peer_in6_addr;
 	struct uet_addr *addr;
 	char *env_iters;
+	char *env_msg_size;
 
 	ctx->cfg.job_id = UET_DEF_JOB_ID;
 
@@ -427,7 +429,22 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 		else
 			ctx->cfg.msg_size = UET_MSG_RENDEZVOUS_SIZE * 2;
 	} else {
-		ctx->cfg.msg_size = UET_MSG_SIZE;
+		ctx->cfg.msg_size = UET_DEFAULT_MSG_SIZE;
+		env_msg_size = getenv(UET_MSG_SIZE_ENV);
+		if (env_msg_size != NULL) {
+			char *end;
+			unsigned long long n;
+
+			errno = 0;
+			n = strtoull(env_msg_size, &end, 10);
+			if (errno || (end == env_msg_size) || (*end != '\0') ||
+			    (n == 0) || (n > SIZE_MAX)) {
+				UET_ERR("Invalid %s=%s", UET_MSG_SIZE_ENV,
+					env_msg_size);
+				return UET_ERR_RC;
+			}
+			ctx->cfg.msg_size = (size_t)n;
+		}
 	}
 
 	return UET_SUCCESS_RC;

--- a/uet_api.c
+++ b/uet_api.c
@@ -4621,40 +4621,43 @@ static void uet_dsend_init(struct uet_tx_desc *tx_desc)
 /* assemble packet from gather list */
 static void *gather_iov_to_buffer(
 	const struct iovec *iov, size_t iov_count, size_t payload_len,
-	size_t *saved_offset, size_t *iov_index)
+	size_t payload_offset)
 {
-	void *pkt_buf = calloc(payload_len, sizeof(char));
+	uint8_t *pkt_buf = calloc(payload_len, sizeof(*pkt_buf));
+	size_t iov_index = 0;
+	size_t iov_offset;
+	size_t remaining;
+	size_t pkt_offset = 0;
 
 	if (!pkt_buf)
 		return NULL;
 
-	size_t pkt_buf_offset = 0;
-	size_t copied = 0;
-
-	for (; *iov_index < iov_count; (*iov_index)++) {
-		void *current_buf = (void *)(iov[*iov_index].iov_base +
-				*saved_offset);
-		size_t current_len = iov[*iov_index].iov_len - *saved_offset;
-		size_t still_to_send = payload_len - pkt_buf_offset;
-		size_t to_copy = (current_len < still_to_send) ?
-			current_len : still_to_send;
-
-		memcpy(pkt_buf + pkt_buf_offset, current_buf, to_copy);
-		pkt_buf_offset += to_copy;
-		copied += to_copy;
-
-		if (copied == payload_len) {
-			if (current_len > to_copy) {
-				*saved_offset += to_copy;
-			} else if (current_len == to_copy) {
-				*saved_offset = 0;
-				(*iov_index)++;
-			}
-			break;
-		}
-		if (copied < payload_len && current_len <= to_copy)
-			*saved_offset = 0;
+	while ((iov_index < iov_count) &&
+	       (payload_offset >= iov[iov_index].iov_len)) {
+		payload_offset -= iov[iov_index].iov_len;
+		iov_index++;
 	}
+
+	iov_offset = payload_offset;
+	remaining = payload_len;
+	while (remaining && (iov_index < iov_count)) {
+		size_t available = iov[iov_index].iov_len - iov_offset;
+		size_t to_copy = (available < remaining) ? available : remaining;
+
+		memcpy(pkt_buf + pkt_offset,
+		       (uint8_t *)iov[iov_index].iov_base + iov_offset,
+		       to_copy);
+		pkt_offset += to_copy;
+		remaining -= to_copy;
+		iov_index++;
+		iov_offset = 0;
+	}
+
+	if (remaining) {
+		free(pkt_buf);
+		return NULL;
+	}
+
 	return pkt_buf;
 }
 
@@ -4671,8 +4674,6 @@ static int uet_tx_msg(struct uet_tx_desc *tx_desc)
 	void *ses, *pkt_buf;
 	uet_pds_next_hdr_t next_hdr;
 	struct uet_pds_info *pds_info = NULL;
-	size_t iov_index = 0;
-	size_t saved_offset = 0;
 
 	uet_ep = tx_desc->uet_ep;
 	pds = &uet_ep->uet_domain->uet->pds;
@@ -4736,8 +4737,7 @@ static int uet_tx_msg(struct uet_tx_desc *tx_desc)
 					tx_desc->buf_desc.iov.iov,
 					tx_desc->buf_desc.iov.iov_count,
 					payload_len,
-					&saved_offset,
-					&iov_index);
+					tx_desc->buf_desc.buf_off);
 
 			if (!pkt_buf) {
 				UET_API_ERR("TX: Msg Buffer is null");

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -27,9 +27,11 @@
 #include "bitmap.h"
 #include "crc32c.h"
 
-#define UET_DEFAULT_TC        0
-#define UET_DEFAULT_MPR       128
-#define UET_DEFAULT_ENTROPY   0x4242
+#define UET_DEFAULT_TC          0
+#define UET_PDS_MPR_GRANULARITY 128U
+#define UET_DEFAULT_MP_RANGE    128U
+#define UET_DEFAULT_MPR         (UET_DEFAULT_MP_RANGE / UET_PDS_MPR_GRANULARITY)
+#define UET_DEFAULT_ENTROPY     0x4242
 
 #define UET_PDC_MAX 64
 
@@ -169,6 +171,9 @@ struct uet_pdc {
 	struct bitmap       *tx_bm;
 	uint32_t             tx_bm_base_psn; /* start PSN for initiator MPR */
 	uint32_t             max_cack_psn; /* highest cack PSN received */
+	uint32_t             peer_mp_range; /* 0 means peer ignores MP_RANGE */
+	uint32_t             mpr_update_cack_psn;
+	bool                 mpr_update_valid;
 
 	/* target side fields */
 	struct bitmap      *rx_bm;
@@ -261,12 +266,26 @@ static inline uint32_t uet_pds_rand_start_psn(void)
 		}                                         \
 	} while (0)
 
-#define PSN_IN_MPR(psn, base_psn)                            \
-	(((uint32_t)((psn) - (base_psn)) >= 0) &&            \
-	 ((uint32_t)((psn) - (base_psn)) < UET_DEFAULT_MPR))
+#define PSN_IN_MPR(psn, base_psn) \
+	((uint32_t)((psn) - (base_psn)) < UET_DEFAULT_MP_RANGE)
 
 #define PSN_IN_PRIOR_MPR(psn, base_psn)                             \
-	PSN_IN_MPR((psn), (uint32_t)((base_psn) - UET_DEFAULT_MPR))
+	PSN_IN_MPR((psn), (uint32_t)((base_psn) - UET_DEFAULT_MP_RANGE))
+
+static inline uint32_t uet_pds_decode_mpr(uint8_t mpr)
+{
+	return (uint32_t)mpr * UET_PDS_MPR_GRANULARITY;
+}
+
+static inline bool uet_pds_tx_psn_allowed(const struct uet_pdc *pdc,
+					   uint32_t psn)
+{
+	if (!PSN_IN_MPR(psn, pdc->tx_bm_base_psn))
+		return false;
+
+	return !pdc->peer_mp_range ||
+	       !UET_PDS_PSN_AFTER(psn, pdc->max_cack_psn + pdc->peer_mp_range);
+}
 
 #define PDS_TYPE_TO_STR(t)                                 \
 	(((t) == UET_PDS_TYPE_RUD_REQ)    ? "RUD_REQ" :    \
@@ -617,6 +636,10 @@ static void uet_init_pdc(struct uet_pdc *pdc,
 	pdc->next_psn = 0;
 	bm_clear(pdc->tx_bm);
 	pdc->tx_bm_base_psn = 0;
+	pdc->max_cack_psn = 0;
+	pdc->peer_mp_range = UET_DEFAULT_MP_RANGE;
+	pdc->mpr_update_cack_psn = 0;
+	pdc->mpr_update_valid = false;
 
 	bm_clear(pdc->rx_bm);
 	pdc->rx_bm_base_psn = 0;
@@ -956,6 +979,7 @@ static int uet_pdsm_assign_tgt_pdc(struct uet_parsed_pkt *pp,
 	pdc->rx_bm_base_psn  = base;
 	pdc->tx_bm_base_psn  = base;
 	pdc->next_psn        = base;
+	pdc->max_cack_psn    = (base - 1);
 	pdc->cack_psn        = (base - 1);
 	pdc->max_clear_psn   = (base - 1);
 	pdc->prev_ar_psn     = (base - 1);
@@ -1196,7 +1220,7 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 	ctrl_hdr->prlg.type_ctrl_flags = htons(ctrl_flags);
 	ctrl_hdr->rsvd = 0;
 
-	if (!PSN_IN_MPR(pdc->next_psn, pdc->tx_bm_base_psn)) {
+	if (!uet_pds_tx_psn_allowed(pdc, pdc->next_psn)) {
 		free(pdc_pkt->pkt_buf);
 		free(pdc_pkt);
 		return -EAGAIN;
@@ -1459,14 +1483,14 @@ int uet_pds_initialize(struct uet_instance *uet)
 		pdc->state = PDC_STATE_UNALLOC;
 		pdc->pdc_id = i;
 
-		pdc->tx_bm = bm_create(UET_DEFAULT_MPR);
+		pdc->tx_bm = bm_create(UET_DEFAULT_MP_RANGE);
 		if (!pdc->tx_bm) {
 			UET_PDS_ERR("failed to create Tx bitmap");
 			uet_pdsm_free_pdc(pdc);
 			return -ENOMEM; /* FIXME unwind and free PDCs */
 		}
 
-		pdc->rx_bm = bm_create(UET_DEFAULT_MPR);
+		pdc->rx_bm = bm_create(UET_DEFAULT_MP_RANGE);
 		if (!pdc->rx_bm) {
 			UET_PDS_ERR("failed to create Rx bitmap");
 			bm_destroy(pdc->tx_bm);
@@ -1820,10 +1844,10 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	 * Returning -EAGAIN leaves the SES descriptor at its current payload
 	 * offset; ACK progress advances tx_bm_base_psn before SES retries it.
 	 */
-	if (!PSN_IN_MPR(pdc->next_psn, pdc->tx_bm_base_psn)) {
-		UET_PDS_DBG("PDC %u Tx window full: base=%u next=%u range=%u",
+	if (!uet_pds_tx_psn_allowed(pdc, pdc->next_psn)) {
+		UET_PDS_DBG("PDC %u Tx window full: base=%u next=%u local=%u peer=%u",
 			    pdc->pdc_id, pdc->tx_bm_base_psn, pdc->next_psn,
-			    UET_DEFAULT_MPR);
+			    UET_DEFAULT_MP_RANGE, pdc->peer_mp_range);
 		return -EAGAIN;
 	}
 
@@ -2213,6 +2237,10 @@ static int uet_pds_rtx_pkt(struct uet_instance *uet,
 		return 0;
 	}
 
+	/* A reduced peer MPR also gates retransmissions. */
+	if (!uet_pds_tx_psn_allowed(pdc, pdc_pkt->psn))
+		return -EAGAIN;
+
 	/* set the retransmit flag in the PDS header */
 	pds_hdr = (struct uet_pds_req *)pdc_pkt->pkt_pp.pds;
 	pds_hdr->prlg.type_next_flags |=
@@ -2247,6 +2275,10 @@ static int uet_pds_check_rtx_pkt(struct uet_instance *uet,
 	if (delta < uet->pds.tx_timeout)
 		return 0; /* no retransmit */
 
+	if (!pdc_pkt->dst_recvd &&
+	    !uet_pds_tx_psn_allowed(pdc, pdc_pkt->psn))
+		return 0; /* wait for CACK to advance the peer window */
+
 	if (pdc_pkt->tx_retry_cnt >= uet->pds.max_tx_retries) {
 		UET_PDS_ERR("PDC %u PSN %u retry exceeded",
 			    pdc->pdc_id, pdc_pkt->psn);
@@ -2256,6 +2288,9 @@ static int uet_pds_check_rtx_pkt(struct uet_instance *uet,
 	UET_PDS_WARN("PDC %u PSN %u retransmit", pdc->pdc_id, pdc_pkt->psn);
 
 	rc = uet_pds_rtx_pkt(uet, pdc, pdc_pkt);
+	if (rc == -EAGAIN)
+		return 0; /* wait for CACK to advance the peer window */
+
 	if (rc != 0) {
 		UET_PDS_ERR("PDC %u PSN %u retransmit failed",
 			    pdc->pdc_id, pdc_pkt->psn);
@@ -2932,7 +2967,7 @@ static int uet_pds_check_duplicate_and_rtx(struct uet_instance *uet,
 	} else {
 		UET_PDS_WARN("invalid PSN %u on PDC %u (outside MPR %u[+/-%u])",
 			     pdc_pkt->pkt_pp.pds_psn, pdc->pdc_id,
-			     pdc->rx_bm_base_psn, UET_DEFAULT_MPR);
+			     pdc->rx_bm_base_psn, UET_DEFAULT_MP_RANGE);
 		nack_code = (pdc_pkt->pkt_pp.pds_flags &
 			     UET_PDS_REQ_FLAGS_SYN) ? UET_NACK_INVALID_SYN :
 			    UET_NACK_PSN_OOR_WINDOW;
@@ -3396,6 +3431,10 @@ static int uet_pds_process_nack(struct uet_instance *uet,
 	if (pdc_pkt->tx_pkt_acked)
 		return 0;
 
+	if (!pdc_pkt->dst_recvd &&
+	    !uet_pds_tx_psn_allowed(pdc, pdc_pkt->psn))
+		return 0; /* wait for CACK to advance the peer window */
+
 	if (pdc_pkt->tx_retry_cnt >= uet->pds.max_tx_retries) {
 		UET_PDS_ERR("PDC %u PSN %u NACK retries exhausted",
 			    pdc->pdc_id, pp->pds_psn);
@@ -3404,6 +3443,9 @@ static int uet_pds_process_nack(struct uet_instance *uet,
 	}
 
 	rc = uet_pds_rtx_pkt(uet, pdc, pdc_pkt);
+	if (rc == -EAGAIN)
+		return 0; /* wait for CACK to advance the peer window */
+
 	if (rc != 0) {
 		UET_PDS_ERR("PDC %u PSN %u NACK-triggered retransmit failed",
 			    pdc->pdc_id, pp->pds_psn);
@@ -3415,12 +3457,34 @@ static int uet_pds_process_nack(struct uet_instance *uet,
 	return 0;
 }
 
+static void uet_pds_process_mpr(struct uet_pdc *pdc,
+				const struct uet_parsed_pkt *pp)
+{
+	uint32_t mp_range;
+
+	if (pdc->mpr_update_valid &&
+	    !UET_PDS_PSN_AFTER(pp->pds_cack_psn, pdc->mpr_update_cack_psn)) {
+		UET_PDS_DBG("PDC %u ignored stale MPR %u at CACK %u",
+			    pdc->pdc_id, pp->pds_mpr, pp->pds_cack_psn);
+		return;
+	}
+
+	mp_range = uet_pds_decode_mpr(pp->pds_mpr);
+	pdc->peer_mp_range = mp_range;
+	pdc->mpr_update_cack_psn = pp->pds_cack_psn;
+	pdc->mpr_update_valid = true;
+
+	UET_PDS_DBG("PDC %u peer MPR %u -> MP_RANGE %u at CACK %u",
+		    pdc->pdc_id, pp->pds_mpr, mp_range, pp->pds_cack_psn);
+}
+
 static int uet_pds_process_ack(struct uet_instance *uet,
 			       struct uet_parsed_pkt *pp)
 {
 	struct uet_pdc *pdc;
-	struct uet_pdc_pkt *pdc_pkt;
+	struct uet_pdc_pkt *pdc_pkt = NULL;
 	uint32_t start_psn;
+	bool duplicate = false;
 	int rc;
 
 	rc = uet_pdsm_get_pdc(pp->pds_dpdcid, false, &pdc);
@@ -3435,38 +3499,55 @@ static int uet_pds_process_ack(struct uet_instance *uet,
 		return -EINVAL;
 	}
 
-	if (!PSN_IN_MPR(pp->pds_psn, pdc->tx_bm_base_psn)) {
+	if (UET_PDS_PSN_AFTER(pp->pds_cack_psn, pdc->next_psn - 1)) {
+		UET_PDS_WARN("invalid CACK PSN %u on PDC %u (next PSN %u)",
+			     pp->pds_cack_psn, pp->pds_dpdcid, pdc->next_psn);
+		return -EINVAL;
+	}
+
+	/*
+	 * The explicit PSN may already have left the local bitmap when ACKs
+	 * are reordered.  Its newer CACK, MPR, or SACK state is still useful,
+	 * but its SES response must not be delivered twice.
+	 */
+	if (UET_PDS_PSN_AFTER(pdc->tx_bm_base_psn, pp->pds_psn)) {
+		duplicate = true;
+	} else if (!PSN_IN_MPR(pp->pds_psn, pdc->tx_bm_base_psn)) {
 		UET_PDS_WARN("invalid ACK PSN %u on PDC %u "
 			     "(outside MPR %u[+%u])",
 			     pp->pds_psn, pp->pds_dpdcid,
-			     pdc->tx_bm_base_psn, UET_DEFAULT_MPR);
+			     pdc->tx_bm_base_psn, UET_DEFAULT_MP_RANGE);
 		return -EINVAL;
-	}
-
-	if (!bm_get(pdc->tx_bm, (pp->pds_psn - pdc->tx_bm_base_psn),
-		    (void **)&pdc_pkt)) {
+	} else if (!bm_get(pdc->tx_bm,
+			   (pp->pds_psn - pdc->tx_bm_base_psn),
+			   (void **)&pdc_pkt)) {
 		UET_PDS_WARN("invalid ACK PSN %u on PDC %u (packet not found)",
 			     pp->pds_psn, pp->pds_dpdcid);
 		return -EINVAL;
-	}
-
-	if (pdc_pkt->tx_pkt_acked) {
-		UET_PDS_WARN("duplicate ACK PSN %u on PDC %u",
-			     pp->pds_psn, pp->pds_dpdcid);
-		return -EINVAL;
+	} else if (pdc_pkt->tx_pkt_acked) {
+		duplicate = true;
 	}
 
 	/*
 	 * The packets explicitly acknowledged and implicitly acknowledged
 	 * by coalesced ack are processed separately.
 	 */
-	pdc_pkt->tx_pkt_acked = true;
-	dlist_remove(&pdc_pkt->node); /* remove from Tx list */
+	if (!duplicate) {
+		pdc_pkt->tx_pkt_acked = true;
+		dlist_remove(&pdc_pkt->node); /* remove from Tx list */
+	}
+
+	if (pp->pds_type == UET_PDS_TYPE_ACK_CC ||
+	    pp->pds_type == UET_PDS_TYPE_ACK_CCX)
+		uet_pds_process_mpr(pdc, pp);
 	uet_pds_process_cack(uet, pdc, pp);
 	if (pp->pds_type == UET_PDS_TYPE_ACK_CC ||
 	    pp->pds_type == UET_PDS_TYPE_ACK_CCX) {
 		uet_pds_process_sack_bitmap(uet, pdc, pp);
 	}
+
+	if (duplicate)
+		return uet_pds_shift_tx_window(uet, pdc);
 
 	if (UET_LOG_LVL >= UET_LOG_DBG) {
 		UET_PDS_DBG("PDC %d tx_bm (base %u):",

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -1139,7 +1139,7 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 	struct uet_entropy *entropy_hdr;
 	size_t ip_hdr_size;
 	uint16_t ctrl_flags;
-	int rc;
+	int rc, tx_bm_idx;
 
 	/* allocate the packet descriptor */
 	pdc_pkt = calloc(1, sizeof(struct uet_pdc_pkt));
@@ -1196,9 +1196,14 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 	ctrl_hdr->prlg.type_ctrl_flags = htons(ctrl_flags);
 	ctrl_hdr->rsvd = 0;
 
-	/* assign PSN for close command */
-	pdc->close_cmd_psn = pdc->next_psn++;
-	pdc_pkt->psn = pdc->close_cmd_psn;
+	if (!PSN_IN_MPR(pdc->next_psn, pdc->tx_bm_base_psn)) {
+		free(pdc_pkt->pkt_buf);
+		free(pdc_pkt);
+		return -EAGAIN;
+	}
+
+	/* Reserve the PSN; commit next_psn only after successful submission. */
+	pdc_pkt->psn = pdc->next_psn;
 	ctrl_hdr->psn = htonl(pdc_pkt->psn);
 
 	ctrl_hdr->spdcid = htons(pdc->pdc_id);
@@ -1235,16 +1240,30 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 	pdc_pkt->tx_pkt_handle = NULL; /* no SES handle for control packets */
 	pdc_pkt->tx_pkt_acked = false;
 	pdc_pkt->flags = 0;
+	tx_bm_idx = pdc_pkt->psn - pdc->tx_bm_base_psn;
+
+	if (bm_get(pdc->tx_bm, tx_bm_idx, NULL) ||
+	    !bm_set(pdc->tx_bm, tx_bm_idx, pdc_pkt)) {
+		UET_PDS_ERR("PDC %u cannot track close PSN %u at tx_bm index %d",
+			    pdc->pdc_id, pdc_pkt->psn, tx_bm_idx);
+		free(pdc_pkt->pkt_buf);
+		free(pdc_pkt);
+		return -EIO;
+	}
 
 	/* send the packet */
 	rc = uet_pds_sec_tx_pkt(uet, pdc, pdc_pkt, true, false);
 	if (rc != 0) {
 		UET_PDS_ERR("failed to send close command for PDC %u",
 			    pdc->pdc_id);
+		bm_unset(pdc->tx_bm, tx_bm_idx);
 		free(pdc_pkt->pkt_buf);
 		free(pdc_pkt);
 		return rc;
 	}
+
+	pdc->close_cmd_psn = pdc_pkt->psn;
+	pdc->next_psn++;
 
 	/* the packet was sent successfully */
 	uet_pds_pkt_dbg(uet, &pdc_pkt->pkt_pp, true, "TX CLOSE COMMAND");
@@ -1253,8 +1272,6 @@ static int uet_pds_send_close_cmd(struct uet_instance *uet,
 	UET_PDS_DBG("PDC %u tx_bm: base=%u psn=%u SET bit=%u (close cmd)",
 		    pdc->pdc_id, pdc->tx_bm_base_psn, pdc_pkt->psn,
 		    (pdc_pkt->psn - pdc->tx_bm_base_psn));
-
-	bm_set(pdc->tx_bm, (pdc_pkt->psn - pdc->tx_bm_base_psn), pdc_pkt);
 
 	/* insert the packet to the end of the timeout queue for retries */
 	dlist_insert_tail(&pdc_pkt->node, &pdc->tx_pkt_list_head);
@@ -1685,7 +1702,9 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	size_t ip_hdr_size;
 	void *ses_hdr, *payload;
 	uint16_t pds_flags;
-	int rc, hdr_len;
+	int rc, hdr_len, tx_bm_idx;
+	bool map_msg_id = false;
+	bool mapped_msg_id = false;
 
 	PDS_GO();
 
@@ -1759,30 +1778,22 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 			    tx_pkt_handle, msg_id,
 			    ((flags & UET_PDS_FLAG_EOM) ? " [EOM]" : ""));
 		pdc = uet_pdsm_assign_ini_pdc(uet_ep, av_entry, mode);
-		if (pdc) {
-			/* verify PDC has no active message */
-			if (pdc->active_msg_id_valid) {
-				UET_PDS_DBG("PDC %u already has "
-					    "active_msg_id %u, cannot start "
-					    "msg_id %u (EAGAIN)",
-					    pdc->pdc_id, pdc->active_msg_id,
-					    msg_id);
-				return -EAGAIN;
-			}
-
-			rc = uet_pdsm_map_msgid_pdc(msg_id, pdc);
-			if (rc != 0)
-				return rc;
-
-			/* set the active message for this PDC */
-			pdc->active_msg_id = msg_id;
-			pdc->active_msg_id_valid = true;
-		} else {
+		if (!pdc) {
 			UET_PDS_DBG("failed to get PDC for SOM %p "
 				    "msg_id %u (EAGAIN)",
 				    tx_pkt_handle, msg_id);
 			return -EAGAIN;
 		}
+
+		/* verify PDC has no active message */
+		if (pdc->active_msg_id_valid) {
+			UET_PDS_DBG("PDC %u active msg_id %u blocks SOM msg_id %u (EAGAIN)",
+				    pdc->pdc_id, pdc->active_msg_id, msg_id);
+			return -EAGAIN;
+		}
+
+		/* Commit this mapping only when the first packet can be sent. */
+		map_msg_id = true;
 	} else {
 		UET_PDS_DBG("SES Tx %p msg_id %u%s",
 			    tx_pkt_handle, msg_id,
@@ -1804,6 +1815,18 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 		return -EINVAL;
 	}
 
+	/*
+	 * tx_bm owns all state required to acknowledge or retransmit a PSN.
+	 * Returning -EAGAIN leaves the SES descriptor at its current payload
+	 * offset; ACK progress advances tx_bm_base_psn before SES retries it.
+	 */
+	if (!PSN_IN_MPR(pdc->next_psn, pdc->tx_bm_base_psn)) {
+		UET_PDS_DBG("PDC %u Tx window full: base=%u next=%u range=%u",
+			    pdc->pdc_id, pdc->tx_bm_base_psn, pdc->next_psn,
+			    UET_DEFAULT_MPR);
+		return -EAGAIN;
+	}
+
 	/* for non-SOM packets, verify msg_id matches the active message */
 	if (!(flags & UET_PDS_FLAG_SOM)) {
 		if (!pdc->active_msg_id_valid) {
@@ -1818,47 +1841,6 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 				    "msg_id %u",
 				    pdc->pdc_id, pdc->active_msg_id, msg_id);
 			return -EINVAL;
-		}
-	}
-
-	if (!pds_info && (flags & UET_PDS_FLAG_EOM)) {
-		if (flags & UET_PDS_FLAG_MAINTAIN_PDC) {
-			UET_PDS_DBG("PDC %u flagged with MAINTAIN_PDC on EOM",
-				    pdc->pdc_id);
-		} else {
-			/* clear the active message on this PDC */
-			pdc->active_msg_id = 0;
-			pdc->active_msg_id_valid = false;
-
-			rc = uet_pdsm_unmap_msgid_pdc(msg_id);
-			if (rc != 0)
-				return rc;
-
-			/* randomly mark the PDC for close */
-			if (pds_pdc_close_thresh &&
-			    pdc->is_initiator && !pdc->close_requested &&
-			    uet_pds_random_check(pds_pdc_close_thresh)) {
-				UET_PDS_ERR("PDC %u random marked for close!",
-					    pdc->pdc_id);
-				pdc->close_requested = true;
-			}
-
-			/*
-			 * PSN-range close, when an encrypted PDC's PSN
-			 * reaches Start_PSN + 2^31, mark it for close (it
-			 * re-establishes on the next send). Marking at EOM
-			 * lets in-process messages complete normally.
-			 */
-			if (pdc->sec_enabled &&
-			    pdc->is_initiator && !pdc->close_requested &&
-			    ((uint32_t)(pdc->next_psn - pdc->start_psn) >=
-			     UET_PSN_RANGE_LIMIT)) {
-				UET_PDS_ERR("PDC %u PSN range exhausted "
-					    "marked for close!",
-					    pdc->pdc_id);
-				pdc->close_requested = true;
-				pds_state.psn_range_close_cnt++;
-			}
 		}
 	}
 
@@ -1934,7 +1916,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 
 	pds_hdr->prlg.type_next_flags = htons(pds_flags);
 
-	pdc_pkt->psn = pdc->next_psn++;
+	pdc_pkt->psn = pdc->next_psn;
 	pds_hdr->psn = htonl(pdc_pkt->psn);
 
 	/*
@@ -1953,7 +1935,6 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 			htons((pdc->syn_offset &
 			       UET_PDS_REQ_PSN_OFFSET_MASK) <<
 			      UET_PDS_REQ_PSN_OFFSET_SHIFT);
-		pdc->syn_offset++;
 	} else {
 		pds_hdr->dpdcid = htons(pdc->dpdcid);
 	}
@@ -1992,14 +1973,50 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	pdc_pkt->tx_pkt_handle = tx_pkt_handle;
 	pdc_pkt->tx_pkt_acked  = false;
 	pdc_pkt->flags         = flags;
+	tx_bm_idx = pdc_pkt->psn - pdc->tx_bm_base_psn;
+
+	if (bm_get(pdc->tx_bm, tx_bm_idx, NULL) ||
+	    !bm_set(pdc->tx_bm, tx_bm_idx, pdc_pkt)) {
+		UET_PDS_ERR("PDC %u cannot track PSN %u at tx_bm index %d",
+			    pdc->pdc_id, pdc_pkt->psn, tx_bm_idx);
+		free(pdc_pkt->pkt_buf);
+		free(pdc_pkt);
+		return -EIO;
+	}
+
+	if (map_msg_id) {
+		rc = uet_pdsm_map_msgid_pdc(msg_id, pdc);
+		if (rc != 0) {
+			bm_unset(pdc->tx_bm, tx_bm_idx);
+			free(pdc_pkt->pkt_buf);
+			free(pdc_pkt);
+			return rc;
+		}
+
+		pdc->active_msg_id = msg_id;
+		pdc->active_msg_id_valid = true;
+		mapped_msg_id = true;
+	}
 
 	/* send the packet */
 	rc = uet_pds_sec_tx_pkt(uet, pdc, pdc_pkt, true, false);
 	if (rc != 0) {
+		bm_unset(pdc->tx_bm, tx_bm_idx);
+		if (mapped_msg_id) {
+			pdc->active_msg_id = 0;
+			pdc->active_msg_id_valid = false;
+			if (uet_pdsm_unmap_msgid_pdc(msg_id) != 0)
+				UET_PDS_ERR("PDC %u failed to roll back msg_id %u",
+					    pdc->pdc_id, msg_id);
+		}
 		free(pdc_pkt->pkt_buf);
 		free(pdc_pkt);
 		return rc;
 	}
+
+	pdc->next_psn++;
+	if (pdc->state == PDC_STATE_SYN)
+		pdc->syn_offset++;
 
 	/* the packet was sent successfully */
 	uet_pds_pkt_dbg(uet, &pdc_pkt->pkt_pp, true, "TX PACKET");
@@ -2010,8 +2027,6 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 		    pdc_pkt->pkt_pp.pds_clear_psn, pdc_pkt->psn,
 		    (pdc_pkt->psn - pdc->tx_bm_base_psn));
 
-	bm_set(pdc->tx_bm, (pdc_pkt->psn - pdc->tx_bm_base_psn), pdc_pkt);
-
 	if (UET_LOG_LVL >= UET_LOG_DBG) {
 		UET_PDS_DBG("PDC %u tx_bm (base %u):",
 			    pdc->pdc_id, pdc->tx_bm_base_psn);
@@ -2020,6 +2035,40 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 
 	/* insert the packet to the end of the timeout queue */
 	dlist_insert_tail(&pdc_pkt->node, &pdc->tx_pkt_list_head);
+
+	/* Commit end-of-message state only after the EOM packet was sent. */
+	if (!pds_info && (flags & UET_PDS_FLAG_EOM)) {
+		if (flags & UET_PDS_FLAG_MAINTAIN_PDC) {
+			UET_PDS_DBG("PDC %u flagged with MAINTAIN_PDC on EOM",
+				    pdc->pdc_id);
+		} else {
+			pdc->active_msg_id = 0;
+			pdc->active_msg_id_valid = false;
+
+			rc = uet_pdsm_unmap_msgid_pdc(msg_id);
+			if (rc != 0)
+				UET_PDS_ERR("PDC %u failed to unmap completed msg_id %u",
+					    pdc->pdc_id, msg_id);
+
+			if (pds_pdc_close_thresh && pdc->is_initiator &&
+			    !pdc->close_requested &&
+			    uet_pds_random_check(pds_pdc_close_thresh)) {
+				UET_PDS_ERR("PDC %u random marked for close!",
+					    pdc->pdc_id);
+				pdc->close_requested = true;
+			}
+
+			if (pdc->sec_enabled && pdc->is_initiator &&
+			    !pdc->close_requested &&
+			    ((uint32_t)(pdc->next_psn - pdc->start_psn) >=
+			     UET_PSN_RANGE_LIMIT)) {
+				UET_PDS_ERR("PDC %u PSN range exhausted; marked for close!",
+					    pdc->pdc_id);
+				pdc->close_requested = true;
+				pds_state.psn_range_close_cnt++;
+			}
+		}
+	}
 
 	/* if close was requested, send it now */
 	if ((pdc->state == PDC_STATE_ESTABLISHED) && pdc->is_initiator &&
@@ -3612,7 +3661,12 @@ static int uet_pds_process_syn_pkt(struct uet_instance *uet,
 		    pdc->pdc_id, pdc->rx_bm_base_psn, pp->pds_psn,
 		    (pp->pds_psn - pdc->rx_bm_base_psn));
 
-	bm_set(pdc->rx_bm, (pp->pds_psn - pdc->rx_bm_base_psn), pdc_pkt);
+	if (!bm_set(pdc->rx_bm,
+		    (pp->pds_psn - pdc->rx_bm_base_psn), pdc_pkt)) {
+		UET_PDS_ERR("PDC %u cannot track RX PSN %u",
+			    pdc->pdc_id, pp->pds_psn);
+		return -ERANGE;
+	}
 
 	if (UET_LOG_LVL >= UET_LOG_DBG) {
 		UET_PDS_DBG("PDC %d rx_bm (base %u):",
@@ -3921,8 +3975,14 @@ static int uet_pds_process_request(struct uet_instance *uet,
 		    pdc_pkt->pkt_pp.pds_psn,
 		    (pdc_pkt->pkt_pp.pds_psn - pdc->rx_bm_base_psn));
 
-	bm_set(pdc->rx_bm, (pdc_pkt->pkt_pp.pds_psn - pdc->rx_bm_base_psn),
-	       pdc_pkt);
+	if (!bm_set(pdc->rx_bm,
+		    (pdc_pkt->pkt_pp.pds_psn - pdc->rx_bm_base_psn),
+		    pdc_pkt)) {
+		UET_PDS_ERR("PDC %u cannot track RX PSN %u",
+			    pdc->pdc_id, pdc_pkt->pkt_pp.pds_psn);
+		rc = -ERANGE;
+		goto exit_err;
+	}
 
 	if (UET_LOG_LVL >= UET_LOG_DBG) {
 		UET_PDS_DBG("PDC %d rx_bm (base %u):",

--- a/util/bitmap.c
+++ b/util/bitmap.c
@@ -67,18 +67,21 @@ int bm_count(const struct bitmap *bm)
 	return total;
 }
 
-void bm_set(struct bitmap *bm, int i, void *data)
+bool bm_set(struct bitmap *bm, int i, void *data)
 {
-	int idx = (i / 64);
-
-	if (idx >= bm->bit_arr_len)
-		return; /* could assert() here */
+	int idx;
 
 	if ((i < 0) || (i >= bm->size))
-		return; /* could assert() here */
+		return false;
+
+	idx = (i / 64);
+
+	if (idx >= bm->bit_arr_len)
+		return false;
 
 	bm->bit_arr[idx] |= ((uint64_t)1 << (i % 64));
 	bm->data_arr[i] = data;
+	return true;
 }
 
 void bm_unset(struct bitmap *bm, int i)

--- a/util/bitmap.h
+++ b/util/bitmap.h
@@ -20,7 +20,7 @@ struct bitmap *bm_create(int size); /* size = number of bits (mult of 64) */
 void bm_destroy(struct bitmap *bm);
 void bm_clear(struct bitmap *bm);
 int bm_count(const struct bitmap *bm); /* total bits set */
-void bm_set(struct bitmap *bm, int i, void *data);
+bool bm_set(struct bitmap *bm, int i, void *data);
 void bm_unset(struct bitmap *bm, int i);
 bool bm_get(const struct bitmap *bm, int i, void **data);
 int bm_min(const struct bitmap *bm); /* -1 if empty */


### PR DESCRIPTION
## Summary

- stop PDS transmission before the 128-entry PSN tracker overflows
- make PSN, message-map, EOM, and close state transactional across deferred sends
- encode `pds.mpr` in its specified 128-packet units and honor peer MPR updates
- gate both new transmissions and retransmissions at `CACK_PSN + MP_RANGE`
- preserve the IOV position when SES resumes a send after `-EAGAIN`
- add `UET_MSG_SIZE` to reproduce large-message regressions

## Problem

The transmit path continued assigning and sending PSNs after its bitmap was
full. The bitmap silently rejected those entries, so the packets had no ACK or
retransmission state and large messages eventually failed with
packet-not-found and retry-exceeded errors.

The ACK_CC path also wrote the 128-entry bitmap size directly to `pds.mpr`.
Because the wire field is encoded in units of 128 packets, this advertised an
MP_RANGE of 16384 packets instead of 128. Received MPR updates were parsed but
not enforced.

## Validation

- bitmap unit tests: 227 checks, 0 failures
- Linux build of `libuet_fabric.so` and `uet`
- directly connected Ethernet interfaces using the traditional `rawsock` backend:
  - ACK and ACK_CC
  - 256 KiB and 1 MiB messages
  - buffer and IOV modes
  - three ping-pong iterations per case
- no data corruption, packet-not-found, retry-exceeded, or invalid-ACK failure

This branch is based directly on current upstream `main` and contains only
generic API, PDS, test, and bitmap changes.
