### PR TITLE
libfabric: add a backend-neutral UET provider

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Compile uet-ref-prov
         run: |
           make
+          make provider provider-smoke
 
       - name: Check network brm to vm
         run: |
@@ -99,6 +100,59 @@ jobs:
           sudo ip -6 neigh add fd00:1::1 lladdr $MAC2 dev vm2 nud permanent
           sudo ip -6 neigh add fd00:1::2 lladdr $MAC1 dev brm nud permanent
 
+      - name: Validate the external libfabric provider
+        run: |
+          set -euo pipefail
+          provider_env=(
+            FI_PROVIDER_PATH="$PWD"
+            LD_LIBRARY_PATH="$PWD:../libfabric/src/.libs"
+            UET_NIC_SHIM=rawsock
+          )
+
+          env "${provider_env[@]}" ../libfabric/util/fi_info -p uet
+          if [ "${{ matrix.family }}" = ipv6 ]; then
+            smoke_addr=fd00:1::1
+          else
+            smoke_addr=10.1.0.1
+          fi
+          sudo env "${provider_env[@]}" UET_IFNAME=brm \
+            ./uet_provider_smoke "$smoke_addr"
+
+          server_pid=
+          cleanup() {
+            if [ -n "$server_pid" ]; then
+              sudo kill "$server_pid" 2>/dev/null || true
+            fi
+            sudo ip netns del uet-fi-provider-a 2>/dev/null || true
+            sudo ip netns del uet-fi-provider-b 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          sudo ip netns add uet-fi-provider-a
+          sudo ip netns add uet-fi-provider-b
+          sudo ip link add uet-fi-a type veth peer name uet-fi-b
+          sudo ip link set uet-fi-a netns uet-fi-provider-a
+          sudo ip link set uet-fi-b netns uet-fi-provider-b
+          sudo ip -n uet-fi-provider-a addr add 192.0.2.1/24 dev uet-fi-a
+          sudo ip -n uet-fi-provider-b addr add 192.0.2.2/24 dev uet-fi-b
+          sudo ip -n uet-fi-provider-a link set lo up
+          sudo ip -n uet-fi-provider-b link set lo up
+          sudo ip -n uet-fi-provider-a link set uet-fi-a up
+          sudo ip -n uet-fi-provider-b link set uet-fi-b up
+
+          timeout 30 sudo ip netns exec uet-fi-provider-a \
+            env "${provider_env[@]}" UET_IFNAME=uet-fi-a \
+            ../libfabric/util/fi_pingpong -p uet -e rdm -m msg \
+            -I 100 -S 1024 -c &
+          server_pid=$!
+          sleep 2
+          timeout 30 sudo ip netns exec uet-fi-provider-b \
+            env "${provider_env[@]}" UET_IFNAME=uet-fi-b \
+            ../libfabric/util/fi_pingpong -p uet -e rdm -m msg \
+            -I 100 -S 1024 -c 192.0.2.1
+          wait "$server_pid"
+          server_pid=
+
       # Suite via scripts/uet_test.sh, which sets each mode's env (security
       # modes, SSI, ack_cc, timeouts) and auto-discovers ../libfabric. One
       # PDS-cell/test per loop iteration keeps the server (background) and
@@ -126,4 +180,3 @@ jobs:
               echo "::endgroup::"
             done
           done
-

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ XDP_MAIN_OBJ=$(XDP_OBJ_DIR)/uet.o
 XDP_KERN_SRC=$(wildcard nic_shim/*xdp_kern*)
 XDP_KERN_BIN=uet_xdp_kern.o
 
-xdp: CFLAGS+=-DENABLE_XDP -DXDP_PROG=$(XDP_KERN_BIN)
-xdp: LDFLAGS+=-lbpf -lxdp
+xdp xdp-engine: CFLAGS+=-DENABLE_VERBS=0 -DENABLE_XDP -DXDP_PROG=$(XDP_KERN_BIN)
+xdp xdp-engine: LDFLAGS+=-lxdp -lbpf
 
 # Libfabric provider.  The provider is backend-neutral and loads one of the
 # existing UET engine libraries at fi_fabric() time according to UET_NIC_SHIM.
@@ -116,7 +116,9 @@ xdp: $(XDP_BIN) $(XDP_KERN_BIN)
 
 provider: $(FABRIC_LIB) $(PROVIDER_LIB)
 
-provider-xdp: provider xdp
+provider-xdp: provider xdp-engine
+
+xdp-engine: $(XDP_LIB) $(XDP_KERN_BIN)
 
 provider-smoke: $(PROVIDER_SMOKE)
 
@@ -219,4 +221,4 @@ clean:
 		$(PROVIDER_SMOKE) \
 		$(CC_SIM_OBJ_DIR) $(CC_SIM_BIN)
 
-.PHONY: all xdp provider provider-xdp provider-smoke cc_sim clean
+.PHONY: all xdp xdp-engine provider provider-xdp provider-smoke cc_sim clean

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ MAIN_OBJ=$(OBJ_DIR)/uet.o
 XDP_LIBNAME=xdpuet
 XDP_LIB=lib$(XDP_LIBNAME).so
 XDP_LIB_SRC=$(filter-out uet.c, \
-	    $(filter-out nic_shim/*xdp_kern*, \
+	    $(filter-out $(wildcard nic_shim/*xdp_kern*), \
 			 $(wildcard *.c \
 				    util/*.c \
 				    imp_shim/*.c \
@@ -93,6 +93,16 @@ XDP_KERN_BIN=uet_xdp_kern.o
 xdp: CFLAGS+=-DENABLE_XDP -DXDP_PROG=$(XDP_KERN_BIN)
 xdp: LDFLAGS+=-lbpf -lxdp
 
+# Libfabric provider.  The provider is backend-neutral and loads one of the
+# existing UET engine libraries at fi_fabric() time according to UET_NIC_SHIM.
+PROVIDER_LIB=libuet-fi.so
+PROVIDER_SRC=$(wildcard libfabric-provider/*.c)
+PROVIDER_HDRS=$(wildcard libfabric-provider/*.h)
+PROVIDER_OBJ_DIR=obj_libuet_provider
+PROVIDER_OBJ=$(patsubst %.c, $(PROVIDER_OBJ_DIR)/%.o, $(PROVIDER_SRC))
+PROVIDER_SMOKE=uet_provider_smoke
+PROVIDER_SMOKE_SRC=libfabric-provider/tests/provider_smoke.c
+
 CC_SIM_BIN=uet_cc_sim
 CC_SIM_SRC=$(wildcard cc/*.c cc_sim/*.c)
 CC_SIM_OBJ_DIR=obj_cc_sim
@@ -103,6 +113,12 @@ all: $(FABRIC_LIB) $(VERBS_LIB) $(BIN)
 
 # XDP target
 xdp: $(XDP_BIN) $(XDP_KERN_BIN)
+
+provider: $(FABRIC_LIB) $(PROVIDER_LIB)
+
+provider-xdp: provider xdp
+
+provider-smoke: $(PROVIDER_SMOKE)
 
 # CC sim target
 cc_sim: $(CC_SIM_BIN)
@@ -164,9 +180,24 @@ $(XDP_BIN): $(XDP_LIB) $(XDP_MAIN_OBJ)
 
 $(XDP_KERN_BIN): $(XDP_KERN_SRC)
 	@echo 'Building XDP kernel program: $@'
-	@$(CLANG) -O2 -g -Wall -target bpf \
+	@$(CLANG) -O2 -g -Wall -target bpf -D__$(shell uname -m)__ \
 		  -I/usr/include/$(shell uname -m)-linux-gnu \
 		  -c -o $(XDP_KERN_BIN) $(XDP_KERN_SRC)
+
+$(PROVIDER_OBJ_DIR)/%.o: %.c $(HDRS) $(PROVIDER_HDRS)
+	@mkdir -p $(PROVIDER_OBJ_DIR)/$(dir $<)
+	@echo 'Building libfabric provider object: $<'
+	@$(CC) $(CFLAGS) -D_GNU_SOURCE -DENABLE_VERBS=0 $(INCS) $(LF_HDRS) \
+		-Ilibfabric-provider -fPIC -c -o $@ $<
+
+$(PROVIDER_LIB): $(PROVIDER_OBJ)
+	@echo 'Building libfabric provider: $@'
+	@$(CC) -shared $(PROVIDER_OBJ) -o $@ $(LDFLAGS) $(LF_LIBS) -ldl
+
+$(PROVIDER_SMOKE): $(PROVIDER_SMOKE_SRC)
+	@echo 'Building libfabric provider smoke test: $@'
+	@$(CC) $(CFLAGS) -D_GNU_SOURCE $(INCS) $(LF_HDRS) $< -o $@ \
+		$(LDFLAGS) $(LF_LIBS)
 
 $(CC_SIM_OBJ_DIR)/%.o: %.c $(HDRS)
 	@mkdir -p $(CC_SIM_OBJ_DIR)/$(dir $<)
@@ -184,7 +215,8 @@ clean:
 		$(XDP_LIB_OBJ_DIR) $(XDP_LIB) \
 		$(XDP_OBJ_DIR) $(XDP_BIN) \
 		$(XDP_KERN_BIN) \
+		$(PROVIDER_OBJ_DIR) $(PROVIDER_LIB) \
+		$(PROVIDER_SMOKE) \
 		$(CC_SIM_OBJ_DIR) $(CC_SIM_BIN)
 
-.PHONY: all xdp cc_sim clean
-
+.PHONY: all xdp provider provider-xdp provider-smoke cc_sim clean

--- a/README.md
+++ b/README.md
@@ -122,6 +122,31 @@ below build libfabric v1.20.1 and use a symlink for the common name.
 
 ## Build and Run
 
+### libfabric provider
+
+Build the external `uet` provider and its default raw-socket engine with:
+
+```
+% make provider
+% make provider-smoke
+```
+
+`libuet-fi.so` is a single provider plugin for the existing NIC backends. It
+loads an engine when the fabric is opened, according to `UET_NIC_SHIM`:
+
+```
+% FI_PROVIDER_PATH=$PWD \
+  LD_LIBRARY_PATH=../libfabric/src/.libs:$PWD \
+  UET_NIC_SHIM=rawsock \
+  ../libfabric/util/fi_info -p uet
+```
+
+Use `UET_NIC_SHIM=xdp` (or `af_xdp`) with `make provider-xdp`. An application
+selects provider `uet` through the usual libfabric mechanism; no
+backend-specific provider library or application source change is required.
+See the [provider documentation](libfabric-provider/README.md) for its API
+scope, tests, and current zero-copy boundary.
+
 ### rawsock
 
 > The `uet` program only has the `rawsock` NIC shim built into it.
@@ -193,9 +218,15 @@ Replace `2` with the desired number of senders.
 
 ## Environment Variables
 
-- **LD_LIBRARY_PATH** - Needed for dynamic linking to the `libfabric` and `libuet` libraries.
+- **LD_LIBRARY_PATH** - Needed for dynamic linking to the `libfabric` and
+  `libuet` libraries.
+- **FI_PROVIDER_PATH** - Directory containing the external `libuet-fi.so`
+  provider.
 - **UET_IFNAME** - The ifname of the interface to attach to.
-- **UET_NIC_SHIM** - [ `rawsock` | `xdp` ]
+- **UET_NIC_SHIM** - [ `rawsock` | `xdp` | `af_xdp` ]. The external `uet`
+  provider accepts `af_xdp` as an alias for `xdp`.
+- **UET_ENGINE_LIBRARY** - Optional path overriding the engine selected by
+  `UET_NIC_SHIM` when `libuet-fi.so` opens a fabric.
 - **UET_PDS** - [ `sng` | `pds` ] (default=`sng` stop-n-go)
 - **UET_PDS_PER_PKT_ACK_ENB** - [ `0` | `1` ] (default=`0`)
 - **UET_PDS_ACK_TYPE** - [ `ack` | `ack_cc` | `ack_ccx` ] (default=`ack`)
@@ -392,4 +423,3 @@ Running `checkpatch.pl` out of tree against a local `.h` or `.c` file:
 ```
 
 Thank you! 😀
-

--- a/libfabric-provider/README.md
+++ b/libfabric-provider/README.md
@@ -1,0 +1,108 @@
+# UET external libfabric provider
+
+`libuet-fi.so` is an external libfabric provider named `uet`. It lets an
+application use the normal libfabric API while choosing the existing UET NIC
+backend at runtime. There is no backend-specific provider library:
+
+| `UET_NIC_SHIM` | Engine loaded by `libuet-fi.so` |
+| --- | --- |
+| unset or `rawsock` | `libuet_fabric.so` |
+| `xdp` or `af_xdp` | `libxdpuet.so` |
+
+`UET_ENGINE_LIBRARY=/absolute/path/to/library.so` can override this mapping for
+development. The engine is loaded when `fi_fabric()` is called, not during
+`fi_getinfo()`, so provider discovery does not acquire a NIC.
+
+## API scope
+
+The initial provider implements:
+
+- `FI_EP_RDM` with `FI_MSG` and `FI_TAGGED` send/receive operations;
+- `FI_AV_TABLE`, including lookup and removal;
+- context, message, data, and tagged completion-queue formats with manual
+  progress;
+- endpoint-bound provider-key memory regions (`FI_MR_ENDPOINT |
+  FI_MR_PROV_KEY`);
+- source-name exchange through `fi_getname()`; and
+- a minimal event queue for RDM applications that allocate an EQ as part of a
+  common setup path.
+
+The provider reports `FI_THREAD_SAFE`. Control operations are serialized per
+domain, AV reads use an RW lock, and CQ reads use a per-CQ mutex. Data
+operations retain the existing engine's per-endpoint synchronization; there is
+no provider-wide datapath mutex. The current engine lifecycle permits one
+active domain per fabric.
+
+RMA, atomics, inject operations, counters, scalable endpoints, shared contexts,
+and connection-oriented endpoints are not advertised yet. The UET engine has
+some of these operations internally, but they must not be advertised until
+their libfabric objects, completion semantics, and error paths are implemented
+and tested at this provider boundary.
+
+## Build
+
+With a built libfabric tree in `../libfabric`:
+
+```sh
+make provider
+make provider-smoke
+```
+
+This builds `libuet-fi.so`, `libuet_fabric.so`, and
+`uet_provider_smoke`. Use `make provider-xdp` to build the AF_XDP engine as
+well.
+
+The provider itself links only to libfabric, pthreads, and `libdl`. Backend
+dependencies remain in their engine libraries.
+
+## Run an unchanged libfabric application
+
+Point libfabric at the external provider, make the selected engine visible to
+the dynamic loader, and select provider `uet` in the application's normal way:
+
+```sh
+export FI_PROVIDER_PATH=$PWD
+export LD_LIBRARY_PATH=$PWD:../libfabric/src/.libs
+export UET_NIC_SHIM=rawsock
+export UET_IFNAME=ens4f0np0
+
+../libfabric/util/fi_info -p uet
+../libfabric/util/fi_pingpong -p uet -e rdm -m msg
+```
+
+The peer runs the same application and provider. Its backend may be selected
+independently.
+
+## Tests
+
+The backend-neutral lifecycle test exercises fabric, domain, AV, CQ, endpoint,
+MR, enable, `fi_getname()`, and ordered teardown:
+
+```sh
+sudo env \
+  FI_PROVIDER_PATH=$PWD \
+  LD_LIBRARY_PATH=$PWD:../libfabric/src/.libs \
+  UET_NIC_SHIM=rawsock \
+  UET_IFNAME=ens4f0np0 \
+  ./uet_provider_smoke 192.0.2.1
+```
+
+Functional validation also uses the unmodified libfabric `fi_pingpong`
+utility. MSG and TAGGED transfers have been validated over the raw-socket
+engine and MSG over AF_XDP.
+
+## Zero-copy boundary
+
+The provider layer forwards application buffer pointers and IOVs to the UET
+engine without adding a provider-side staging copy. This is not yet
+end-to-end zero copy:
+
+- the current AF_XDP engine copies between application data and its UMEM;
+- the raw-socket engine serializes TX into a packet buffer and delivers RX
+  payload into the application's posted receive buffer.
+
+End-to-end zero copy requires a backend able to register or allocate compatible
+application buffers and preserve their ownership through TX, RX, completion,
+and cancellation. That can remain a single `uet` provider and does not require
+application source changes for applications that already follow the relevant
+libfabric MR allocation and registration contract.

--- a/libfabric-provider/tests/provider_smoke.c
+++ b/libfabric-provider/tests/provider_smoke.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_errno.h>
+
+#include "uet_addr.h"
+
+static int check(int rc, const char *operation)
+{
+	if (!rc)
+		return 0;
+	fprintf(stderr, "%s: %s (%d)\n", operation, fi_strerror(-rc), rc);
+	return rc;
+}
+
+int main(int argc, char **argv)
+{
+	struct fi_info *hints = NULL, *info = NULL;
+	struct fid_fabric *fabric = NULL;
+	struct fid_eq *eq = NULL;
+	struct fid_domain *domain = NULL;
+	struct fid_av *av = NULL;
+	struct fid_cq *cq = NULL;
+	struct fid_ep *ep = NULL;
+	struct fid_mr *mr = NULL;
+	struct fi_av_attr av_attr = { .type = FI_AV_TABLE, .count = 16 };
+	struct fi_eq_attr eq_attr = { .wait_obj = FI_WAIT_NONE };
+	struct fi_cq_attr cq_attr = {
+		.size = 32,
+		.format = FI_CQ_FORMAT_TAGGED,
+		.wait_obj = FI_WAIT_NONE,
+	};
+	struct uet_addr local_addr;
+	size_t addrlen = sizeof(local_addr);
+	char buffer[4096];
+	int close_rc;
+	int rc = 1;
+
+	if (argc != 2) {
+		fprintf(stderr, "usage: %s <local-ip>\n", argv[0]);
+		return 2;
+	}
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return 1;
+	hints->caps = FI_MSG | FI_TAGGED;
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->fabric_attr->prov_name = strdup("uet");
+	if (!hints->fabric_attr->prov_name)
+		goto out;
+
+	fprintf(stderr, "smoke: fi_getinfo\n");
+	rc = fi_getinfo(FI_VERSION(1, 20), argv[1], NULL, FI_SOURCE,
+			hints, &info);
+	if (check(rc, "fi_getinfo"))
+		goto out;
+	fprintf(stderr, "smoke: fi_fabric\n");
+	rc = fi_fabric(info->fabric_attr, &fabric, NULL);
+	if (check(rc, "fi_fabric"))
+		goto out;
+	fprintf(stderr, "smoke: fi_eq_open\n");
+	rc = fi_eq_open(fabric, &eq_attr, &eq, NULL);
+	if (check(rc, "fi_eq_open"))
+		goto out;
+	fprintf(stderr, "smoke: fi_domain\n");
+	rc = fi_domain(fabric, info, &domain, NULL);
+	if (check(rc, "fi_domain"))
+		goto out;
+	fprintf(stderr, "smoke: fi_av_open\n");
+	rc = fi_av_open(domain, &av_attr, &av, NULL);
+	if (check(rc, "fi_av_open"))
+		goto out;
+	fprintf(stderr, "smoke: fi_cq_open\n");
+	rc = fi_cq_open(domain, &cq_attr, &cq, NULL);
+	if (check(rc, "fi_cq_open"))
+		goto out;
+	fprintf(stderr, "smoke: fi_endpoint\n");
+	rc = fi_endpoint(domain, info, &ep, NULL);
+	if (check(rc, "fi_endpoint"))
+		goto out;
+	fprintf(stderr, "smoke: fi_ep_bind(AV)\n");
+	rc = fi_ep_bind(ep, &av->fid, 0);
+	if (check(rc, "fi_ep_bind(AV)"))
+		goto out;
+	fprintf(stderr, "smoke: fi_ep_bind(CQ)\n");
+	rc = fi_ep_bind(ep, &cq->fid, FI_SEND | FI_RECV);
+	if (check(rc, "fi_ep_bind(CQ)"))
+		goto out;
+	fprintf(stderr, "smoke: fi_mr_reg\n");
+	rc = fi_mr_reg(domain, buffer, sizeof(buffer), FI_SEND | FI_RECV |
+		       FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 0, 0, &mr, NULL);
+	if (check(rc, "fi_mr_reg"))
+		goto out;
+	fprintf(stderr, "smoke: fi_mr_bind\n");
+	rc = fi_mr_bind(mr, &ep->fid, FI_REMOTE_READ | FI_REMOTE_WRITE);
+	if (check(rc, "fi_mr_bind"))
+		goto out;
+	fprintf(stderr, "smoke: fi_mr_enable\n");
+	rc = fi_mr_enable(mr);
+	if (check(rc, "fi_mr_enable"))
+		goto out;
+	fprintf(stderr, "smoke: fi_enable\n");
+	rc = fi_enable(ep);
+	if (check(rc, "fi_enable"))
+		goto out;
+	fprintf(stderr, "smoke: fi_getname\n");
+	rc = fi_getname(&ep->fid, &local_addr, &addrlen);
+	if (check(rc, "fi_getname"))
+		goto out;
+
+	/* Exercise normal FI_MR_ENDPOINT cleanup before endpoint close. */
+	fprintf(stderr, "smoke: fi_close(MR)\n");
+	rc = fi_close(&mr->fid);
+	if (check(rc, "fi_close(MR)"))
+		goto out;
+	mr = NULL;
+
+	rc = 0;
+
+out:
+	fprintf(stderr, "smoke: cleanup\n");
+	if (mr) {
+		close_rc = fi_close(&mr->fid);
+		if (close_rc && !rc)
+			rc = check(close_rc, "fi_close(MR)");
+	}
+	if (ep) {
+		close_rc = fi_close(&ep->fid);
+		if (close_rc && !rc)
+			rc = check(close_rc, "fi_close(EP)");
+	}
+	if (cq) {
+		close_rc = fi_close(&cq->fid);
+		if (close_rc && !rc)
+			rc = check(close_rc, "fi_close(CQ)");
+	}
+	if (av) {
+		close_rc = fi_close(&av->fid);
+		if (close_rc && !rc)
+			rc = check(close_rc, "fi_close(AV)");
+	}
+	if (eq) {
+		close_rc = fi_close(&eq->fid);
+		if (close_rc && !rc)
+			rc = check(close_rc, "fi_close(EQ)");
+	}
+	if (domain) {
+		close_rc = fi_close(&domain->fid);
+		if (close_rc && !rc)
+			rc = check(close_rc, "fi_close(domain)");
+	}
+	if (fabric) {
+		close_rc = fi_close(&fabric->fid);
+		if (close_rc && !rc)
+			rc = check(close_rc, "fi_close(fabric)");
+	}
+	fi_freeinfo(info);
+	fi_freeinfo(hints);
+	if (!rc)
+		printf("uet provider smoke test passed (%s backend)\n",
+		       getenv("UET_NIC_SHIM") ? getenv("UET_NIC_SHIM") :
+						 "rawsock");
+	return rc ? 1 : 0;
+}

--- a/libfabric-provider/tests/provider_smoke.c
+++ b/libfabric-provider/tests/provider_smoke.c
@@ -197,24 +197,24 @@ int main(int argc, char **argv)
 	if (check(rc, "fi_endpoint"))
 		goto out;
 	{
-		size_t inject_size = 0;
-		size_t optlen = sizeof(inject_size);
+		size_t option_value = 0;
+		size_t optlen = sizeof(option_value);
 
 		fprintf(stderr, "smoke: unsupported endpoint options\n");
 		rc = fi_getopt(&ep->fid, FI_OPT_ENDPOINT,
-			       FI_OPT_INJECT_MSG_SIZE, &inject_size, &optlen);
+			       FI_OPT_SEND_BUF_SIZE, &option_value, &optlen);
 		if (rc != -FI_ENOPROTOOPT) {
 			fprintf(stderr,
-				"fi_getopt(inject size): expected %d, got %d\n",
+				"fi_getopt(send buffer): expected %d, got %d\n",
 				-FI_ENOPROTOOPT, rc);
 			goto out;
 		}
 		rc = fi_setopt(&ep->fid, FI_OPT_ENDPOINT,
-			       FI_OPT_INJECT_MSG_SIZE, &inject_size,
-			       sizeof(inject_size));
+			       FI_OPT_SEND_BUF_SIZE, &option_value,
+			       sizeof(option_value));
 		if (rc != -FI_ENOPROTOOPT) {
 			fprintf(stderr,
-				"fi_setopt(inject size): expected %d, got %d\n",
+				"fi_setopt(send buffer): expected %d, got %d\n",
 				-FI_ENOPROTOOPT, rc);
 			goto out;
 		}

--- a/libfabric-provider/tests/provider_smoke.c
+++ b/libfabric-provider/tests/provider_smoke.c
@@ -158,6 +158,20 @@ int main(int argc, char **argv)
 		rc = -FI_ENODATA;
 		goto out;
 	}
+	if (info->domain_attr->ep_cnt < 3 ||
+	    info->domain_attr->tx_ctx_cnt < 3 ||
+	    info->domain_attr->rx_ctx_cnt < 3) {
+		fprintf(stderr,
+			"fi_getinfo did not advertise multi-endpoint capacity\n");
+		rc = -FI_ENODATA;
+		goto out;
+	}
+	if (info->caps & FI_DIRECTED_RECV) {
+		fprintf(stderr,
+			"fi_getinfo advertised unqualified directed receive\n");
+		rc = -FI_ENODATA;
+		goto out;
+	}
 	fprintf(stderr, "smoke: fi_fabric\n");
 	rc = fi_fabric(info->fabric_attr, &fabric, NULL);
 	if (check(rc, "fi_fabric"))

--- a/libfabric-provider/tests/provider_smoke.c
+++ b/libfabric-provider/tests/provider_smoke.c
@@ -1,7 +1,6 @@
+// SPDX-License-Identifier: MIT
 /*
  * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
- *
- * SPDX-License-Identifier: MIT
  */
 
 #include <stdio.h>

--- a/libfabric-provider/tests/provider_smoke.c
+++ b/libfabric-provider/tests/provider_smoke.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
 	struct fid_domain *domain = NULL;
 	struct fid_av *av = NULL;
 	struct fid_cq *cq = NULL;
-	struct fid_ep *ep = NULL;
+	struct fid_ep *ep = NULL, *ep2 = NULL, *ep3 = NULL;
 	struct fid_mr *mr = NULL;
 	struct fi_av_attr av_attr = { .type = FI_AV_TABLE, .count = 16 };
 	struct fi_eq_attr eq_attr = { .wait_obj = FI_WAIT_NONE };
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
 		.format = FI_CQ_FORMAT_TAGGED,
 		.wait_obj = FI_WAIT_NONE,
 	};
-	struct uet_addr local_addr;
+	struct uet_addr local_addr, local_addr2, local_addr3;
 	size_t addrlen = sizeof(local_addr);
 	char buffer[4096];
 	int close_rc;
@@ -120,12 +120,57 @@ int main(int argc, char **argv)
 	if (check(rc, "fi_getname"))
 		goto out;
 
+	/* A single process may create several endpoints on the same fabric
+	 * address and PIDonFEP.  They must receive distinct Resource Indices.
+	 */
+	fprintf(stderr, "smoke: fi_endpoint(second)\n");
+	rc = fi_endpoint(domain, info, &ep2, NULL);
+	if (check(rc, "fi_endpoint(second)"))
+		goto out;
+	addrlen = sizeof(local_addr2);
+	rc = fi_getname(&ep2->fid, &local_addr2, &addrlen);
+	if (check(rc, "fi_getname(second)"))
+		goto out;
+	if (local_addr.pid_on_fep != local_addr2.pid_on_fep ||
+	    local_addr.start_index == local_addr2.start_index) {
+		fprintf(stderr,
+			"multi-endpoint address allocation failed: PID %u, RI %u/%u\n",
+			local_addr.pid_on_fep, local_addr.start_index,
+			local_addr2.start_index);
+		rc = -FI_EADDRINUSE;
+		goto out;
+	}
+
 	/* Exercise normal FI_MR_ENDPOINT cleanup before endpoint close. */
 	fprintf(stderr, "smoke: fi_close(MR)\n");
 	rc = fi_close(&mr->fid);
 	if (check(rc, "fi_close(MR)"))
 		goto out;
 	mr = NULL;
+
+	/* The engine waits for its close lifetime before removing the address.
+	 * Once close returns, the index may be allocated again without colliding
+	 * with the still-live second endpoint.
+	 */
+	fprintf(stderr, "smoke: fi_close(first EP)\n");
+	rc = fi_close(&ep->fid);
+	if (check(rc, "fi_close(first EP)"))
+		goto out;
+	ep = NULL;
+	fprintf(stderr, "smoke: fi_endpoint(reallocated)\n");
+	rc = fi_endpoint(domain, info, &ep3, NULL);
+	if (check(rc, "fi_endpoint(reallocated)"))
+		goto out;
+	addrlen = sizeof(local_addr3);
+	rc = fi_getname(&ep3->fid, &local_addr3, &addrlen);
+	if (check(rc, "fi_getname(reallocated)"))
+		goto out;
+	if (local_addr3.start_index != local_addr.start_index) {
+		fprintf(stderr, "closed Resource Index was not reused: %u != %u\n",
+			local_addr3.start_index, local_addr.start_index);
+		rc = -FI_EINVAL;
+		goto out;
+	}
 
 	rc = 0;
 
@@ -140,6 +185,16 @@ out:
 		close_rc = fi_close(&ep->fid);
 		if (close_rc && !rc)
 			rc = check(close_rc, "fi_close(EP)");
+	}
+	if (ep3) {
+		close_rc = fi_close(&ep3->fid);
+		if (close_rc && !rc)
+			rc = check(close_rc, "fi_close(reallocated EP)");
+	}
+	if (ep2) {
+		close_rc = fi_close(&ep2->fid);
+		if (close_rc && !rc)
+			rc = check(close_rc, "fi_close(second EP)");
 	}
 	if (cq) {
 		close_rc = fi_close(&cq->fid);

--- a/libfabric-provider/tests/provider_smoke.c
+++ b/libfabric-provider/tests/provider_smoke.c
@@ -16,12 +16,52 @@
 
 #include "uet_addr.h"
 
+#define UET_PROVIDER_SMOKE_ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 static int check(int rc, const char *operation)
 {
 	if (!rc)
 		return 0;
 	fprintf(stderr, "%s: %s (%d)\n", operation, fi_strerror(-rc), rc);
 	return rc;
+}
+
+static int check_threading_hints(const char *node)
+{
+	static const enum fi_threading models[] = {
+		FI_THREAD_SAFE,
+		FI_THREAD_FID,
+		FI_THREAD_DOMAIN,
+		FI_THREAD_COMPLETION,
+		FI_THREAD_ENDPOINT,
+	};
+	struct fi_info *hints;
+	struct fi_info *info;
+	size_t i;
+	int rc;
+
+	for (i = 0; i < UET_PROVIDER_SMOKE_ARRAY_SIZE(models); i++) {
+		hints = fi_allocinfo();
+		if (!hints)
+			return -FI_ENOMEM;
+		hints->caps = FI_MSG | FI_TAGGED;
+		hints->ep_attr->type = FI_EP_RDM;
+		hints->domain_attr->threading = models[i];
+		hints->fabric_attr->prov_name = strdup("uet");
+		if (!hints->fabric_attr->prov_name) {
+			fi_freeinfo(hints);
+			return -FI_ENOMEM;
+		}
+
+		info = NULL;
+		rc = fi_getinfo(FI_VERSION(1, 20), node, NULL, FI_SOURCE,
+				hints, &info);
+		fi_freeinfo(info);
+		fi_freeinfo(hints);
+		if (rc)
+			return rc;
+	}
+
+	return FI_SUCCESS;
 }
 
 int main(int argc, char **argv)
@@ -51,6 +91,11 @@ int main(int argc, char **argv)
 		fprintf(stderr, "usage: %s <local-ip>\n", argv[0]);
 		return 2;
 	}
+
+	fprintf(stderr, "smoke: threading hints\n");
+	rc = check_threading_hints(argv[1]);
+	if (check(rc, "fi_getinfo(threading hints)"))
+		return 1;
 
 	hints = fi_allocinfo();
 	if (!hints)
@@ -90,6 +135,30 @@ int main(int argc, char **argv)
 	rc = fi_endpoint(domain, info, &ep, NULL);
 	if (check(rc, "fi_endpoint"))
 		goto out;
+	{
+		size_t inject_size = 0;
+		size_t optlen = sizeof(inject_size);
+
+		fprintf(stderr, "smoke: unsupported endpoint options\n");
+		rc = fi_getopt(&ep->fid, FI_OPT_ENDPOINT,
+			       FI_OPT_INJECT_MSG_SIZE, &inject_size, &optlen);
+		if (rc != -FI_ENOPROTOOPT) {
+			fprintf(stderr,
+				"fi_getopt(inject size): expected %d, got %d\n",
+				-FI_ENOPROTOOPT, rc);
+			goto out;
+		}
+		rc = fi_setopt(&ep->fid, FI_OPT_ENDPOINT,
+			       FI_OPT_INJECT_MSG_SIZE, &inject_size,
+			       sizeof(inject_size));
+		if (rc != -FI_ENOPROTOOPT) {
+			fprintf(stderr,
+				"fi_setopt(inject size): expected %d, got %d\n",
+				-FI_ENOPROTOOPT, rc);
+			goto out;
+		}
+		rc = FI_SUCCESS;
+	}
 	fprintf(stderr, "smoke: fi_ep_bind(AV)\n");
 	rc = fi_ep_bind(ep, &av->fid, 0);
 	if (check(rc, "fi_ep_bind(AV)"))

--- a/libfabric-provider/tests/provider_smoke.c
+++ b/libfabric-provider/tests/provider_smoke.c
@@ -16,6 +16,8 @@
 
 #include "uet_addr.h"
 
+#define UET_PROVIDER_SMOKE_EXTRA_MRS 31
+#define UET_PROVIDER_SMOKE_REQUESTED_MRS 8192
 #define UET_PROVIDER_SMOKE_ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 static int check(int rc, const char *operation)
 {
@@ -64,6 +66,38 @@ static int check_threading_hints(const char *node)
 	return FI_SUCCESS;
 }
 
+static int check_mr_count_hint(const char *node)
+{
+	struct fi_info *hints;
+	struct fi_info *info = NULL;
+	int rc;
+
+	hints = fi_allocinfo();
+	if (!hints)
+		return -FI_ENOMEM;
+	hints->caps = FI_MSG;
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->domain_attr->mr_cnt = UET_PROVIDER_SMOKE_REQUESTED_MRS;
+	hints->fabric_attr->prov_name = strdup("uet");
+	if (!hints->fabric_attr->prov_name) {
+		rc = -FI_ENOMEM;
+		goto out;
+	}
+
+	rc = fi_getinfo(FI_VERSION(1, 20), node, NULL, FI_SOURCE,
+			hints, &info);
+	if (!rc && info->domain_attr->mr_cnt < UET_PROVIDER_SMOKE_REQUESTED_MRS) {
+		fprintf(stderr, "requested %u memory regions, provider returned %zu\n",
+			UET_PROVIDER_SMOKE_REQUESTED_MRS,
+			info->domain_attr->mr_cnt);
+		rc = -FI_ENODATA;
+	}
+out:
+	fi_freeinfo(info);
+	fi_freeinfo(hints);
+	return rc;
+}
+
 int main(int argc, char **argv)
 {
 	struct fi_info *hints = NULL, *info = NULL;
@@ -74,6 +108,7 @@ int main(int argc, char **argv)
 	struct fid_cq *cq = NULL;
 	struct fid_ep *ep = NULL, *ep2 = NULL, *ep3 = NULL;
 	struct fid_mr *mr = NULL;
+	struct fid_mr *extra_mrs[UET_PROVIDER_SMOKE_EXTRA_MRS] = { 0 };
 	struct fi_av_attr av_attr = { .type = FI_AV_TABLE, .count = 16 };
 	struct fi_eq_attr eq_attr = { .wait_obj = FI_WAIT_NONE };
 	struct fi_cq_attr cq_attr = {
@@ -84,6 +119,8 @@ int main(int argc, char **argv)
 	struct uet_addr local_addr, local_addr2, local_addr3;
 	size_t addrlen = sizeof(local_addr);
 	char buffer[4096];
+	char extra_buffers[UET_PROVIDER_SMOKE_EXTRA_MRS][64];
+	size_t i;
 	int close_rc;
 	int rc = 1;
 
@@ -95,6 +132,10 @@ int main(int argc, char **argv)
 	fprintf(stderr, "smoke: threading hints\n");
 	rc = check_threading_hints(argv[1]);
 	if (check(rc, "fi_getinfo(threading hints)"))
+		return 1;
+	fprintf(stderr, "smoke: MR count hint\n");
+	rc = check_mr_count_hint(argv[1]);
+	if (check(rc, "fi_getinfo(MR count hint)"))
 		return 1;
 
 	hints = fi_allocinfo();
@@ -111,6 +152,12 @@ int main(int argc, char **argv)
 			hints, &info);
 	if (check(rc, "fi_getinfo"))
 		goto out;
+	if (info->domain_attr->mr_cnt < UET_PROVIDER_SMOKE_EXTRA_MRS + 1) {
+		fprintf(stderr, "fi_getinfo returned only %zu memory regions\n",
+			info->domain_attr->mr_cnt);
+		rc = -FI_ENODATA;
+		goto out;
+	}
 	fprintf(stderr, "smoke: fi_fabric\n");
 	rc = fi_fabric(info->fabric_attr, &fabric, NULL);
 	if (check(rc, "fi_fabric"))
@@ -180,6 +227,21 @@ int main(int argc, char **argv)
 	rc = fi_mr_enable(mr);
 	if (check(rc, "fi_mr_enable"))
 		goto out;
+	/* The provider's default domain must support more than the engine's
+	 * historical 16-MR minimum without application-specific fi_info edits.
+	 */
+	for (i = 0; i < UET_PROVIDER_SMOKE_EXTRA_MRS; i++) {
+		rc = fi_mr_reg(domain, extra_buffers[i], sizeof(extra_buffers[i]),
+			       FI_SEND | FI_RECV, 0, 0, 0, &extra_mrs[i], NULL);
+		if (check(rc, "fi_mr_reg(extra)"))
+			goto out;
+		rc = fi_mr_bind(extra_mrs[i], &ep->fid, 0);
+		if (check(rc, "fi_mr_bind(extra)"))
+			goto out;
+		rc = fi_mr_enable(extra_mrs[i]);
+		if (check(rc, "fi_mr_enable(extra)"))
+			goto out;
+	}
 	fprintf(stderr, "smoke: fi_enable\n");
 	rc = fi_enable(ep);
 	if (check(rc, "fi_enable"))
@@ -216,6 +278,12 @@ int main(int argc, char **argv)
 	if (check(rc, "fi_close(MR)"))
 		goto out;
 	mr = NULL;
+	for (i = 0; i < UET_PROVIDER_SMOKE_EXTRA_MRS; i++) {
+		rc = fi_close(&extra_mrs[i]->fid);
+		if (check(rc, "fi_close(extra MR)"))
+			goto out;
+		extra_mrs[i] = NULL;
+	}
 
 	/* The engine waits for its close lifetime before removing the address.
 	 * Once close returns, the index may be allocated again without colliding
@@ -245,6 +313,13 @@ int main(int argc, char **argv)
 
 out:
 	fprintf(stderr, "smoke: cleanup\n");
+	for (i = 0; i < UET_PROVIDER_SMOKE_EXTRA_MRS; i++) {
+		if (!extra_mrs[i])
+			continue;
+		close_rc = fi_close(&extra_mrs[i]->fid);
+		if (close_rc && !rc)
+			rc = check(close_rc, "fi_close(extra MR)");
+	}
 	if (mr) {
 		close_rc = fi_close(&mr->fid);
 		if (close_rc && !rc)

--- a/libfabric-provider/uet_fi.h
+++ b/libfabric-provider/uet_fi.h
@@ -1,7 +1,6 @@
+/* SPDX-License-Identifier: MIT */
 /*
  * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
- *
- * SPDX-License-Identifier: MIT
  */
 
 #ifndef UET_FI_H

--- a/libfabric-provider/uet_fi.h
+++ b/libfabric-provider/uet_fi.h
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef UET_FI_H
+#define UET_FI_H
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_eq.h>
+#include <rdma/fi_tagged.h>
+
+#include "uet_api.h"
+
+#define UET_FI_PROV_NAME        "uet"
+#define UET_FI_FABRIC_NAME      "uet"
+#define UET_FI_DOMAIN_NAME      "uet"
+#define UET_FI_DEFAULT_QUEUE    256
+#define UET_FI_DEFAULT_AV       64
+#define UET_FI_IOV_LIMIT        8
+#define UET_FI_MAX_MSG_SIZE     ((size_t)UINT32_MAX - 1)
+
+struct uet_fi_engine {
+	void *dl_handle;
+	const char *name;
+
+	int (*initialize)(uet_handle_t *handle);
+	int (*finalize)(uet_handle_t handle);
+	int (*getinfo)(uet_handle_t handle, struct uet_addr *node,
+		       const struct fi_info *hints, struct fi_info **info);
+	int (*domain)(uet_handle_t handle, struct fid_fabric *fabric,
+		      struct fi_info *info, struct fid_domain *domain,
+		      void *context, uet_eq_callback_t eq_callback,
+		      uet_eq_err_callback_t eq_err_callback,
+		      uet_domain_handle_t *domain_handle);
+	int (*domain_close)(uet_domain_handle_t domain_handle);
+	int (*endpoint)(uet_domain_handle_t domain_handle, struct fi_info *info,
+			struct fid_ep *ep, void *context,
+			uet_ep_handle_t *ep_handle);
+	int (*getname)(uet_ep_handle_t ep_handle, struct uet_addr *addr);
+	int (*ep_bind_cq)(uet_ep_handle_t ep_handle, struct fi_cq_attr *attr,
+			  struct fid_cq *cq, uint64_t flags, void *context,
+			  uet_cq_handle_t *cq_handle);
+	int (*ep_bind_mr)(uet_ep_handle_t ep_handle, uet_mr_handle_t mr_handle,
+			  uint64_t flags);
+	int (*ep_enable)(uet_ep_handle_t ep_handle);
+	int (*ep_control)(uet_ep_handle_t ep_handle, int command, void *arg);
+	int (*ep_setopt)(uet_ep_handle_t ep_handle, int level, int optname,
+			 const void *optval, size_t optlen);
+	int (*ep_close)(uet_ep_handle_t ep_handle);
+	int (*cancel)(uet_ep_handle_t ep_handle, void *context);
+
+	ssize_t (*cq_read)(uet_cq_handle_t cq_handle, void *buf, size_t count);
+	uint32_t (*cq_read_src_id)(uet_cq_handle_t cq_handle);
+	ssize_t (*cq_readerr)(uet_cq_handle_t cq_handle,
+			      struct fi_cq_err_entry *buf);
+	int (*cq_close)(uet_cq_handle_t cq_handle);
+
+	int (*av_insert)(uet_domain_handle_t domain_handle,
+			 struct uet_addr *addr, uet_addr_handle_t *addr_handle);
+	int (*av_remove)(uet_addr_handle_t addr_handle);
+
+	int (*mr_reg)(uet_domain_handle_t domain_handle, const void *buf,
+		      size_t len, uint64_t access, uint64_t requested_key,
+		      uint64_t flags, void *context, uet_mr_handle_t *mr_handle);
+	int (*mr_regv)(uet_domain_handle_t domain_handle,
+		       const struct iovec *iov, size_t iov_count,
+		       uint64_t access, uint64_t requested_key, uint64_t flags,
+		       void *context, uet_mr_handle_t *mr_handle);
+	uint64_t (*mr_key)(uet_mr_handle_t mr_handle);
+	int (*mr_enable)(uet_mr_handle_t mr_handle);
+	int (*mr_disable)(uet_mr_handle_t mr_handle);
+	int (*mr_close)(uet_mr_handle_t mr_handle);
+
+	ssize_t (*send)(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
+			size_t len, uet_mr_handle_t mr_handle,
+			uet_addr_handle_t dst_addr_handle, void *context);
+	ssize_t (*sendv)(uet_ep_handle_t ep_handle, uint32_t job_id,
+			 const struct iovec *iov, size_t count,
+			 uet_mr_handle_t mr_handle,
+			 uet_addr_handle_t dst_addr_handle, void *context);
+	ssize_t (*recv)(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
+			size_t len, uet_mr_handle_t mr_handle,
+			uet_addr_handle_t src_addr_handle, void *context);
+	ssize_t (*recvv)(uet_ep_handle_t ep_handle, uint32_t job_id,
+			 const struct iovec *iov, size_t count,
+			 uet_mr_handle_t mr_handle,
+			 uet_addr_handle_t src_addr_handle, void *context);
+	ssize_t (*tsend)(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
+			 size_t len, uet_mr_handle_t mr_handle,
+			 uet_addr_handle_t dst_addr_handle, uint64_t tag,
+			 void *context);
+	ssize_t (*tsendv)(uet_ep_handle_t ep_handle, uint32_t job_id,
+			  const struct iovec *iov, size_t count,
+			  uet_mr_handle_t mr_handle,
+			  uet_addr_handle_t dst_addr_handle, uint64_t tag,
+			  void *context);
+	ssize_t (*trecv)(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
+			 size_t len, uet_mr_handle_t mr_handle,
+			 uet_addr_handle_t src_addr_handle, uint64_t tag,
+			 uint64_t ignore, void *context);
+	ssize_t (*trecvv)(uet_ep_handle_t ep_handle, uint32_t job_id,
+			  const struct iovec *iov, size_t count,
+			  uet_mr_handle_t mr_handle,
+			  uet_addr_handle_t src_addr_handle, uint64_t tag,
+			  uint64_t ignore, void *context);
+};
+
+struct uet_fi_fabric {
+	struct fid_fabric fabric_fid;
+	struct uet_fi_engine engine;
+	uet_handle_t uet;
+	atomic_uint refs;
+	atomic_bool domain_open;
+};
+
+struct uet_fi_eq {
+	struct fid_eq eq_fid;
+	struct uet_fi_fabric *fabric;
+};
+
+struct uet_fi_domain {
+	struct fid_domain domain_fid;
+	struct uet_fi_fabric *fabric;
+	uet_domain_handle_t uet_domain;
+	struct fi_info *engine_info;
+	pthread_mutex_t control_lock;
+	atomic_uint refs;
+};
+
+struct uet_fi_av_entry {
+	struct uet_addr addr;
+	uet_addr_handle_t uet_addr;
+	bool active;
+};
+
+struct uet_fi_av {
+	struct fid_av av_fid;
+	struct uet_fi_domain *domain;
+	struct uet_fi_av_entry **entries;
+	size_t count;
+	pthread_rwlock_t lock;
+	atomic_uint refs;
+};
+
+struct uet_fi_ep;
+
+struct uet_fi_cq {
+	struct fid_cq cq_fid;
+	struct uet_fi_domain *domain;
+	struct fi_cq_attr attr;
+	struct uet_fi_ep *ep;
+	uet_cq_handle_t tx_cq;
+	uet_cq_handle_t rx_cq;
+	pthread_mutex_t lock;
+	bool read_rx_next;
+	atomic_uint refs;
+};
+
+struct uet_fi_mr {
+	struct fid_mr mr_fid;
+	struct uet_fi_domain *domain;
+	struct uet_fi_ep *ep;
+	struct uet_fi_mr *ep_next;
+	uet_mr_handle_t uet_mr;
+	bool enabled;
+};
+
+struct uet_fi_ep {
+	struct fid_ep ep_fid;
+	struct uet_fi_domain *domain;
+	struct fi_info *engine_info;
+	uet_ep_handle_t uet_ep;
+	struct uet_fi_av *av;
+	struct uet_fi_cq *tx_cq;
+	struct uet_fi_cq *rx_cq;
+	struct uet_fi_mr *mrs;
+	bool enabled;
+};
+
+#define UET_FI_CONTAINER(ptr, type, member) \
+	((type *)((char *)(ptr) - offsetof(type, member)))
+
+int uet_fi_engine_load(struct uet_fi_engine *engine);
+void uet_fi_engine_unload(struct uet_fi_engine *engine);
+
+int uet_fi_domain_open(struct fid_fabric *fabric, struct fi_info *info,
+		       struct fid_domain **domain, void *context);
+int uet_fi_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+		   struct fid_eq **eq, void *context);
+int uet_fi_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
+		   struct fid_av **av, void *context);
+int uet_fi_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
+		   struct fid_cq **cq, void *context);
+int uet_fi_endpoint_open(struct fid_domain *domain, struct fi_info *info,
+			 struct fid_ep **ep, void *context);
+
+int uet_fi_mr_reg(struct fid *fid, const void *buf, size_t len,
+		  uint64_t access, uint64_t offset, uint64_t requested_key,
+		  uint64_t flags, struct fid_mr **mr, void *context);
+int uet_fi_mr_regv(struct fid *fid, const struct iovec *iov, size_t count,
+		   uint64_t access, uint64_t offset, uint64_t requested_key,
+		   uint64_t flags, struct fid_mr **mr, void *context);
+int uet_fi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
+		      uint64_t flags, struct fid_mr **mr);
+
+struct uet_fi_av_entry *uet_fi_av_get(struct uet_fi_av *av,
+				      fi_addr_t fi_addr);
+fi_addr_t uet_fi_av_find_src(struct uet_fi_av *av, uint32_t initiator_id);
+
+#endif /* UET_FI_H */

--- a/libfabric-provider/uet_fi.h
+++ b/libfabric-provider/uet_fi.h
@@ -28,6 +28,7 @@
 #define UET_FI_DEFAULT_QUEUE    256
 #define UET_FI_DEFAULT_AV       64
 #define UET_FI_DEFAULT_MR_CNT   256
+#define UET_FI_DEFAULT_EP_CNT   256
 #define UET_FI_IOV_LIMIT        8
 #define UET_FI_MAX_MSG_SIZE     ((size_t)UINT32_MAX - 1)
 

--- a/libfabric-provider/uet_fi.h
+++ b/libfabric-provider/uet_fi.h
@@ -27,6 +27,7 @@
 #define UET_FI_DOMAIN_NAME      "uet"
 #define UET_FI_DEFAULT_QUEUE    256
 #define UET_FI_DEFAULT_AV       64
+#define UET_FI_DEFAULT_MR_CNT   256
 #define UET_FI_IOV_LIMIT        8
 #define UET_FI_MAX_MSG_SIZE     ((size_t)UINT32_MAX - 1)
 

--- a/libfabric-provider/uet_fi_av_mr.c
+++ b/libfabric-provider/uet_fi_av_mr.c
@@ -1,7 +1,6 @@
+// SPDX-License-Identifier: MIT
 /*
  * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
- *
- * SPDX-License-Identifier: MIT
  */
 
 #include <arpa/inet.h>

--- a/libfabric-provider/uet_fi_av_mr.c
+++ b/libfabric-provider/uet_fi_av_mr.c
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <arpa/inet.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rdma/fi_errno.h>
+
+#include "uet_fi.h"
+#include "uet_fi_noop.h"
+
+static int uet_fi_av_grow(struct uet_fi_av *av, size_t needed)
+{
+	struct uet_fi_av_entry **entries;
+	size_t count;
+
+	if (needed <= av->count)
+		return FI_SUCCESS;
+	count = av->count ? av->count : UET_FI_DEFAULT_AV;
+	while (count < needed) {
+		if (count > SIZE_MAX / 2)
+			return -FI_ENOMEM;
+		count *= 2;
+	}
+	entries = realloc(av->entries, count * sizeof(*entries));
+	if (!entries)
+		return -FI_ENOMEM;
+	memset(entries + av->count, 0,
+	       (count - av->count) * sizeof(*entries));
+	av->entries = entries;
+	av->count = count;
+	return FI_SUCCESS;
+}
+
+static int uet_fi_av_close(struct fid *fid)
+{
+	struct uet_fi_av *av;
+	struct uet_fi_engine *engine;
+	size_t i;
+	int rc;
+
+	av = UET_FI_CONTAINER(fid, struct uet_fi_av, av_fid.fid);
+	if (atomic_load_explicit(&av->refs, memory_order_acquire))
+		return -FI_EBUSY;
+	engine = &av->domain->fabric->engine;
+
+	pthread_rwlock_wrlock(&av->lock);
+	pthread_mutex_lock(&av->domain->control_lock);
+	for (i = 0; i < av->count; i++) {
+		if (!av->entries[i])
+			continue;
+		rc = engine->av_remove(av->entries[i]->uet_addr);
+		if (rc) {
+			pthread_mutex_unlock(&av->domain->control_lock);
+			pthread_rwlock_unlock(&av->lock);
+			return rc;
+		}
+		free(av->entries[i]);
+	}
+	pthread_mutex_unlock(&av->domain->control_lock);
+	pthread_rwlock_unlock(&av->lock);
+
+	pthread_rwlock_destroy(&av->lock);
+	free(av->entries);
+	atomic_fetch_sub_explicit(&av->domain->refs, 1, memory_order_release);
+	free(av);
+	return FI_SUCCESS;
+}
+
+static int uet_fi_av_insert(struct fid_av *av_fid, const void *addr,
+			    size_t count, fi_addr_t *fi_addr, uint64_t flags,
+			    void *context)
+{
+	struct uet_fi_av *av;
+	const struct uet_addr *uet_addr = addr;
+	struct uet_fi_av_entry *entry;
+	size_t i, slot;
+	int inserted = 0;
+	int rc = FI_SUCCESS;
+
+	(void)context;
+	if (!addr || !count || !fi_addr || flags)
+		return -FI_EINVAL;
+	av = UET_FI_CONTAINER(av_fid, struct uet_fi_av, av_fid);
+
+	pthread_rwlock_wrlock(&av->lock);
+	pthread_mutex_lock(&av->domain->control_lock);
+	for (i = 0; i < count; i++) {
+		for (slot = 0; slot < av->count && av->entries[slot]; slot++)
+			;
+		if (slot == av->count) {
+			rc = uet_fi_av_grow(av, av->count + 1);
+			if (rc)
+				break;
+		}
+
+		entry = calloc(1, sizeof(*entry));
+		if (!entry) {
+			rc = -FI_ENOMEM;
+			break;
+		}
+		entry->addr = uet_addr[i];
+		rc = av->domain->fabric->engine.av_insert(av->domain->uet_domain,
+							    &entry->addr,
+							    &entry->uet_addr);
+		if (rc) {
+			free(entry);
+			break;
+		}
+		entry->active = true;
+		av->entries[slot] = entry;
+		fi_addr[i] = slot;
+		inserted++;
+	}
+	pthread_mutex_unlock(&av->domain->control_lock);
+	pthread_rwlock_unlock(&av->lock);
+
+	return inserted ? inserted : rc;
+}
+
+static int uet_fi_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
+			    size_t count, uint64_t flags)
+{
+	struct uet_fi_av *av;
+	struct uet_fi_av_entry *entry;
+	size_t i;
+	int rc;
+
+	if (!fi_addr || flags)
+		return -FI_EINVAL;
+	av = UET_FI_CONTAINER(av_fid, struct uet_fi_av, av_fid);
+
+	pthread_rwlock_wrlock(&av->lock);
+	pthread_mutex_lock(&av->domain->control_lock);
+	for (i = 0; i < count; i++) {
+		if (fi_addr[i] >= av->count || !av->entries[fi_addr[i]]) {
+			rc = -FI_EINVAL;
+			goto out;
+		}
+		entry = av->entries[fi_addr[i]];
+		rc = av->domain->fabric->engine.av_remove(entry->uet_addr);
+		if (rc)
+			goto out;
+		av->entries[fi_addr[i]] = NULL;
+		free(entry);
+	}
+	rc = FI_SUCCESS;
+out:
+	pthread_mutex_unlock(&av->domain->control_lock);
+	pthread_rwlock_unlock(&av->lock);
+	return rc;
+}
+
+static int uet_fi_av_lookup(struct fid_av *av_fid, fi_addr_t fi_addr,
+			    void *addr, size_t *addrlen)
+{
+	struct uet_fi_av *av;
+	int rc = FI_SUCCESS;
+
+	if (!addrlen)
+		return -FI_EINVAL;
+	av = UET_FI_CONTAINER(av_fid, struct uet_fi_av, av_fid);
+	pthread_rwlock_rdlock(&av->lock);
+	if (fi_addr >= av->count || !av->entries[fi_addr]) {
+		rc = -FI_EINVAL;
+		goto out;
+	}
+	if (!addr || *addrlen < sizeof(struct uet_addr)) {
+		*addrlen = sizeof(struct uet_addr);
+		rc = -FI_ETOOSMALL;
+		goto out;
+	}
+	memcpy(addr, &av->entries[fi_addr]->addr, sizeof(struct uet_addr));
+	*addrlen = sizeof(struct uet_addr);
+out:
+	pthread_rwlock_unlock(&av->lock);
+	return rc;
+}
+
+static const char *uet_fi_av_straddr(struct fid_av *av_fid, const void *addr,
+				     char *buf, size_t *len)
+{
+	const struct uet_addr *uet_addr = addr;
+	char text[INET6_ADDRSTRLEN];
+	struct in_addr in4;
+	const void *src;
+	size_t needed;
+
+	(void)av_fid;
+	if (!addr || !len)
+		return NULL;
+	if (uet_addr_is_ipv6(uet_addr)) {
+		src = uet_addr->fa.v6;
+		if (!inet_ntop(AF_INET6, src, text, sizeof(text)))
+			return NULL;
+	} else {
+		in4.s_addr = htonl(uet_addr->fa.v4);
+		if (!inet_ntop(AF_INET, &in4, text, sizeof(text)))
+			return NULL;
+	}
+	needed = strlen(text) + 1;
+	if (!buf || *len < needed) {
+		*len = needed;
+		return NULL;
+	}
+	memcpy(buf, text, needed);
+	*len = needed;
+	return buf;
+}
+
+static struct fi_ops uet_fi_av_fid_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = uet_fi_av_close,
+	.bind = uet_fi_no_bind,
+	.control = uet_fi_no_control,
+	.ops_open = uet_fi_no_ops_open,
+	.tostr = uet_fi_no_tostr,
+	.ops_set = uet_fi_no_ops_set,
+};
+
+static struct fi_ops_av uet_fi_av_ops = {
+	.size = sizeof(struct fi_ops_av),
+	.insert = uet_fi_av_insert,
+	.insertsvc = uet_fi_no_av_insertsvc,
+	.insertsym = uet_fi_no_av_insertsym,
+	.remove = uet_fi_av_remove,
+	.lookup = uet_fi_av_lookup,
+	.straddr = uet_fi_av_straddr,
+	.av_set = NULL,
+};
+
+int uet_fi_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
+		   struct fid_av **av_out, void *context)
+{
+	struct uet_fi_domain *domain;
+	struct uet_fi_av *av;
+	size_t count;
+
+	if (!domain_fid || !av_out)
+		return -FI_EINVAL;
+	if (attr && attr->type != FI_AV_UNSPEC && attr->type != FI_AV_TABLE)
+		return -FI_ENOSYS;
+	if (attr && (attr->flags || attr->name || attr->rx_ctx_bits))
+		return -FI_ENOSYS;
+
+	domain = UET_FI_CONTAINER(domain_fid, struct uet_fi_domain, domain_fid);
+	av = calloc(1, sizeof(*av));
+	if (!av)
+		return -FI_ENOMEM;
+	count = attr && attr->count ? attr->count : UET_FI_DEFAULT_AV;
+	av->entries = calloc(count, sizeof(*av->entries));
+	if (!av->entries) {
+		free(av);
+		return -FI_ENOMEM;
+	}
+	if (pthread_rwlock_init(&av->lock, NULL)) {
+		free(av->entries);
+		free(av);
+		return -FI_ENOMEM;
+	}
+
+	av->domain = domain;
+	av->count = count;
+	av->av_fid.fid.fclass = FI_CLASS_AV;
+	av->av_fid.fid.context = context;
+	av->av_fid.fid.ops = &uet_fi_av_fid_ops;
+	av->av_fid.ops = &uet_fi_av_ops;
+	atomic_init(&av->refs, 0);
+	atomic_fetch_add_explicit(&domain->refs, 1, memory_order_release);
+	*av_out = &av->av_fid;
+	return FI_SUCCESS;
+}
+
+/* Caller holds av->lock for reading. */
+struct uet_fi_av_entry *uet_fi_av_get(struct uet_fi_av *av,
+				      fi_addr_t fi_addr)
+{
+	if (!av || fi_addr == FI_ADDR_UNSPEC || fi_addr >= av->count)
+		return NULL;
+	return av->entries[fi_addr];
+}
+
+fi_addr_t uet_fi_av_find_src(struct uet_fi_av *av, uint32_t initiator_id)
+{
+	fi_addr_t found = FI_ADDR_NOTAVAIL;
+	size_t i;
+
+	if (!av)
+		return found;
+	pthread_rwlock_rdlock(&av->lock);
+	for (i = 0; i < av->count; i++) {
+		if (av->entries[i] &&
+		    av->entries[i]->addr.initiator_id == initiator_id) {
+			found = i;
+			break;
+		}
+	}
+	pthread_rwlock_unlock(&av->lock);
+	return found;
+}
+
+static void uet_fi_mr_unlink(struct uet_fi_mr *mr)
+{
+	struct uet_fi_mr **link;
+
+	if (!mr->ep)
+		return;
+	for (link = &mr->ep->mrs; *link; link = &(*link)->ep_next) {
+		if (*link == mr) {
+			*link = mr->ep_next;
+			break;
+		}
+	}
+	mr->ep = NULL;
+	mr->ep_next = NULL;
+}
+
+static int uet_fi_mr_close(struct fid *fid)
+{
+	struct uet_fi_mr *mr;
+	struct uet_fi_engine *engine;
+	int rc;
+
+	mr = UET_FI_CONTAINER(fid, struct uet_fi_mr, mr_fid.fid);
+	engine = &mr->domain->fabric->engine;
+	pthread_mutex_lock(&mr->domain->control_lock);
+	if (mr->enabled) {
+		rc = engine->mr_disable(mr->uet_mr);
+		if (rc)
+			goto out;
+		mr->enabled = false;
+	}
+	rc = engine->mr_close(mr->uet_mr);
+	if (rc)
+		goto out;
+	uet_fi_mr_unlink(mr);
+	pthread_mutex_unlock(&mr->domain->control_lock);
+	atomic_fetch_sub_explicit(&mr->domain->refs, 1, memory_order_release);
+	free(mr);
+	return FI_SUCCESS;
+out:
+	pthread_mutex_unlock(&mr->domain->control_lock);
+	return rc;
+}
+
+static int uet_fi_mr_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
+{
+	struct uet_fi_mr *mr;
+	struct uet_fi_ep *ep;
+	int rc;
+
+	if (!bfid || bfid->fclass != FI_CLASS_EP)
+		return -FI_EINVAL;
+	mr = UET_FI_CONTAINER(fid, struct uet_fi_mr, mr_fid.fid);
+	ep = UET_FI_CONTAINER(bfid, struct uet_fi_ep, ep_fid.fid);
+	if (ep->domain != mr->domain || mr->ep)
+		return -FI_EINVAL;
+
+	pthread_mutex_lock(&mr->domain->control_lock);
+	rc = mr->domain->fabric->engine.ep_bind_mr(ep->uet_ep, mr->uet_mr,
+						     flags);
+	if (!rc) {
+		mr->ep = ep;
+		mr->ep_next = ep->mrs;
+		ep->mrs = mr;
+	}
+	pthread_mutex_unlock(&mr->domain->control_lock);
+	return rc;
+}
+
+static int uet_fi_mr_control(struct fid *fid, int command, void *arg)
+{
+	struct uet_fi_mr *mr;
+	int rc;
+
+	(void)arg;
+	if (command != FI_ENABLE)
+		return -FI_ENOSYS;
+	mr = UET_FI_CONTAINER(fid, struct uet_fi_mr, mr_fid.fid);
+	if (!mr->ep || mr->enabled)
+		return -FI_EINVAL;
+
+	pthread_mutex_lock(&mr->domain->control_lock);
+	rc = mr->domain->fabric->engine.mr_enable(mr->uet_mr);
+	if (!rc)
+		mr->enabled = true;
+	pthread_mutex_unlock(&mr->domain->control_lock);
+	return rc;
+}
+
+static struct fi_ops uet_fi_mr_fid_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = uet_fi_mr_close,
+	.bind = uet_fi_mr_bind,
+	.control = uet_fi_mr_control,
+	.ops_open = uet_fi_no_ops_open,
+	.tostr = uet_fi_no_tostr,
+	.ops_set = uet_fi_no_ops_set,
+};
+
+static int uet_fi_mr_finish(struct uet_fi_domain *domain,
+			    uet_mr_handle_t uet_mr, void *context,
+			    struct fid_mr **mr_out)
+{
+	struct uet_fi_mr *mr;
+
+	mr = calloc(1, sizeof(*mr));
+	if (!mr) {
+		domain->fabric->engine.mr_close(uet_mr);
+		return -FI_ENOMEM;
+	}
+	mr->domain = domain;
+	mr->uet_mr = uet_mr;
+	mr->mr_fid.fid.fclass = FI_CLASS_MR;
+	mr->mr_fid.fid.context = context;
+	mr->mr_fid.fid.ops = &uet_fi_mr_fid_ops;
+	mr->mr_fid.mem_desc = uet_mr;
+	mr->mr_fid.key = domain->fabric->engine.mr_key(uet_mr);
+	atomic_fetch_add_explicit(&domain->refs, 1, memory_order_release);
+	*mr_out = &mr->mr_fid;
+	return FI_SUCCESS;
+}
+
+int uet_fi_mr_reg(struct fid *fid, const void *buf, size_t len,
+		  uint64_t access, uint64_t offset, uint64_t requested_key,
+		  uint64_t flags, struct fid_mr **mr_out, void *context)
+{
+	struct uet_fi_domain *domain;
+	uet_mr_handle_t uet_mr;
+	int rc;
+
+	if (!fid || fid->fclass != FI_CLASS_DOMAIN || !buf || !len || !mr_out ||
+	    offset || flags)
+		return -FI_EINVAL;
+	domain = UET_FI_CONTAINER(fid, struct uet_fi_domain, domain_fid.fid);
+	pthread_mutex_lock(&domain->control_lock);
+	rc = domain->fabric->engine.mr_reg(domain->uet_domain, buf, len, access,
+					   requested_key, UET_FLAGS_NONE,
+					   context, &uet_mr);
+	if (!rc)
+		rc = uet_fi_mr_finish(domain, uet_mr, context, mr_out);
+	pthread_mutex_unlock(&domain->control_lock);
+	return rc;
+}
+
+int uet_fi_mr_regv(struct fid *fid, const struct iovec *iov, size_t count,
+		   uint64_t access, uint64_t offset, uint64_t requested_key,
+		   uint64_t flags, struct fid_mr **mr_out, void *context)
+{
+	struct uet_fi_domain *domain;
+	uet_mr_handle_t uet_mr;
+	int rc;
+
+	if (!fid || fid->fclass != FI_CLASS_DOMAIN || !iov || !count || !mr_out ||
+	    count > UET_FI_IOV_LIMIT || offset || flags)
+		return -FI_EINVAL;
+	domain = UET_FI_CONTAINER(fid, struct uet_fi_domain, domain_fid.fid);
+	pthread_mutex_lock(&domain->control_lock);
+	rc = domain->fabric->engine.mr_regv(domain->uet_domain, iov, count,
+					    access, requested_key, UET_FLAGS_NONE,
+					    context, &uet_mr);
+	if (!rc)
+		rc = uet_fi_mr_finish(domain, uet_mr, context, mr_out);
+	pthread_mutex_unlock(&domain->control_lock);
+	return rc;
+}
+
+int uet_fi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
+		      uint64_t flags, struct fid_mr **mr_out)
+{
+	if (!attr || attr->iface != FI_HMEM_SYSTEM || attr->auth_key_size)
+		return -FI_ENOSYS;
+	return uet_fi_mr_regv(fid, attr->mr_iov, attr->iov_count, attr->access,
+			      attr->offset, attr->requested_key, flags, mr_out,
+			      attr->context);
+}

--- a/libfabric-provider/uet_fi_cq.c
+++ b/libfabric-provider/uet_fi_cq.c
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <sched.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <rdma/fi_errno.h>
+
+#include "uet_fi.h"
+#include "uet_fi_noop.h"
+
+static size_t uet_fi_cq_entry_size(enum fi_cq_format format)
+{
+	switch (format) {
+	case FI_CQ_FORMAT_CONTEXT:
+	case FI_CQ_FORMAT_UNSPEC:
+		return sizeof(struct fi_cq_entry);
+	case FI_CQ_FORMAT_MSG:
+		return sizeof(struct fi_cq_msg_entry);
+	case FI_CQ_FORMAT_DATA:
+		return sizeof(struct fi_cq_data_entry);
+	case FI_CQ_FORMAT_TAGGED:
+		return sizeof(struct fi_cq_tagged_entry);
+	default:
+		return 0;
+	}
+}
+
+static int uet_fi_cq_close(struct fid *fid)
+{
+	struct uet_fi_cq *cq;
+
+	cq = UET_FI_CONTAINER(fid, struct uet_fi_cq, cq_fid.fid);
+	if (atomic_load_explicit(&cq->refs, memory_order_acquire))
+		return -FI_EBUSY;
+	pthread_mutex_destroy(&cq->lock);
+	atomic_fetch_sub_explicit(&cq->domain->refs, 1, memory_order_release);
+	free(cq);
+	return FI_SUCCESS;
+}
+
+static ssize_t uet_fi_cq_read_handle(struct uet_fi_cq *cq,
+				     uet_cq_handle_t handle, void *buf,
+				     size_t count)
+{
+	ssize_t rc;
+
+	if (!handle)
+		return -FI_EAGAIN;
+	rc = cq->domain->fabric->engine.cq_read(handle, buf, count);
+	return rc ? rc : -FI_EAGAIN;
+}
+
+static ssize_t uet_fi_cq_read_internal(struct uet_fi_cq *cq, void *buf,
+				       size_t count, bool *is_rx,
+				       uet_cq_handle_t *used)
+{
+	uet_cq_handle_t first, second;
+	bool first_rx;
+	ssize_t rc;
+
+	if (!count)
+		return -FI_EINVAL;
+	if (cq->tx_cq && cq->rx_cq) {
+		first_rx = cq->read_rx_next;
+		first = first_rx ? cq->rx_cq : cq->tx_cq;
+		second = first_rx ? cq->tx_cq : cq->rx_cq;
+		cq->read_rx_next = !cq->read_rx_next;
+	} else {
+		first = cq->rx_cq ? cq->rx_cq : cq->tx_cq;
+		second = NULL;
+		first_rx = !!cq->rx_cq;
+	}
+
+	rc = uet_fi_cq_read_handle(cq, first, buf, count);
+	if (rc != -FI_EAGAIN) {
+		if (is_rx)
+			*is_rx = first_rx;
+		if (used)
+			*used = first;
+		return rc;
+	}
+	if (!second)
+		return rc;
+	rc = uet_fi_cq_read_handle(cq, second, buf, count);
+	if (rc != -FI_EAGAIN) {
+		if (is_rx)
+			*is_rx = !first_rx;
+		if (used)
+			*used = second;
+	}
+	return rc;
+}
+
+static ssize_t uet_fi_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
+{
+	struct uet_fi_cq *cq;
+
+	if (!buf)
+		return -FI_EINVAL;
+	cq = UET_FI_CONTAINER(cq_fid, struct uet_fi_cq, cq_fid);
+	pthread_mutex_lock(&cq->lock);
+	ssize_t rc = uet_fi_cq_read_internal(cq, buf, count, NULL, NULL);
+	pthread_mutex_unlock(&cq->lock);
+	return rc;
+}
+
+static ssize_t uet_fi_cq_readfrom(struct fid_cq *cq_fid, void *buf,
+				  size_t count, fi_addr_t *src_addr)
+{
+	struct uet_fi_cq *cq;
+	uet_cq_handle_t used;
+	size_t entry_size;
+	ssize_t done = 0;
+	ssize_t rc;
+	bool is_rx;
+
+	if (!buf || !src_addr || !count)
+		return -FI_EINVAL;
+	cq = UET_FI_CONTAINER(cq_fid, struct uet_fi_cq, cq_fid);
+	entry_size = uet_fi_cq_entry_size(cq->attr.format);
+	pthread_mutex_lock(&cq->lock);
+	while ((size_t)done < count) {
+		rc = uet_fi_cq_read_internal(cq, (char *)buf + done * entry_size,
+					     1, &is_rx, &used);
+		if (rc < 0) {
+			rc = done ? done : rc;
+			goto out;
+		}
+		if (is_rx && cq->ep && cq->ep->av)
+			src_addr[done] = uet_fi_av_find_src(
+				cq->ep->av,
+				cq->domain->fabric->engine.cq_read_src_id(used));
+		else
+			src_addr[done] = FI_ADDR_NOTAVAIL;
+		done++;
+	}
+	rc = done;
+out:
+	pthread_mutex_unlock(&cq->lock);
+	return rc;
+}
+
+static ssize_t uet_fi_cq_readerr(struct fid_cq *cq_fid,
+				 struct fi_cq_err_entry *buf, uint64_t flags)
+{
+	struct uet_fi_cq *cq;
+	ssize_t rc;
+
+	if (!buf || flags)
+		return -FI_EINVAL;
+	cq = UET_FI_CONTAINER(cq_fid, struct uet_fi_cq, cq_fid);
+	pthread_mutex_lock(&cq->lock);
+	if (cq->tx_cq) {
+		rc = cq->domain->fabric->engine.cq_readerr(cq->tx_cq, buf);
+		if (rc != -FI_EAGAIN)
+			goto out;
+	}
+	if (cq->rx_cq)
+		rc = cq->domain->fabric->engine.cq_readerr(cq->rx_cq, buf);
+	else
+		rc = -FI_EAGAIN;
+out:
+	pthread_mutex_unlock(&cq->lock);
+	return rc;
+}
+
+static uint64_t uet_fi_monotonic_ms(void)
+{
+	struct timespec ts;
+
+	if (clock_gettime(CLOCK_MONOTONIC, &ts))
+		return 0;
+	return (uint64_t)ts.tv_sec * 1000 + (uint64_t)ts.tv_nsec / 1000000;
+}
+
+static ssize_t uet_fi_cq_sread_common(struct fid_cq *cq_fid, void *buf,
+				      size_t count, fi_addr_t *src_addr,
+				      const void *cond, int timeout)
+{
+	const size_t *threshold_ptr = cond;
+	struct uet_fi_cq *cq;
+	struct timespec pause = { .tv_sec = 0, .tv_nsec = 50000 };
+	uint64_t deadline = 0;
+	size_t threshold = 1;
+	ssize_t rc;
+
+	cq = UET_FI_CONTAINER(cq_fid, struct uet_fi_cq, cq_fid);
+	if (cq->attr.wait_cond == FI_CQ_COND_THRESHOLD && threshold_ptr)
+		threshold = *threshold_ptr;
+	if (!threshold || threshold > count)
+		return -FI_EINVAL;
+	if (timeout >= 0)
+		deadline = uet_fi_monotonic_ms() + (uint64_t)timeout;
+
+	for (;;) {
+		rc = src_addr ? uet_fi_cq_readfrom(cq_fid, buf, count, src_addr) :
+				uet_fi_cq_read(cq_fid, buf, count);
+		if (rc >= (ssize_t)threshold || rc == -FI_EAVAIL)
+			return rc;
+		if (rc > 0)
+			return rc;
+		if (rc != -FI_EAGAIN)
+			return rc;
+		if (!timeout || (timeout > 0 &&
+		    uet_fi_monotonic_ms() >= deadline))
+			return -FI_EAGAIN;
+		nanosleep(&pause, NULL);
+	}
+}
+
+static ssize_t uet_fi_cq_sread(struct fid_cq *cq, void *buf, size_t count,
+			       const void *cond, int timeout)
+{
+	return uet_fi_cq_sread_common(cq, buf, count, NULL, cond, timeout);
+}
+
+static ssize_t uet_fi_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
+				   fi_addr_t *src_addr, const void *cond,
+				   int timeout)
+{
+	return uet_fi_cq_sread_common(cq, buf, count, src_addr, cond, timeout);
+}
+
+static const char *uet_fi_cq_strerror(struct fid_cq *cq, int prov_errno,
+				      const void *err_data, char *buf,
+				      size_t len)
+{
+	const char *text = fi_strerror(prov_errno);
+
+	(void)cq;
+	(void)err_data;
+	if (buf && len) {
+		strncpy(buf, text, len - 1);
+		buf[len - 1] = '\0';
+		return buf;
+	}
+	return text;
+}
+
+static struct fi_ops uet_fi_cq_fid_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = uet_fi_cq_close,
+	.bind = uet_fi_no_bind,
+	.control = uet_fi_no_control,
+	.ops_open = uet_fi_no_ops_open,
+	.tostr = uet_fi_no_tostr,
+	.ops_set = uet_fi_no_ops_set,
+};
+
+static struct fi_ops_cq uet_fi_cq_ops = {
+	.size = sizeof(struct fi_ops_cq),
+	.read = uet_fi_cq_read,
+	.readfrom = uet_fi_cq_readfrom,
+	.readerr = uet_fi_cq_readerr,
+	.sread = uet_fi_cq_sread,
+	.sreadfrom = uet_fi_cq_sreadfrom,
+	.signal = uet_fi_no_cq_signal,
+	.strerror = uet_fi_cq_strerror,
+};
+
+int uet_fi_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
+		   struct fid_cq **cq_out, void *context)
+{
+	struct uet_fi_domain *domain;
+	struct uet_fi_cq *cq;
+
+	if (!domain_fid || !attr || !cq_out ||
+	    !uet_fi_cq_entry_size(attr->format))
+		return -FI_EINVAL;
+	if (attr->wait_obj != FI_WAIT_NONE && attr->wait_obj != FI_WAIT_UNSPEC)
+		return -FI_ENOSYS;
+	if (attr->flags || attr->wait_set)
+		return -FI_ENOSYS;
+
+	domain = UET_FI_CONTAINER(domain_fid, struct uet_fi_domain, domain_fid);
+	cq = calloc(1, sizeof(*cq));
+	if (!cq)
+		return -FI_ENOMEM;
+	if (pthread_mutex_init(&cq->lock, NULL)) {
+		free(cq);
+		return -FI_ENOMEM;
+	}
+	cq->domain = domain;
+	cq->attr = *attr;
+	if (!cq->attr.size)
+		cq->attr.size = UET_FI_DEFAULT_QUEUE;
+	if (cq->attr.format == FI_CQ_FORMAT_UNSPEC)
+		cq->attr.format = FI_CQ_FORMAT_CONTEXT;
+	cq->cq_fid.fid.fclass = FI_CLASS_CQ;
+	cq->cq_fid.fid.context = context;
+	cq->cq_fid.fid.ops = &uet_fi_cq_fid_ops;
+	cq->cq_fid.ops = &uet_fi_cq_ops;
+	atomic_init(&cq->refs, 0);
+	atomic_fetch_add_explicit(&domain->refs, 1, memory_order_release);
+	*cq_out = &cq->cq_fid;
+	return FI_SUCCESS;
+}

--- a/libfabric-provider/uet_fi_cq.c
+++ b/libfabric-provider/uet_fi_cq.c
@@ -1,7 +1,6 @@
+// SPDX-License-Identifier: MIT
 /*
  * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
- *
- * SPDX-License-Identifier: MIT
  */
 
 #include <sched.h>
@@ -100,12 +99,13 @@ static ssize_t uet_fi_cq_read_internal(struct uet_fi_cq *cq, void *buf,
 static ssize_t uet_fi_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 {
 	struct uet_fi_cq *cq;
+	ssize_t rc;
 
 	if (!buf)
 		return -FI_EINVAL;
 	cq = UET_FI_CONTAINER(cq_fid, struct uet_fi_cq, cq_fid);
 	pthread_mutex_lock(&cq->lock);
-	ssize_t rc = uet_fi_cq_read_internal(cq, buf, count, NULL, NULL);
+	rc = uet_fi_cq_read_internal(cq, buf, count, NULL, NULL);
 	pthread_mutex_unlock(&cq->lock);
 	return rc;
 }
@@ -232,12 +232,14 @@ static const char *uet_fi_cq_strerror(struct fid_cq *cq, int prov_errno,
 				      size_t len)
 {
 	const char *text = fi_strerror(prov_errno);
+	size_t copy_len;
 
 	(void)cq;
 	(void)err_data;
 	if (buf && len) {
-		strncpy(buf, text, len - 1);
-		buf[len - 1] = '\0';
+		copy_len = strnlen(text, len - 1);
+		memcpy(buf, text, copy_len);
+		buf[copy_len] = '\0';
 		return buf;
 	}
 	return text;

--- a/libfabric-provider/uet_fi_domain.c
+++ b/libfabric-provider/uet_fi_domain.c
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdlib.h>
+
+#include <rdma/fi_errno.h>
+
+#include "uet_fi.h"
+#include "uet_fi_noop.h"
+
+static int uet_fi_domain_close(struct fid *fid)
+{
+	struct uet_fi_domain *domain;
+	int rc;
+
+	domain = UET_FI_CONTAINER(fid, struct uet_fi_domain, domain_fid.fid);
+	if (atomic_load_explicit(&domain->refs, memory_order_acquire))
+		return -FI_EBUSY;
+
+	rc = domain->fabric->engine.domain_close(domain->uet_domain);
+	if (rc)
+		return rc;
+
+	fi_freeinfo(domain->engine_info);
+	pthread_mutex_destroy(&domain->control_lock);
+	atomic_store_explicit(&domain->fabric->domain_open, false,
+			      memory_order_release);
+	atomic_fetch_sub_explicit(&domain->fabric->refs, 1, memory_order_release);
+	free(domain);
+	return FI_SUCCESS;
+}
+
+static struct fi_ops uet_fi_domain_fid_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = uet_fi_domain_close,
+	.bind = uet_fi_no_bind,
+	.control = uet_fi_no_control,
+	.ops_open = uet_fi_no_ops_open,
+	.tostr = uet_fi_no_tostr,
+	.ops_set = uet_fi_no_ops_set,
+};
+
+static struct fi_ops_domain uet_fi_domain_ops = {
+	.size = sizeof(struct fi_ops_domain),
+	.av_open = uet_fi_av_open,
+	.cq_open = uet_fi_cq_open,
+	.endpoint = uet_fi_endpoint_open,
+	.scalable_ep = uet_fi_no_scalable_ep,
+	.cntr_open = uet_fi_no_cntr_open,
+	.poll_open = uet_fi_no_poll_open,
+	.stx_ctx = uet_fi_no_stx_context,
+	.srx_ctx = uet_fi_no_srx_context,
+	.query_atomic = uet_fi_no_query_atomic,
+	.query_collective = uet_fi_no_query_collective,
+	.endpoint2 = uet_fi_no_endpoint2,
+};
+
+static struct fi_ops_mr uet_fi_mr_ops = {
+	.size = sizeof(struct fi_ops_mr),
+	.reg = uet_fi_mr_reg,
+	.regv = uet_fi_mr_regv,
+	.regattr = uet_fi_mr_regattr,
+};
+
+static void uet_fi_merge_engine_info(struct fi_info *engine_info,
+				     const struct fi_info *requested)
+{
+	engine_info->caps = requested->caps;
+	engine_info->mode = requested->mode;
+	engine_info->addr_format = FI_FORMAT_UNSPEC;
+
+	engine_info->tx_attr->caps = requested->tx_attr->caps;
+	engine_info->tx_attr->mode = requested->tx_attr->mode;
+	engine_info->tx_attr->op_flags = requested->tx_attr->op_flags;
+	engine_info->tx_attr->msg_order = requested->tx_attr->msg_order;
+	engine_info->tx_attr->size = requested->tx_attr->size ?
+		requested->tx_attr->size : UET_FI_DEFAULT_QUEUE;
+	engine_info->tx_attr->iov_limit = UET_FI_IOV_LIMIT;
+	engine_info->tx_attr->rma_iov_limit = UET_FI_IOV_LIMIT;
+	engine_info->tx_attr->tclass = requested->tx_attr->tclass;
+
+	engine_info->rx_attr->caps = requested->rx_attr->caps;
+	engine_info->rx_attr->mode = requested->rx_attr->mode;
+	engine_info->rx_attr->op_flags = requested->rx_attr->op_flags;
+	engine_info->rx_attr->msg_order = requested->rx_attr->msg_order;
+	engine_info->rx_attr->size = requested->rx_attr->size ?
+		requested->rx_attr->size : UET_FI_DEFAULT_QUEUE;
+	engine_info->rx_attr->iov_limit = UET_FI_IOV_LIMIT;
+
+	engine_info->ep_attr->type = FI_EP_RDM;
+	engine_info->ep_attr->max_msg_size = UET_FI_MAX_MSG_SIZE;
+	engine_info->ep_attr->mem_tag_format = UINT64_MAX;
+	engine_info->ep_attr->tx_ctx_cnt = 1;
+	engine_info->ep_attr->rx_ctx_cnt = 1;
+
+	engine_info->domain_attr->threading = FI_THREAD_SAFE;
+	engine_info->domain_attr->control_progress = FI_PROGRESS_MANUAL;
+	engine_info->domain_attr->data_progress = FI_PROGRESS_MANUAL;
+	engine_info->domain_attr->resource_mgmt = FI_RM_ENABLED;
+	engine_info->domain_attr->av_type = FI_AV_TABLE;
+	engine_info->domain_attr->mr_mode = FI_MR_ENDPOINT | FI_MR_PROV_KEY;
+	engine_info->domain_attr->mr_key_size = sizeof(uint64_t);
+	engine_info->domain_attr->mr_iov_limit = UET_FI_IOV_LIMIT;
+	engine_info->domain_attr->mr_cnt = requested->domain_attr->mr_cnt ?
+		requested->domain_attr->mr_cnt : UET_DEF_MR_CNT;
+}
+
+int uet_fi_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
+		       struct fid_domain **domain_out, void *context)
+{
+	struct uet_fi_fabric *fabric;
+	struct uet_fi_domain *domain;
+	struct uet_addr *family = NULL;
+	bool expected = false;
+	int rc;
+
+	if (!fabric_fid || !info || !domain_out)
+		return -FI_EINVAL;
+	if (!info->ep_attr || info->ep_attr->type != FI_EP_RDM)
+		return -FI_ENODATA;
+	if (!info->domain_attr ||
+	    !(info->domain_attr->mr_mode & FI_MR_ENDPOINT))
+		return -FI_ENODATA;
+
+	fabric = UET_FI_CONTAINER(fabric_fid, struct uet_fi_fabric, fabric_fid);
+	/* The current engine owns one PDS instance and finalizes it with the
+	 * domain. Keep that engine constraint explicit at the provider boundary.
+	 */
+	if (!atomic_compare_exchange_strong_explicit(
+		    &fabric->domain_open, &expected, true, memory_order_acq_rel,
+		    memory_order_acquire))
+		return -FI_EBUSY;
+	atomic_fetch_add_explicit(&fabric->refs, 1, memory_order_release);
+
+	domain = calloc(1, sizeof(*domain));
+	if (!domain) {
+		rc = -FI_ENOMEM;
+		goto err_ref;
+	}
+	domain->fabric = fabric;
+	atomic_init(&domain->refs, 0);
+	if (pthread_mutex_init(&domain->control_lock, NULL)) {
+		rc = -FI_ENOMEM;
+		goto err_free;
+	}
+
+	domain->domain_fid.fid.fclass = FI_CLASS_DOMAIN;
+	domain->domain_fid.fid.context = context;
+	domain->domain_fid.fid.ops = &uet_fi_domain_fid_ops;
+	domain->domain_fid.ops = &uet_fi_domain_ops;
+	domain->domain_fid.mr = &uet_fi_mr_ops;
+
+	if (info->src_addr && info->src_addrlen == sizeof(struct uet_addr))
+		family = info->src_addr;
+	rc = fabric->engine.getinfo(fabric->uet, family, NULL,
+				    &domain->engine_info);
+	if (rc)
+		goto err_mutex;
+	uet_fi_merge_engine_info(domain->engine_info, info);
+
+	rc = fabric->engine.domain(fabric->uet, fabric_fid,
+				   domain->engine_info, &domain->domain_fid,
+				   context, NULL, NULL, &domain->uet_domain);
+	if (rc)
+		goto err_info;
+
+	*domain_out = &domain->domain_fid;
+	return FI_SUCCESS;
+
+err_info:
+	fi_freeinfo(domain->engine_info);
+err_mutex:
+	pthread_mutex_destroy(&domain->control_lock);
+err_free:
+	free(domain);
+err_ref:
+	atomic_fetch_sub_explicit(&fabric->refs, 1, memory_order_release);
+	atomic_store_explicit(&fabric->domain_open, false, memory_order_release);
+	return rc;
+}

--- a/libfabric-provider/uet_fi_domain.c
+++ b/libfabric-provider/uet_fi_domain.c
@@ -1,7 +1,6 @@
+// SPDX-License-Identifier: MIT
 /*
  * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
- *
- * SPDX-License-Identifier: MIT
  */
 
 #include <stdlib.h>

--- a/libfabric-provider/uet_fi_domain.c
+++ b/libfabric-provider/uet_fi_domain.c
@@ -105,7 +105,7 @@ static void uet_fi_merge_engine_info(struct fi_info *engine_info,
 	engine_info->domain_attr->mr_key_size = sizeof(uint64_t);
 	engine_info->domain_attr->mr_iov_limit = UET_FI_IOV_LIMIT;
 	engine_info->domain_attr->mr_cnt = requested->domain_attr->mr_cnt ?
-		requested->domain_attr->mr_cnt : UET_DEF_MR_CNT;
+		requested->domain_attr->mr_cnt : UET_FI_DEFAULT_MR_CNT;
 }
 
 int uet_fi_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,

--- a/libfabric-provider/uet_fi_engine.c
+++ b/libfabric-provider/uet_fi_engine.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rdma/fi_errno.h>
+
+#include "uet_fi.h"
+
+static const char *uet_fi_engine_library(void)
+{
+	const char *backend;
+	const char *override;
+
+	override = getenv("UET_ENGINE_LIBRARY");
+	if (override && override[0])
+		return override;
+
+	backend = getenv("UET_NIC_SHIM");
+	if (!backend || !backend[0] || !strcmp(backend, "rawsock"))
+		return "libuet_fabric.so";
+
+	if (!strcmp(backend, "xdp") || !strcmp(backend, "af_xdp")) {
+		return "libxdpuet.so";
+	}
+
+	return NULL;
+}
+
+#define UET_FI_LOAD_SYM(engine, field, symbol)                             \
+	do {                                                               \
+		*(void **)(&(engine)->field) = dlsym((engine)->dl_handle, symbol); \
+		if (!(engine)->field)                                           \
+			goto missing_symbol;                                      \
+	} while (0)
+
+int uet_fi_engine_load(struct uet_fi_engine *engine)
+{
+	const char *library;
+
+	library = uet_fi_engine_library();
+	if (!library) {
+		fprintf(stderr, "uet provider: invalid UET_NIC_SHIM\n");
+		return -FI_EINVAL;
+	}
+
+	memset(engine, 0, sizeof(*engine));
+	engine->name = library;
+	engine->dl_handle = dlopen(library, RTLD_NOW | RTLD_LOCAL);
+	if (!engine->dl_handle) {
+		fprintf(stderr, "uet provider: cannot load %s: %s\n",
+			library, dlerror());
+		return -FI_ENODATA;
+	}
+
+	UET_FI_LOAD_SYM(engine, initialize, "uet_initialize");
+	UET_FI_LOAD_SYM(engine, finalize, "uet_finalize");
+	UET_FI_LOAD_SYM(engine, getinfo, "uet_getinfo");
+	UET_FI_LOAD_SYM(engine, domain, "uet_domain");
+	UET_FI_LOAD_SYM(engine, domain_close, "uet_domain_close");
+	UET_FI_LOAD_SYM(engine, endpoint, "uet_endpoint");
+	UET_FI_LOAD_SYM(engine, getname, "uet_getname");
+	UET_FI_LOAD_SYM(engine, ep_bind_cq, "uet_ep_bind_cq");
+	UET_FI_LOAD_SYM(engine, ep_bind_mr, "uet_ep_bind_mr");
+	UET_FI_LOAD_SYM(engine, ep_enable, "uet_ep_enable");
+	UET_FI_LOAD_SYM(engine, ep_control, "uet_ep_control");
+	UET_FI_LOAD_SYM(engine, ep_setopt, "uet_ep_setopt");
+	UET_FI_LOAD_SYM(engine, ep_close, "uet_ep_close");
+	UET_FI_LOAD_SYM(engine, cancel, "uet_cancel");
+
+	UET_FI_LOAD_SYM(engine, cq_read, "uet_cq_read");
+	UET_FI_LOAD_SYM(engine, cq_read_src_id, "uet_cq_read_src_id");
+	UET_FI_LOAD_SYM(engine, cq_readerr, "uet_cq_readerr");
+	UET_FI_LOAD_SYM(engine, cq_close, "uet_cq_close");
+
+	UET_FI_LOAD_SYM(engine, av_insert, "uet_av_insert");
+	UET_FI_LOAD_SYM(engine, av_remove, "uet_av_remove");
+
+	UET_FI_LOAD_SYM(engine, mr_reg, "uet_mr_reg");
+	UET_FI_LOAD_SYM(engine, mr_regv, "uet_mr_regv");
+	UET_FI_LOAD_SYM(engine, mr_key, "uet_mr_key");
+	UET_FI_LOAD_SYM(engine, mr_enable, "uet_mr_enable");
+	UET_FI_LOAD_SYM(engine, mr_disable, "uet_mr_disable");
+	UET_FI_LOAD_SYM(engine, mr_close, "uet_mr_close");
+
+	UET_FI_LOAD_SYM(engine, send, "uet_send");
+	UET_FI_LOAD_SYM(engine, sendv, "uet_sendv");
+	UET_FI_LOAD_SYM(engine, recv, "uet_recv");
+	UET_FI_LOAD_SYM(engine, recvv, "uet_recvv");
+	UET_FI_LOAD_SYM(engine, tsend, "uet_tsend");
+	UET_FI_LOAD_SYM(engine, tsendv, "uet_tsendv");
+	UET_FI_LOAD_SYM(engine, trecv, "uet_trecv");
+	UET_FI_LOAD_SYM(engine, trecvv, "uet_trecvv");
+
+	return FI_SUCCESS;
+
+missing_symbol:
+	fprintf(stderr, "uet provider: %s is missing symbol: %s\n",
+		library, dlerror());
+	uet_fi_engine_unload(engine);
+	return -FI_ENOSYS;
+}
+
+void uet_fi_engine_unload(struct uet_fi_engine *engine)
+{
+	if (engine->dl_handle)
+		dlclose(engine->dl_handle);
+	memset(engine, 0, sizeof(*engine));
+}

--- a/libfabric-provider/uet_fi_engine.c
+++ b/libfabric-provider/uet_fi_engine.c
@@ -1,7 +1,6 @@
+// SPDX-License-Identifier: MIT
 /*
  * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
- *
- * SPDX-License-Identifier: MIT
  */
 
 #include <dlfcn.h>
@@ -26,19 +25,30 @@ static const char *uet_fi_engine_library(void)
 	if (!backend || !backend[0] || !strcmp(backend, "rawsock"))
 		return "libuet_fabric.so";
 
-	if (!strcmp(backend, "xdp") || !strcmp(backend, "af_xdp")) {
+	if (!strcmp(backend, "xdp") || !strcmp(backend, "af_xdp"))
 		return "libxdpuet.so";
-	}
 
 	return NULL;
 }
 
-#define UET_FI_LOAD_SYM(engine, field, symbol)                             \
-	do {                                                               \
-		*(void **)(&(engine)->field) = dlsym((engine)->dl_handle, symbol); \
-		if (!(engine)->field)                                           \
-			goto missing_symbol;                                      \
-	} while (0)
+static int uet_fi_engine_load_symbol(struct uet_fi_engine *engine,
+				     void **target, const char *name)
+{
+	const char *error;
+
+	dlerror();
+	*target = dlsym(engine->dl_handle, name);
+	error = dlerror();
+	if (!error)
+		return FI_SUCCESS;
+
+	fprintf(stderr, "uet provider: %s is missing %s: %s\n",
+		engine->name, name, error);
+	return -FI_ENOSYS;
+}
+
+#define UET_FI_LOAD_SYM(engine, field, symbol) \
+	uet_fi_engine_load_symbol((engine), (void **)&(engine)->field, symbol)
 
 int uet_fi_engine_load(struct uet_fi_engine *engine)
 {
@@ -59,50 +69,45 @@ int uet_fi_engine_load(struct uet_fi_engine *engine)
 		return -FI_ENODATA;
 	}
 
-	UET_FI_LOAD_SYM(engine, initialize, "uet_initialize");
-	UET_FI_LOAD_SYM(engine, finalize, "uet_finalize");
-	UET_FI_LOAD_SYM(engine, getinfo, "uet_getinfo");
-	UET_FI_LOAD_SYM(engine, domain, "uet_domain");
-	UET_FI_LOAD_SYM(engine, domain_close, "uet_domain_close");
-	UET_FI_LOAD_SYM(engine, endpoint, "uet_endpoint");
-	UET_FI_LOAD_SYM(engine, getname, "uet_getname");
-	UET_FI_LOAD_SYM(engine, ep_bind_cq, "uet_ep_bind_cq");
-	UET_FI_LOAD_SYM(engine, ep_bind_mr, "uet_ep_bind_mr");
-	UET_FI_LOAD_SYM(engine, ep_enable, "uet_ep_enable");
-	UET_FI_LOAD_SYM(engine, ep_control, "uet_ep_control");
-	UET_FI_LOAD_SYM(engine, ep_setopt, "uet_ep_setopt");
-	UET_FI_LOAD_SYM(engine, ep_close, "uet_ep_close");
-	UET_FI_LOAD_SYM(engine, cancel, "uet_cancel");
-
-	UET_FI_LOAD_SYM(engine, cq_read, "uet_cq_read");
-	UET_FI_LOAD_SYM(engine, cq_read_src_id, "uet_cq_read_src_id");
-	UET_FI_LOAD_SYM(engine, cq_readerr, "uet_cq_readerr");
-	UET_FI_LOAD_SYM(engine, cq_close, "uet_cq_close");
-
-	UET_FI_LOAD_SYM(engine, av_insert, "uet_av_insert");
-	UET_FI_LOAD_SYM(engine, av_remove, "uet_av_remove");
-
-	UET_FI_LOAD_SYM(engine, mr_reg, "uet_mr_reg");
-	UET_FI_LOAD_SYM(engine, mr_regv, "uet_mr_regv");
-	UET_FI_LOAD_SYM(engine, mr_key, "uet_mr_key");
-	UET_FI_LOAD_SYM(engine, mr_enable, "uet_mr_enable");
-	UET_FI_LOAD_SYM(engine, mr_disable, "uet_mr_disable");
-	UET_FI_LOAD_SYM(engine, mr_close, "uet_mr_close");
-
-	UET_FI_LOAD_SYM(engine, send, "uet_send");
-	UET_FI_LOAD_SYM(engine, sendv, "uet_sendv");
-	UET_FI_LOAD_SYM(engine, recv, "uet_recv");
-	UET_FI_LOAD_SYM(engine, recvv, "uet_recvv");
-	UET_FI_LOAD_SYM(engine, tsend, "uet_tsend");
-	UET_FI_LOAD_SYM(engine, tsendv, "uet_tsendv");
-	UET_FI_LOAD_SYM(engine, trecv, "uet_trecv");
-	UET_FI_LOAD_SYM(engine, trecvv, "uet_trecvv");
+	if (UET_FI_LOAD_SYM(engine, initialize, "uet_initialize") ||
+	    UET_FI_LOAD_SYM(engine, finalize, "uet_finalize") ||
+	    UET_FI_LOAD_SYM(engine, getinfo, "uet_getinfo") ||
+	    UET_FI_LOAD_SYM(engine, domain, "uet_domain") ||
+	    UET_FI_LOAD_SYM(engine, domain_close, "uet_domain_close") ||
+	    UET_FI_LOAD_SYM(engine, endpoint, "uet_endpoint") ||
+	    UET_FI_LOAD_SYM(engine, getname, "uet_getname") ||
+	    UET_FI_LOAD_SYM(engine, ep_bind_cq, "uet_ep_bind_cq") ||
+	    UET_FI_LOAD_SYM(engine, ep_bind_mr, "uet_ep_bind_mr") ||
+	    UET_FI_LOAD_SYM(engine, ep_enable, "uet_ep_enable") ||
+	    UET_FI_LOAD_SYM(engine, ep_control, "uet_ep_control") ||
+	    UET_FI_LOAD_SYM(engine, ep_setopt, "uet_ep_setopt") ||
+	    UET_FI_LOAD_SYM(engine, ep_close, "uet_ep_close") ||
+	    UET_FI_LOAD_SYM(engine, cancel, "uet_cancel") ||
+	    UET_FI_LOAD_SYM(engine, cq_read, "uet_cq_read") ||
+	    UET_FI_LOAD_SYM(engine, cq_read_src_id, "uet_cq_read_src_id") ||
+	    UET_FI_LOAD_SYM(engine, cq_readerr, "uet_cq_readerr") ||
+	    UET_FI_LOAD_SYM(engine, cq_close, "uet_cq_close") ||
+	    UET_FI_LOAD_SYM(engine, av_insert, "uet_av_insert") ||
+	    UET_FI_LOAD_SYM(engine, av_remove, "uet_av_remove") ||
+	    UET_FI_LOAD_SYM(engine, mr_reg, "uet_mr_reg") ||
+	    UET_FI_LOAD_SYM(engine, mr_regv, "uet_mr_regv") ||
+	    UET_FI_LOAD_SYM(engine, mr_key, "uet_mr_key") ||
+	    UET_FI_LOAD_SYM(engine, mr_enable, "uet_mr_enable") ||
+	    UET_FI_LOAD_SYM(engine, mr_disable, "uet_mr_disable") ||
+	    UET_FI_LOAD_SYM(engine, mr_close, "uet_mr_close") ||
+	    UET_FI_LOAD_SYM(engine, send, "uet_send") ||
+	    UET_FI_LOAD_SYM(engine, sendv, "uet_sendv") ||
+	    UET_FI_LOAD_SYM(engine, recv, "uet_recv") ||
+	    UET_FI_LOAD_SYM(engine, recvv, "uet_recvv") ||
+	    UET_FI_LOAD_SYM(engine, tsend, "uet_tsend") ||
+	    UET_FI_LOAD_SYM(engine, tsendv, "uet_tsendv") ||
+	    UET_FI_LOAD_SYM(engine, trecv, "uet_trecv") ||
+	    UET_FI_LOAD_SYM(engine, trecvv, "uet_trecvv"))
+		goto missing_symbol;
 
 	return FI_SUCCESS;
 
 missing_symbol:
-	fprintf(stderr, "uet provider: %s is missing symbol: %s\n",
-		library, dlerror());
 	uet_fi_engine_unload(engine);
 	return -FI_ENOSYS;
 }

--- a/libfabric-provider/uet_fi_ep.c
+++ b/libfabric-provider/uet_fi_ep.c
@@ -181,10 +181,12 @@ static int uet_fi_ep_setopt(fid_t fid, int level, int optname,
 			    const void *optval, size_t optlen)
 {
 	struct uet_fi_ep *ep;
+	int rc;
 
 	ep = UET_FI_CONTAINER(fid, struct uet_fi_ep, ep_fid.fid);
-	return ep->domain->fabric->engine.ep_setopt(ep->uet_ep, level, optname,
-						      optval, optlen);
+	rc = ep->domain->fabric->engine.ep_setopt(ep->uet_ep, level, optname,
+						   optval, optlen);
+	return rc == -FI_ENOSYS ? -FI_ENOPROTOOPT : rc;
 }
 
 static int uet_fi_ep_getname(fid_t fid, void *addr, size_t *addrlen)

--- a/libfabric-provider/uet_fi_ep.c
+++ b/libfabric-provider/uet_fi_ep.c
@@ -1,0 +1,639 @@
+/*
+ * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <rdma/fi_errno.h>
+
+#include "uet_fi.h"
+#include "uet_fi_noop.h"
+
+static int uet_fi_ep_close(struct fid *fid)
+{
+	struct uet_fi_ep *ep;
+	struct uet_fi_mr *mr, *next;
+	int rc;
+
+	ep = UET_FI_CONTAINER(fid, struct uet_fi_ep, ep_fid.fid);
+	pthread_mutex_lock(&ep->domain->control_lock);
+	rc = ep->domain->fabric->engine.ep_close(ep->uet_ep);
+	if (rc) {
+		pthread_mutex_unlock(&ep->domain->control_lock);
+		return rc;
+	}
+
+	for (mr = ep->mrs; mr; mr = next) {
+		next = mr->ep_next;
+		mr->ep = NULL;
+		mr->ep_next = NULL;
+		mr->enabled = false;
+	}
+	if (ep->tx_cq) {
+		atomic_fetch_sub_explicit(&ep->tx_cq->refs, 1,
+					  memory_order_release);
+		ep->tx_cq->tx_cq = NULL;
+	}
+	if (ep->rx_cq) {
+		atomic_fetch_sub_explicit(&ep->rx_cq->refs, 1,
+					  memory_order_release);
+		ep->rx_cq->rx_cq = NULL;
+	}
+	if (ep->tx_cq && ep->tx_cq == ep->rx_cq)
+		ep->tx_cq->ep = NULL;
+	else {
+		if (ep->tx_cq)
+			ep->tx_cq->ep = NULL;
+		if (ep->rx_cq)
+			ep->rx_cq->ep = NULL;
+	}
+	if (ep->av)
+		atomic_fetch_sub_explicit(&ep->av->refs, 1, memory_order_release);
+	pthread_mutex_unlock(&ep->domain->control_lock);
+
+	fi_freeinfo(ep->engine_info);
+	atomic_fetch_sub_explicit(&ep->domain->refs, 1, memory_order_release);
+	free(ep);
+	return FI_SUCCESS;
+}
+
+static int uet_fi_ep_bind_av(struct uet_fi_ep *ep, struct uet_fi_av *av,
+			     uint64_t flags)
+{
+	if (flags || av->domain != ep->domain || ep->av)
+		return -FI_EINVAL;
+	ep->av = av;
+	atomic_fetch_add_explicit(&av->refs, 1, memory_order_release);
+	return FI_SUCCESS;
+}
+
+static int uet_fi_ep_bind_one_cq(struct uet_fi_ep *ep, struct uet_fi_cq *cq,
+				 uint64_t direction)
+{
+	uet_cq_handle_t *handle;
+	struct uet_fi_cq **ep_cq;
+	int rc;
+
+	if (cq->domain != ep->domain || (cq->ep && cq->ep != ep))
+		return -FI_EINVAL;
+	if (direction == FI_SEND) {
+		handle = &cq->tx_cq;
+		ep_cq = &ep->tx_cq;
+	} else {
+		handle = &cq->rx_cq;
+		ep_cq = &ep->rx_cq;
+	}
+	if (*handle || *ep_cq)
+		return -FI_EINVAL;
+
+	rc = ep->domain->fabric->engine.ep_bind_cq(ep->uet_ep, &cq->attr,
+						     &cq->cq_fid, direction,
+						     cq->cq_fid.fid.context,
+						     handle);
+	if (!rc) {
+		*ep_cq = cq;
+		cq->ep = ep;
+		atomic_fetch_add_explicit(&cq->refs, 1, memory_order_release);
+	}
+	return rc;
+}
+
+static int uet_fi_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
+{
+	struct uet_fi_ep *ep;
+	struct uet_fi_cq *cq;
+	int rc = FI_SUCCESS;
+
+	if (!bfid)
+		return -FI_EINVAL;
+	ep = UET_FI_CONTAINER(fid, struct uet_fi_ep, ep_fid.fid);
+	if (ep->enabled)
+		return -FI_EOPBADSTATE;
+
+	pthread_mutex_lock(&ep->domain->control_lock);
+	switch (bfid->fclass) {
+	case FI_CLASS_AV:
+		rc = uet_fi_ep_bind_av(
+			ep, UET_FI_CONTAINER(bfid, struct uet_fi_av, av_fid.fid),
+			flags);
+		break;
+	case FI_CLASS_CQ:
+		if (flags & ~(FI_SEND | FI_RECV)) {
+			rc = -FI_EINVAL;
+			break;
+		}
+		if (!(flags & (FI_SEND | FI_RECV))) {
+			rc = -FI_EINVAL;
+			break;
+		}
+		cq = UET_FI_CONTAINER(bfid, struct uet_fi_cq, cq_fid.fid);
+		if (flags & FI_SEND) {
+			rc = uet_fi_ep_bind_one_cq(ep, cq, FI_SEND);
+			if (rc)
+				break;
+		}
+		if (flags & FI_RECV)
+			rc = uet_fi_ep_bind_one_cq(ep, cq, FI_RECV);
+		break;
+	default:
+		rc = -FI_ENOSYS;
+		break;
+	}
+	pthread_mutex_unlock(&ep->domain->control_lock);
+	return rc;
+}
+
+static int uet_fi_ep_control(struct fid *fid, int command, void *arg)
+{
+	struct uet_fi_ep *ep;
+	int rc;
+
+	ep = UET_FI_CONTAINER(fid, struct uet_fi_ep, ep_fid.fid);
+	pthread_mutex_lock(&ep->domain->control_lock);
+	if (command == FI_ENABLE) {
+		if (ep->enabled)
+			rc = -FI_EOPBADSTATE;
+		else {
+			rc = ep->domain->fabric->engine.ep_enable(ep->uet_ep);
+			if (!rc)
+				ep->enabled = true;
+		}
+	} else {
+		rc = ep->domain->fabric->engine.ep_control(ep->uet_ep,
+							 command, arg);
+	}
+	pthread_mutex_unlock(&ep->domain->control_lock);
+	return rc;
+}
+
+static ssize_t uet_fi_ep_cancel(fid_t fid, void *context)
+{
+	struct uet_fi_ep *ep;
+
+	ep = UET_FI_CONTAINER(fid, struct uet_fi_ep, ep_fid.fid);
+	return ep->domain->fabric->engine.cancel(ep->uet_ep, context);
+}
+
+static int uet_fi_ep_setopt(fid_t fid, int level, int optname,
+			    const void *optval, size_t optlen)
+{
+	struct uet_fi_ep *ep;
+
+	ep = UET_FI_CONTAINER(fid, struct uet_fi_ep, ep_fid.fid);
+	return ep->domain->fabric->engine.ep_setopt(ep->uet_ep, level, optname,
+						      optval, optlen);
+}
+
+static int uet_fi_ep_getname(fid_t fid, void *addr, size_t *addrlen)
+{
+	struct uet_fi_ep *ep;
+	struct uet_addr uet_addr;
+	int rc;
+
+	if (!addrlen)
+		return -FI_EINVAL;
+	if (!addr || *addrlen < sizeof(uet_addr)) {
+		*addrlen = sizeof(uet_addr);
+		return -FI_ETOOSMALL;
+	}
+	ep = UET_FI_CONTAINER(fid, struct uet_fi_ep, ep_fid.fid);
+	rc = ep->domain->fabric->engine.getname(ep->uet_ep, &uet_addr);
+	if (rc)
+		return rc;
+	memcpy(addr, &uet_addr, sizeof(uet_addr));
+	*addrlen = sizeof(uet_addr);
+	return FI_SUCCESS;
+}
+
+static struct fi_ops uet_fi_ep_fid_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = uet_fi_ep_close,
+	.bind = uet_fi_ep_bind,
+	.control = uet_fi_ep_control,
+	.ops_open = uet_fi_no_ops_open,
+	.tostr = uet_fi_no_tostr,
+	.ops_set = uet_fi_no_ops_set,
+};
+
+static struct fi_ops_ep uet_fi_ep_ops = {
+	.size = sizeof(struct fi_ops_ep),
+	.cancel = uet_fi_ep_cancel,
+	.getopt = uet_fi_no_getopt,
+	.setopt = uet_fi_ep_setopt,
+	.tx_ctx = uet_fi_no_tx_ctx,
+	.rx_ctx = uet_fi_no_rx_ctx,
+	.rx_size_left = uet_fi_no_rx_size_left,
+	.tx_size_left = uet_fi_no_tx_size_left,
+};
+
+static struct fi_ops_cm uet_fi_cm_ops = {
+	.size = sizeof(struct fi_ops_cm),
+	.setname = uet_fi_no_setname,
+	.getname = uet_fi_ep_getname,
+	.getpeer = uet_fi_no_getpeer,
+	.connect = uet_fi_no_connect,
+	.listen = uet_fi_no_listen,
+	.accept = uet_fi_no_accept,
+	.reject = uet_fi_no_reject,
+	.shutdown = uet_fi_no_shutdown,
+	.join = uet_fi_no_join,
+};
+
+static int uet_fi_ep_check_data(struct uet_fi_ep *ep, size_t count)
+{
+	if (!ep->enabled)
+		return -FI_EOPBADSTATE;
+	if (!count || count > UET_FI_IOV_LIMIT)
+		return -FI_EINVAL;
+	return FI_SUCCESS;
+}
+
+static uet_mr_handle_t uet_fi_one_desc(void **desc, size_t count, int *rc)
+{
+	uet_mr_handle_t first;
+	size_t i;
+
+	*rc = FI_SUCCESS;
+	if (!desc)
+		return UET_NULL_HANDLE;
+	first = desc[0];
+	for (i = 1; i < count; i++) {
+		if (desc[i] != first) {
+			*rc = -FI_EINVAL;
+			return UET_NULL_HANDLE;
+		}
+	}
+	return first;
+}
+
+static ssize_t uet_fi_msg_send(struct fid_ep *ep_fid, const void *buf,
+			       size_t len, void *desc, fi_addr_t dest_addr,
+			       void *context)
+{
+	struct uet_fi_av_entry *entry;
+	struct uet_fi_ep *ep;
+	ssize_t rc;
+
+	ep = UET_FI_CONTAINER(ep_fid, struct uet_fi_ep, ep_fid);
+	rc = uet_fi_ep_check_data(ep, 1);
+	if (rc)
+		return rc;
+	if (!ep->av)
+		return -FI_EINVAL;
+	pthread_rwlock_rdlock(&ep->av->lock);
+	entry = uet_fi_av_get(ep->av, dest_addr);
+	if (!entry)
+		rc = -FI_EINVAL;
+	else
+		rc = ep->domain->fabric->engine.send(ep->uet_ep, UET_DEF_JOB_ID,
+						      (void *)buf, len, desc,
+						      entry->uet_addr, context);
+	pthread_rwlock_unlock(&ep->av->lock);
+	return rc;
+}
+
+static ssize_t uet_fi_msg_sendv(struct fid_ep *ep_fid,
+				const struct iovec *iov, void **desc,
+				size_t count, fi_addr_t dest_addr,
+				void *context)
+{
+	struct uet_fi_av_entry *entry;
+	struct uet_fi_ep *ep;
+	uet_mr_handle_t mr;
+	ssize_t rc;
+	int desc_rc;
+
+	ep = UET_FI_CONTAINER(ep_fid, struct uet_fi_ep, ep_fid);
+	rc = uet_fi_ep_check_data(ep, count);
+	if (rc || !iov)
+		return rc ? rc : -FI_EINVAL;
+	mr = uet_fi_one_desc(desc, count, &desc_rc);
+	if (desc_rc)
+		return desc_rc;
+	if (!ep->av)
+		return -FI_EINVAL;
+	pthread_rwlock_rdlock(&ep->av->lock);
+	entry = uet_fi_av_get(ep->av, dest_addr);
+	if (!entry)
+		rc = -FI_EINVAL;
+	else
+		rc = ep->domain->fabric->engine.sendv(ep->uet_ep, UET_DEF_JOB_ID,
+						       iov, count, mr,
+						       entry->uet_addr, context);
+	pthread_rwlock_unlock(&ep->av->lock);
+	return rc;
+}
+
+static ssize_t uet_fi_msg_sendmsg(struct fid_ep *ep,
+				  const struct fi_msg *msg, uint64_t flags)
+{
+	if (!msg || (flags & ~(FI_COMPLETION | FI_TRANSMIT_COMPLETE)))
+		return -FI_ENOSYS;
+	return uet_fi_msg_sendv(ep, msg->msg_iov, msg->desc, msg->iov_count,
+				msg->addr, msg->context);
+}
+
+static ssize_t uet_fi_msg_recv(struct fid_ep *ep_fid, void *buf, size_t len,
+			       void *desc, fi_addr_t src_addr, void *context)
+{
+	struct uet_fi_av_entry *entry = NULL;
+	struct uet_fi_ep *ep;
+	ssize_t rc;
+
+	ep = UET_FI_CONTAINER(ep_fid, struct uet_fi_ep, ep_fid);
+	rc = uet_fi_ep_check_data(ep, 1);
+	if (rc)
+		return rc;
+	if ((ep->engine_info->caps & FI_DIRECTED_RECV) &&
+	    src_addr != FI_ADDR_UNSPEC) {
+		if (!ep->av)
+			return -FI_EINVAL;
+		pthread_rwlock_rdlock(&ep->av->lock);
+		entry = uet_fi_av_get(ep->av, src_addr);
+		if (!entry) {
+			pthread_rwlock_unlock(&ep->av->lock);
+			return -FI_EINVAL;
+		}
+	}
+	rc = ep->domain->fabric->engine.recv(ep->uet_ep, UET_JOB_ID_ANY, buf,
+						    len, desc,
+						    entry ? entry->uet_addr : NULL,
+						    context);
+	if (entry)
+		pthread_rwlock_unlock(&ep->av->lock);
+	return rc;
+}
+
+static ssize_t uet_fi_msg_recvv(struct fid_ep *ep_fid,
+				const struct iovec *iov, void **desc,
+				size_t count, fi_addr_t src_addr,
+				void *context)
+{
+	struct uet_fi_av_entry *entry = NULL;
+	struct uet_fi_ep *ep;
+	uet_mr_handle_t mr;
+	ssize_t rc;
+	int desc_rc;
+
+	ep = UET_FI_CONTAINER(ep_fid, struct uet_fi_ep, ep_fid);
+	rc = uet_fi_ep_check_data(ep, count);
+	if (rc || !iov)
+		return rc ? rc : -FI_EINVAL;
+	mr = uet_fi_one_desc(desc, count, &desc_rc);
+	if (desc_rc)
+		return desc_rc;
+	if ((ep->engine_info->caps & FI_DIRECTED_RECV) &&
+	    src_addr != FI_ADDR_UNSPEC) {
+		if (!ep->av)
+			return -FI_EINVAL;
+		pthread_rwlock_rdlock(&ep->av->lock);
+		entry = uet_fi_av_get(ep->av, src_addr);
+		if (!entry) {
+			pthread_rwlock_unlock(&ep->av->lock);
+			return -FI_EINVAL;
+		}
+	}
+	rc = ep->domain->fabric->engine.recvv(ep->uet_ep, UET_JOB_ID_ANY,
+						     iov, count, mr,
+						     entry ? entry->uet_addr : NULL,
+						     context);
+	if (entry)
+		pthread_rwlock_unlock(&ep->av->lock);
+	return rc;
+}
+
+static ssize_t uet_fi_msg_recvmsg(struct fid_ep *ep,
+				  const struct fi_msg *msg, uint64_t flags)
+{
+	if (!msg || (flags & ~FI_COMPLETION))
+		return -FI_ENOSYS;
+	return uet_fi_msg_recvv(ep, msg->msg_iov, msg->desc, msg->iov_count,
+				msg->addr, msg->context);
+}
+
+static struct fi_ops_msg uet_fi_msg_ops = {
+	.size = sizeof(struct fi_ops_msg),
+	.recv = uet_fi_msg_recv,
+	.recvv = uet_fi_msg_recvv,
+	.recvmsg = uet_fi_msg_recvmsg,
+	.send = uet_fi_msg_send,
+	.sendv = uet_fi_msg_sendv,
+	.sendmsg = uet_fi_msg_sendmsg,
+	.inject = uet_fi_no_msg_inject,
+	.senddata = uet_fi_no_msg_senddata,
+	.injectdata = uet_fi_no_msg_injectdata,
+};
+
+static ssize_t uet_fi_tagged_send(struct fid_ep *ep_fid, const void *buf,
+				  size_t len, void *desc, fi_addr_t dest_addr,
+				  uint64_t tag, void *context)
+{
+	struct uet_fi_av_entry *entry;
+	struct uet_fi_ep *ep;
+	ssize_t rc;
+
+	ep = UET_FI_CONTAINER(ep_fid, struct uet_fi_ep, ep_fid);
+	rc = uet_fi_ep_check_data(ep, 1);
+	if (rc)
+		return rc;
+	if (!ep->av)
+		return -FI_EINVAL;
+	pthread_rwlock_rdlock(&ep->av->lock);
+	entry = uet_fi_av_get(ep->av, dest_addr);
+	if (!entry)
+		rc = -FI_EINVAL;
+	else
+		rc = ep->domain->fabric->engine.tsend(
+			ep->uet_ep, UET_DEF_JOB_ID, (void *)buf, len, desc,
+			entry->uet_addr, tag, context);
+	pthread_rwlock_unlock(&ep->av->lock);
+	return rc;
+}
+
+static ssize_t uet_fi_tagged_sendv(struct fid_ep *ep_fid,
+				   const struct iovec *iov, void **desc,
+				   size_t count, fi_addr_t dest_addr,
+				   uint64_t tag, void *context)
+{
+	struct uet_fi_av_entry *entry;
+	struct uet_fi_ep *ep;
+	uet_mr_handle_t mr;
+	ssize_t rc;
+	int desc_rc;
+
+	ep = UET_FI_CONTAINER(ep_fid, struct uet_fi_ep, ep_fid);
+	rc = uet_fi_ep_check_data(ep, count);
+	if (rc || !iov)
+		return rc ? rc : -FI_EINVAL;
+	mr = uet_fi_one_desc(desc, count, &desc_rc);
+	if (desc_rc)
+		return desc_rc;
+	if (!ep->av)
+		return -FI_EINVAL;
+	pthread_rwlock_rdlock(&ep->av->lock);
+	entry = uet_fi_av_get(ep->av, dest_addr);
+	if (!entry)
+		rc = -FI_EINVAL;
+	else
+		rc = ep->domain->fabric->engine.tsendv(
+			ep->uet_ep, UET_DEF_JOB_ID, iov, count, mr,
+			entry->uet_addr, tag, context);
+	pthread_rwlock_unlock(&ep->av->lock);
+	return rc;
+}
+
+static ssize_t uet_fi_tagged_sendmsg(struct fid_ep *ep,
+				     const struct fi_msg_tagged *msg,
+				     uint64_t flags)
+{
+	if (!msg || (flags & ~(FI_COMPLETION | FI_TRANSMIT_COMPLETE)))
+		return -FI_ENOSYS;
+	return uet_fi_tagged_sendv(ep, msg->msg_iov, msg->desc, msg->iov_count,
+				   msg->addr, msg->tag, msg->context);
+}
+
+static ssize_t uet_fi_tagged_recv(struct fid_ep *ep_fid, void *buf,
+				  size_t len, void *desc, fi_addr_t src_addr,
+				  uint64_t tag, uint64_t ignore, void *context)
+{
+	struct uet_fi_av_entry *entry = NULL;
+	struct uet_fi_ep *ep;
+	ssize_t rc;
+
+	ep = UET_FI_CONTAINER(ep_fid, struct uet_fi_ep, ep_fid);
+	rc = uet_fi_ep_check_data(ep, 1);
+	if (rc)
+		return rc;
+	if ((ep->engine_info->caps & FI_DIRECTED_RECV) &&
+	    src_addr != FI_ADDR_UNSPEC) {
+		if (!ep->av)
+			return -FI_EINVAL;
+		pthread_rwlock_rdlock(&ep->av->lock);
+		entry = uet_fi_av_get(ep->av, src_addr);
+		if (!entry) {
+			pthread_rwlock_unlock(&ep->av->lock);
+			return -FI_EINVAL;
+		}
+	}
+	rc = ep->domain->fabric->engine.trecv(
+		ep->uet_ep, UET_JOB_ID_ANY, buf, len, desc,
+		entry ? entry->uet_addr : NULL, tag, ignore, context);
+	if (entry)
+		pthread_rwlock_unlock(&ep->av->lock);
+	return rc;
+}
+
+static ssize_t uet_fi_tagged_recvv(struct fid_ep *ep_fid,
+				   const struct iovec *iov, void **desc,
+				   size_t count, fi_addr_t src_addr,
+				   uint64_t tag, uint64_t ignore,
+				   void *context)
+{
+	struct uet_fi_av_entry *entry = NULL;
+	struct uet_fi_ep *ep;
+	uet_mr_handle_t mr;
+	ssize_t rc;
+	int desc_rc;
+
+	ep = UET_FI_CONTAINER(ep_fid, struct uet_fi_ep, ep_fid);
+	rc = uet_fi_ep_check_data(ep, count);
+	if (rc || !iov)
+		return rc ? rc : -FI_EINVAL;
+	mr = uet_fi_one_desc(desc, count, &desc_rc);
+	if (desc_rc)
+		return desc_rc;
+	if ((ep->engine_info->caps & FI_DIRECTED_RECV) &&
+	    src_addr != FI_ADDR_UNSPEC) {
+		if (!ep->av)
+			return -FI_EINVAL;
+		pthread_rwlock_rdlock(&ep->av->lock);
+		entry = uet_fi_av_get(ep->av, src_addr);
+		if (!entry) {
+			pthread_rwlock_unlock(&ep->av->lock);
+			return -FI_EINVAL;
+		}
+	}
+	rc = ep->domain->fabric->engine.trecvv(
+		ep->uet_ep, UET_JOB_ID_ANY, iov, count, mr,
+		entry ? entry->uet_addr : NULL, tag, ignore, context);
+	if (entry)
+		pthread_rwlock_unlock(&ep->av->lock);
+	return rc;
+}
+
+static ssize_t uet_fi_tagged_recvmsg(struct fid_ep *ep,
+				     const struct fi_msg_tagged *msg,
+				     uint64_t flags)
+{
+	if (!msg || (flags & ~FI_COMPLETION))
+		return -FI_ENOSYS;
+	return uet_fi_tagged_recvv(ep, msg->msg_iov, msg->desc, msg->iov_count,
+				   msg->addr, msg->tag, msg->ignore,
+				   msg->context);
+}
+
+static struct fi_ops_tagged uet_fi_tagged_ops = {
+	.size = sizeof(struct fi_ops_tagged),
+	.recv = uet_fi_tagged_recv,
+	.recvv = uet_fi_tagged_recvv,
+	.recvmsg = uet_fi_tagged_recvmsg,
+	.send = uet_fi_tagged_send,
+	.sendv = uet_fi_tagged_sendv,
+	.sendmsg = uet_fi_tagged_sendmsg,
+	.inject = uet_fi_no_tagged_inject,
+	.senddata = uet_fi_no_tagged_senddata,
+	.injectdata = uet_fi_no_tagged_injectdata,
+};
+
+int uet_fi_endpoint_open(struct fid_domain *domain_fid, struct fi_info *info,
+			 struct fid_ep **ep_out, void *context)
+{
+	struct uet_fi_domain *domain;
+	struct uet_fi_ep *ep;
+	int rc;
+
+	if (!domain_fid || !info || !ep_out || !info->ep_attr ||
+	    info->ep_attr->type != FI_EP_RDM)
+		return -FI_EINVAL;
+	domain = UET_FI_CONTAINER(domain_fid, struct uet_fi_domain, domain_fid);
+	ep = calloc(1, sizeof(*ep));
+	if (!ep)
+		return -FI_ENOMEM;
+	ep->domain = domain;
+	ep->engine_info = fi_dupinfo(domain->engine_info);
+	if (!ep->engine_info) {
+		free(ep);
+		return -FI_ENOMEM;
+	}
+	if (info->tx_attr && info->tx_attr->size)
+		ep->engine_info->tx_attr->size = info->tx_attr->size;
+	if (info->rx_attr && info->rx_attr->size)
+		ep->engine_info->rx_attr->size = info->rx_attr->size;
+	if (info->tx_attr)
+		ep->engine_info->tx_attr->tclass = info->tx_attr->tclass;
+
+	ep->ep_fid.fid.fclass = FI_CLASS_EP;
+	ep->ep_fid.fid.context = context;
+	ep->ep_fid.fid.ops = &uet_fi_ep_fid_ops;
+	ep->ep_fid.ops = &uet_fi_ep_ops;
+	ep->ep_fid.cm = &uet_fi_cm_ops;
+	ep->ep_fid.msg = &uet_fi_msg_ops;
+	ep->ep_fid.tagged = &uet_fi_tagged_ops;
+
+	pthread_mutex_lock(&domain->control_lock);
+	rc = domain->fabric->engine.endpoint(domain->uet_domain,
+					     ep->engine_info, &ep->ep_fid,
+					     context, &ep->uet_ep);
+	pthread_mutex_unlock(&domain->control_lock);
+	if (rc) {
+		fi_freeinfo(ep->engine_info);
+		free(ep);
+		return rc;
+	}
+	atomic_fetch_add_explicit(&domain->refs, 1, memory_order_release);
+	*ep_out = &ep->ep_fid;
+	return FI_SUCCESS;
+}

--- a/libfabric-provider/uet_fi_ep.c
+++ b/libfabric-provider/uet_fi_ep.c
@@ -1,7 +1,6 @@
+// SPDX-License-Identifier: MIT
 /*
  * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
- *
- * SPDX-License-Identifier: MIT
  */
 
 #include <stdlib.h>

--- a/libfabric-provider/uet_fi_eq.c
+++ b/libfabric-provider/uet_fi_eq.c
@@ -1,7 +1,6 @@
+// SPDX-License-Identifier: MIT
 /*
  * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
- *
- * SPDX-License-Identifier: MIT
  */
 
 #include <stdlib.h>
@@ -65,12 +64,14 @@ static const char *uet_fi_eq_strerror(struct fid_eq *eq, int prov_errno,
 				     size_t len)
 {
 	const char *text = fi_strerror(prov_errno);
+	size_t copy_len;
 
 	(void)eq;
 	(void)err_data;
 	if (buf && len) {
-		strncpy(buf, text, len - 1);
-		buf[len - 1] = '\0';
+		copy_len = strnlen(text, len - 1);
+		memcpy(buf, text, copy_len);
+		buf[copy_len] = '\0';
 		return buf;
 	}
 	return text;

--- a/libfabric-provider/uet_fi_eq.c
+++ b/libfabric-provider/uet_fi_eq.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <rdma/fi_errno.h>
+
+#include "uet_fi.h"
+#include "uet_fi_noop.h"
+
+static int uet_fi_eq_close(struct fid *fid)
+{
+	struct uet_fi_eq *eq;
+
+	eq = UET_FI_CONTAINER(fid, struct uet_fi_eq, eq_fid.fid);
+	atomic_fetch_sub_explicit(&eq->fabric->refs, 1, memory_order_release);
+	free(eq);
+	return FI_SUCCESS;
+}
+
+static ssize_t uet_fi_eq_read(struct fid_eq *eq, uint32_t *event, void *buf,
+			      size_t len, uint64_t flags)
+{
+	(void)eq;
+	(void)event;
+	(void)buf;
+	(void)len;
+	if (flags & ~FI_PEEK)
+		return -FI_EINVAL;
+	return -FI_EAGAIN;
+}
+
+static ssize_t uet_fi_eq_readerr(struct fid_eq *eq,
+				 struct fi_eq_err_entry *buf, uint64_t flags)
+{
+	(void)eq;
+	(void)buf;
+	return flags ? -FI_EINVAL : -FI_EAGAIN;
+}
+
+static ssize_t uet_fi_eq_write(struct fid_eq *eq, uint32_t event,
+			       const void *buf, size_t len, uint64_t flags)
+{
+	(void)eq;
+	(void)event;
+	(void)buf;
+	(void)len;
+	(void)flags;
+	return -FI_ENOSYS;
+}
+
+static ssize_t uet_fi_eq_sread(struct fid_eq *eq, uint32_t *event, void *buf,
+			       size_t len, int timeout, uint64_t flags)
+{
+	(void)timeout;
+	return uet_fi_eq_read(eq, event, buf, len, flags);
+}
+
+static const char *uet_fi_eq_strerror(struct fid_eq *eq, int prov_errno,
+				     const void *err_data, char *buf,
+				     size_t len)
+{
+	const char *text = fi_strerror(prov_errno);
+
+	(void)eq;
+	(void)err_data;
+	if (buf && len) {
+		strncpy(buf, text, len - 1);
+		buf[len - 1] = '\0';
+		return buf;
+	}
+	return text;
+}
+
+static struct fi_ops uet_fi_eq_fid_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = uet_fi_eq_close,
+	.bind = uet_fi_no_bind,
+	.control = uet_fi_no_control,
+	.ops_open = uet_fi_no_ops_open,
+	.tostr = uet_fi_no_tostr,
+	.ops_set = uet_fi_no_ops_set,
+};
+
+static struct fi_ops_eq uet_fi_eq_ops = {
+	.size = sizeof(struct fi_ops_eq),
+	.read = uet_fi_eq_read,
+	.readerr = uet_fi_eq_readerr,
+	.write = uet_fi_eq_write,
+	.sread = uet_fi_eq_sread,
+	.strerror = uet_fi_eq_strerror,
+};
+
+int uet_fi_eq_open(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
+		   struct fid_eq **eq_out, void *context)
+{
+	struct uet_fi_fabric *fabric;
+	struct uet_fi_eq *eq;
+
+	if (!fabric_fid || !eq_out)
+		return -FI_EINVAL;
+	if (attr && (attr->flags || attr->wait_set ||
+	    (attr->wait_obj != FI_WAIT_NONE &&
+	     attr->wait_obj != FI_WAIT_UNSPEC)))
+		return -FI_ENOSYS;
+
+	fabric = UET_FI_CONTAINER(fabric_fid, struct uet_fi_fabric, fabric_fid);
+	eq = calloc(1, sizeof(*eq));
+	if (!eq)
+		return -FI_ENOMEM;
+	eq->fabric = fabric;
+	eq->eq_fid.fid.fclass = FI_CLASS_EQ;
+	eq->eq_fid.fid.context = context;
+	eq->eq_fid.fid.ops = &uet_fi_eq_fid_ops;
+	eq->eq_fid.ops = &uet_fi_eq_ops;
+	atomic_fetch_add_explicit(&fabric->refs, 1, memory_order_release);
+	*eq_out = &eq->eq_fid;
+	return FI_SUCCESS;
+}

--- a/libfabric-provider/uet_fi_noop.c
+++ b/libfabric-provider/uet_fi_noop.c
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <rdma/fi_errno.h>
+
+#include "uet_fi_noop.h"
+
+#define UET_FI_UNUSED(x) ((void)(x))
+
+int uet_fi_no_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
+{
+	UET_FI_UNUSED(fid); UET_FI_UNUSED(bfid); UET_FI_UNUSED(flags);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_control(struct fid *fid, int command, void *arg)
+{
+	UET_FI_UNUSED(fid); UET_FI_UNUSED(command); UET_FI_UNUSED(arg);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_ops_open(struct fid *fid, const char *name, uint64_t flags,
+		       void **ops, void *context)
+{
+	UET_FI_UNUSED(fid); UET_FI_UNUSED(name); UET_FI_UNUSED(flags);
+	UET_FI_UNUSED(ops); UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_tostr(const struct fid *fid, char *buf, size_t len)
+{
+	UET_FI_UNUSED(fid); UET_FI_UNUSED(buf); UET_FI_UNUSED(len);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_ops_set(struct fid *fid, const char *name, uint64_t flags,
+		      void *ops, void *context)
+{
+	UET_FI_UNUSED(fid); UET_FI_UNUSED(name); UET_FI_UNUSED(flags);
+	UET_FI_UNUSED(ops); UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
+			 struct fid_pep **pep, void *context)
+{
+	UET_FI_UNUSED(fabric); UET_FI_UNUSED(info); UET_FI_UNUSED(pep);
+	UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+		      struct fid_eq **eq, void *context)
+{
+	UET_FI_UNUSED(fabric); UET_FI_UNUSED(attr); UET_FI_UNUSED(eq);
+	UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+			struct fid_wait **waitset)
+{
+	UET_FI_UNUSED(fabric); UET_FI_UNUSED(attr); UET_FI_UNUSED(waitset);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
+{
+	UET_FI_UNUSED(fabric); UET_FI_UNUSED(fids); UET_FI_UNUSED(count);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_domain2(struct fid_fabric *fabric, struct fi_info *info,
+		      struct fid_domain **domain, uint64_t flags, void *context)
+{
+	UET_FI_UNUSED(fabric); UET_FI_UNUSED(info); UET_FI_UNUSED(domain);
+	UET_FI_UNUSED(flags); UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_scalable_ep(struct fid_domain *domain, struct fi_info *info,
+			  struct fid_ep **sep, void *context)
+{
+	UET_FI_UNUSED(domain); UET_FI_UNUSED(info); UET_FI_UNUSED(sep);
+	UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
+			struct fid_cntr **cntr, void *context)
+{
+	UET_FI_UNUSED(domain); UET_FI_UNUSED(attr); UET_FI_UNUSED(cntr);
+	UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
+			struct fid_poll **pollset)
+{
+	UET_FI_UNUSED(domain); UET_FI_UNUSED(attr); UET_FI_UNUSED(pollset);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_stx_context(struct fid_domain *domain, struct fi_tx_attr *attr,
+			  struct fid_stx **stx, void *context)
+{
+	UET_FI_UNUSED(domain); UET_FI_UNUSED(attr); UET_FI_UNUSED(stx);
+	UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
+			  struct fid_ep **rx_ep, void *context)
+{
+	UET_FI_UNUSED(domain); UET_FI_UNUSED(attr); UET_FI_UNUSED(rx_ep);
+	UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_query_atomic(struct fid_domain *domain,
+			   enum fi_datatype datatype, enum fi_op op,
+			   struct fi_atomic_attr *attr, uint64_t flags)
+{
+	UET_FI_UNUSED(domain); UET_FI_UNUSED(datatype); UET_FI_UNUSED(op);
+	UET_FI_UNUSED(attr); UET_FI_UNUSED(flags);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_query_collective(struct fid_domain *domain,
+			       enum fi_collective_op coll,
+			       struct fi_collective_attr *attr, uint64_t flags)
+{
+	UET_FI_UNUSED(domain); UET_FI_UNUSED(coll); UET_FI_UNUSED(attr);
+	UET_FI_UNUSED(flags);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_endpoint2(struct fid_domain *domain, struct fi_info *info,
+			struct fid_ep **ep, uint64_t flags, void *context)
+{
+	UET_FI_UNUSED(domain); UET_FI_UNUSED(info); UET_FI_UNUSED(ep);
+	UET_FI_UNUSED(flags); UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_getopt(fid_t fid, int level, int optname, void *optval,
+		     size_t *optlen)
+{
+	UET_FI_UNUSED(fid); UET_FI_UNUSED(level); UET_FI_UNUSED(optname);
+	UET_FI_UNUSED(optval); UET_FI_UNUSED(optlen);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_tx_ctx(struct fid_ep *sep, int index, struct fi_tx_attr *attr,
+		     struct fid_ep **tx_ep, void *context)
+{
+	UET_FI_UNUSED(sep); UET_FI_UNUSED(index); UET_FI_UNUSED(attr);
+	UET_FI_UNUSED(tx_ep); UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_rx_ctx(struct fid_ep *sep, int index, struct fi_rx_attr *attr,
+		     struct fid_ep **rx_ep, void *context)
+{
+	UET_FI_UNUSED(sep); UET_FI_UNUSED(index); UET_FI_UNUSED(attr);
+	UET_FI_UNUSED(rx_ep); UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+ssize_t uet_fi_no_rx_size_left(struct fid_ep *ep)
+{
+	UET_FI_UNUSED(ep); return -FI_ENOSYS;
+}
+
+ssize_t uet_fi_no_tx_size_left(struct fid_ep *ep)
+{
+	UET_FI_UNUSED(ep); return -FI_ENOSYS;
+}
+
+int uet_fi_no_setname(fid_t fid, void *addr, size_t addrlen)
+{
+	UET_FI_UNUSED(fid); UET_FI_UNUSED(addr); UET_FI_UNUSED(addrlen);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen)
+{
+	UET_FI_UNUSED(ep); UET_FI_UNUSED(addr); UET_FI_UNUSED(addrlen);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_connect(struct fid_ep *ep, const void *addr, const void *param,
+		      size_t paramlen)
+{
+	UET_FI_UNUSED(ep); UET_FI_UNUSED(addr); UET_FI_UNUSED(param);
+	UET_FI_UNUSED(paramlen);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_listen(struct fid_pep *pep)
+{
+	UET_FI_UNUSED(pep); return -FI_ENOSYS;
+}
+
+int uet_fi_no_accept(struct fid_ep *ep, const void *param, size_t paramlen)
+{
+	UET_FI_UNUSED(ep); UET_FI_UNUSED(param); UET_FI_UNUSED(paramlen);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_reject(struct fid_pep *pep, fid_t handle, const void *param,
+		     size_t paramlen)
+{
+	UET_FI_UNUSED(pep); UET_FI_UNUSED(handle); UET_FI_UNUSED(param);
+	UET_FI_UNUSED(paramlen);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_shutdown(struct fid_ep *ep, uint64_t flags)
+{
+	UET_FI_UNUSED(ep); UET_FI_UNUSED(flags); return -FI_ENOSYS;
+}
+
+int uet_fi_no_join(struct fid_ep *ep, const void *addr, uint64_t flags,
+		   struct fid_mc **mc, void *context)
+{
+	UET_FI_UNUSED(ep); UET_FI_UNUSED(addr); UET_FI_UNUSED(flags);
+	UET_FI_UNUSED(mc); UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+ssize_t uet_fi_no_msg_inject(struct fid_ep *ep, const void *buf, size_t len,
+			     fi_addr_t dest_addr)
+{
+	UET_FI_UNUSED(ep); UET_FI_UNUSED(buf); UET_FI_UNUSED(len);
+	UET_FI_UNUSED(dest_addr);
+	return -FI_ENOSYS;
+}
+
+ssize_t uet_fi_no_msg_senddata(struct fid_ep *ep, const void *buf, size_t len,
+			       void *desc, uint64_t data, fi_addr_t dest_addr,
+			       void *context)
+{
+	UET_FI_UNUSED(ep); UET_FI_UNUSED(buf); UET_FI_UNUSED(len);
+	UET_FI_UNUSED(desc); UET_FI_UNUSED(data); UET_FI_UNUSED(dest_addr);
+	UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+ssize_t uet_fi_no_msg_injectdata(struct fid_ep *ep, const void *buf,
+				 size_t len, uint64_t data, fi_addr_t dest_addr)
+{
+	UET_FI_UNUSED(ep); UET_FI_UNUSED(buf); UET_FI_UNUSED(len);
+	UET_FI_UNUSED(data); UET_FI_UNUSED(dest_addr);
+	return -FI_ENOSYS;
+}
+
+ssize_t uet_fi_no_tagged_inject(struct fid_ep *ep, const void *buf, size_t len,
+				fi_addr_t dest_addr, uint64_t tag)
+{
+	UET_FI_UNUSED(ep); UET_FI_UNUSED(buf); UET_FI_UNUSED(len);
+	UET_FI_UNUSED(dest_addr); UET_FI_UNUSED(tag);
+	return -FI_ENOSYS;
+}
+
+ssize_t uet_fi_no_tagged_senddata(struct fid_ep *ep, const void *buf,
+				  size_t len, void *desc, uint64_t data,
+				  fi_addr_t dest_addr, uint64_t tag,
+				  void *context)
+{
+	UET_FI_UNUSED(ep); UET_FI_UNUSED(buf); UET_FI_UNUSED(len);
+	UET_FI_UNUSED(desc); UET_FI_UNUSED(data); UET_FI_UNUSED(dest_addr);
+	UET_FI_UNUSED(tag); UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+ssize_t uet_fi_no_tagged_injectdata(struct fid_ep *ep, const void *buf,
+				    size_t len, uint64_t data,
+				    fi_addr_t dest_addr, uint64_t tag)
+{
+	UET_FI_UNUSED(ep); UET_FI_UNUSED(buf); UET_FI_UNUSED(len);
+	UET_FI_UNUSED(data); UET_FI_UNUSED(dest_addr); UET_FI_UNUSED(tag);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_cq_signal(struct fid_cq *cq)
+{
+	UET_FI_UNUSED(cq); return -FI_ENOSYS;
+}
+
+int uet_fi_no_av_insertsvc(struct fid_av *av, const char *node,
+			   const char *service, fi_addr_t *fi_addr,
+			   uint64_t flags, void *context)
+{
+	UET_FI_UNUSED(av); UET_FI_UNUSED(node); UET_FI_UNUSED(service);
+	UET_FI_UNUSED(fi_addr); UET_FI_UNUSED(flags); UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}
+
+int uet_fi_no_av_insertsym(struct fid_av *av, const char *node,
+			   size_t nodecnt, const char *service, size_t svccnt,
+			   fi_addr_t *fi_addr, uint64_t flags, void *context)
+{
+	UET_FI_UNUSED(av); UET_FI_UNUSED(node); UET_FI_UNUSED(nodecnt);
+	UET_FI_UNUSED(service); UET_FI_UNUSED(svccnt); UET_FI_UNUSED(fi_addr);
+	UET_FI_UNUSED(flags); UET_FI_UNUSED(context);
+	return -FI_ENOSYS;
+}

--- a/libfabric-provider/uet_fi_noop.c
+++ b/libfabric-provider/uet_fi_noop.c
@@ -1,7 +1,6 @@
+// SPDX-License-Identifier: MIT
 /*
  * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
- *
- * SPDX-License-Identifier: MIT
  */
 
 #include <rdma/fi_errno.h>

--- a/libfabric-provider/uet_fi_noop.c
+++ b/libfabric-provider/uet_fi_noop.c
@@ -151,7 +151,7 @@ int uet_fi_no_getopt(fid_t fid, int level, int optname, void *optval,
 {
 	UET_FI_UNUSED(fid); UET_FI_UNUSED(level); UET_FI_UNUSED(optname);
 	UET_FI_UNUSED(optval); UET_FI_UNUSED(optlen);
-	return -FI_ENOSYS;
+	return -FI_ENOPROTOOPT;
 }
 
 int uet_fi_no_tx_ctx(struct fid_ep *sep, int index, struct fi_tx_attr *attr,

--- a/libfabric-provider/uet_fi_noop.h
+++ b/libfabric-provider/uet_fi_noop.h
@@ -1,7 +1,6 @@
+/* SPDX-License-Identifier: MIT */
 /*
  * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
- *
- * SPDX-License-Identifier: MIT
  */
 
 #ifndef UET_FI_NOOP_H

--- a/libfabric-provider/uet_fi_noop.h
+++ b/libfabric-provider/uet_fi_noop.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef UET_FI_NOOP_H
+#define UET_FI_NOOP_H
+
+#include <rdma/fi_atomic.h>
+#include <rdma/fi_collective.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_eq.h>
+#include <rdma/fi_tagged.h>
+
+int uet_fi_no_bind(struct fid *fid, struct fid *bfid, uint64_t flags);
+int uet_fi_no_control(struct fid *fid, int command, void *arg);
+int uet_fi_no_ops_open(struct fid *fid, const char *name, uint64_t flags,
+		       void **ops, void *context);
+int uet_fi_no_tostr(const struct fid *fid, char *buf, size_t len);
+int uet_fi_no_ops_set(struct fid *fid, const char *name, uint64_t flags,
+		      void *ops, void *context);
+
+int uet_fi_no_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
+			 struct fid_pep **pep, void *context);
+int uet_fi_no_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+		      struct fid_eq **eq, void *context);
+int uet_fi_no_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+			struct fid_wait **waitset);
+int uet_fi_no_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
+int uet_fi_no_domain2(struct fid_fabric *fabric, struct fi_info *info,
+		      struct fid_domain **domain, uint64_t flags, void *context);
+
+int uet_fi_no_scalable_ep(struct fid_domain *domain, struct fi_info *info,
+			  struct fid_ep **sep, void *context);
+int uet_fi_no_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
+			struct fid_cntr **cntr, void *context);
+int uet_fi_no_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
+			struct fid_poll **pollset);
+int uet_fi_no_stx_context(struct fid_domain *domain, struct fi_tx_attr *attr,
+			  struct fid_stx **stx, void *context);
+int uet_fi_no_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
+			  struct fid_ep **rx_ep, void *context);
+int uet_fi_no_query_atomic(struct fid_domain *domain,
+			   enum fi_datatype datatype, enum fi_op op,
+			   struct fi_atomic_attr *attr, uint64_t flags);
+int uet_fi_no_query_collective(struct fid_domain *domain,
+			       enum fi_collective_op coll,
+			       struct fi_collective_attr *attr, uint64_t flags);
+int uet_fi_no_endpoint2(struct fid_domain *domain, struct fi_info *info,
+			struct fid_ep **ep, uint64_t flags, void *context);
+
+int uet_fi_no_getopt(fid_t fid, int level, int optname, void *optval,
+		     size_t *optlen);
+int uet_fi_no_tx_ctx(struct fid_ep *sep, int index, struct fi_tx_attr *attr,
+		     struct fid_ep **tx_ep, void *context);
+int uet_fi_no_rx_ctx(struct fid_ep *sep, int index, struct fi_rx_attr *attr,
+		     struct fid_ep **rx_ep, void *context);
+ssize_t uet_fi_no_rx_size_left(struct fid_ep *ep);
+ssize_t uet_fi_no_tx_size_left(struct fid_ep *ep);
+
+int uet_fi_no_setname(fid_t fid, void *addr, size_t addrlen);
+int uet_fi_no_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen);
+int uet_fi_no_connect(struct fid_ep *ep, const void *addr, const void *param,
+		      size_t paramlen);
+int uet_fi_no_listen(struct fid_pep *pep);
+int uet_fi_no_accept(struct fid_ep *ep, const void *param, size_t paramlen);
+int uet_fi_no_reject(struct fid_pep *pep, fid_t handle, const void *param,
+		     size_t paramlen);
+int uet_fi_no_shutdown(struct fid_ep *ep, uint64_t flags);
+int uet_fi_no_join(struct fid_ep *ep, const void *addr, uint64_t flags,
+		   struct fid_mc **mc, void *context);
+
+ssize_t uet_fi_no_msg_inject(struct fid_ep *ep, const void *buf, size_t len,
+			     fi_addr_t dest_addr);
+ssize_t uet_fi_no_msg_senddata(struct fid_ep *ep, const void *buf, size_t len,
+			       void *desc, uint64_t data, fi_addr_t dest_addr,
+			       void *context);
+ssize_t uet_fi_no_msg_injectdata(struct fid_ep *ep, const void *buf,
+				 size_t len, uint64_t data,
+				 fi_addr_t dest_addr);
+ssize_t uet_fi_no_tagged_inject(struct fid_ep *ep, const void *buf, size_t len,
+				fi_addr_t dest_addr, uint64_t tag);
+ssize_t uet_fi_no_tagged_senddata(struct fid_ep *ep, const void *buf,
+				  size_t len, void *desc, uint64_t data,
+				  fi_addr_t dest_addr, uint64_t tag,
+				  void *context);
+ssize_t uet_fi_no_tagged_injectdata(struct fid_ep *ep, const void *buf,
+				    size_t len, uint64_t data,
+				    fi_addr_t dest_addr, uint64_t tag);
+int uet_fi_no_cq_signal(struct fid_cq *cq);
+int uet_fi_no_av_insertsvc(struct fid_av *av, const char *node,
+			   const char *service, fi_addr_t *fi_addr,
+			   uint64_t flags, void *context);
+int uet_fi_no_av_insertsym(struct fid_av *av, const char *node,
+			   size_t nodecnt, const char *service, size_t svccnt,
+			   fi_addr_t *fi_addr, uint64_t flags, void *context);
+
+#endif /* UET_FI_NOOP_H */

--- a/libfabric-provider/uet_fi_provider.c
+++ b/libfabric-provider/uet_fi_provider.c
@@ -138,6 +138,7 @@ static int uet_fi_getinfo(uint32_t version, const char *node,
 	void **addr_out;
 	size_t *addrlen_out;
 	uint64_t caps;
+	size_t requested_mr_cnt;
 	bool have_node;
 	int rc;
 
@@ -203,7 +204,10 @@ static int uet_fi_getinfo(uint32_t version, const char *node,
 	info->domain_attr->mr_iov_limit = UET_FI_IOV_LIMIT;
 	info->domain_attr->caps = caps;
 	info->domain_attr->mode = info->mode;
-	info->domain_attr->mr_cnt = UET_DEF_MR_CNT;
+	requested_mr_cnt = hints && hints->domain_attr ?
+		hints->domain_attr->mr_cnt : 0;
+	info->domain_attr->mr_cnt = requested_mr_cnt > UET_FI_DEFAULT_MR_CNT ?
+		requested_mr_cnt : UET_FI_DEFAULT_MR_CNT;
 	info->fabric_attr->prov_version = uet_fi_provider.version;
 	info->fabric_attr->api_version = version;
 

--- a/libfabric-provider/uet_fi_provider.c
+++ b/libfabric-provider/uet_fi_provider.c
@@ -1,7 +1,6 @@
+// SPDX-License-Identifier: MIT
 /*
  * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
- *
- * SPDX-License-Identifier: MIT
  */
 
 #include <arpa/inet.h>

--- a/libfabric-provider/uet_fi_provider.c
+++ b/libfabric-provider/uet_fi_provider.c
@@ -15,7 +15,7 @@
 #include "uet_fi_noop.h"
 
 #define UET_FI_CAPS (FI_MSG | FI_TAGGED | FI_SEND | FI_RECV | \
-		     FI_DIRECTED_RECV | FI_LOCAL_COMM | FI_REMOTE_COMM)
+		     FI_LOCAL_COMM | FI_REMOTE_COMM)
 
 static struct fi_provider uet_fi_provider;
 
@@ -173,7 +173,7 @@ static int uet_fi_getinfo(uint32_t version, const char *node,
 	info->tx_attr->tclass = FI_TC_BEST_EFFORT;
 
 	info->rx_attr->caps = caps & (FI_MSG | FI_TAGGED | FI_RECV |
-				      FI_DIRECTED_RECV | FI_LOCAL_COMM |
+				      FI_LOCAL_COMM |
 				      FI_REMOTE_COMM);
 	info->rx_attr->mode = info->mode;
 	info->rx_attr->msg_order = FI_ORDER_SAS;
@@ -195,10 +195,10 @@ static int uet_fi_getinfo(uint32_t version, const char *node,
 	info->domain_attr->av_type = FI_AV_TABLE;
 	info->domain_attr->mr_mode = FI_MR_ENDPOINT | FI_MR_PROV_KEY;
 	info->domain_attr->mr_key_size = sizeof(uint64_t);
-	info->domain_attr->cq_cnt = 2;
-	info->domain_attr->ep_cnt = 1;
-	info->domain_attr->tx_ctx_cnt = 1;
-	info->domain_attr->rx_ctx_cnt = 1;
+	info->domain_attr->cq_cnt = 2 * UET_FI_DEFAULT_EP_CNT;
+	info->domain_attr->ep_cnt = UET_FI_DEFAULT_EP_CNT;
+	info->domain_attr->tx_ctx_cnt = UET_FI_DEFAULT_EP_CNT;
+	info->domain_attr->rx_ctx_cnt = UET_FI_DEFAULT_EP_CNT;
 	info->domain_attr->max_ep_tx_ctx = 1;
 	info->domain_attr->max_ep_rx_ctx = 1;
 	info->domain_attr->mr_iov_limit = UET_FI_IOV_LIMIT;

--- a/libfabric-provider/uet_fi_provider.c
+++ b/libfabric-provider/uet_fi_provider.c
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2026 Cisco Systems, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <arpa/inet.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rdma/fi_errno.h>
+#include <rdma/providers/fi_prov.h>
+
+#include "uet_fi.h"
+#include "uet_fi_noop.h"
+
+#define UET_FI_CAPS (FI_MSG | FI_TAGGED | FI_SEND | FI_RECV | \
+		     FI_DIRECTED_RECV | FI_LOCAL_COMM | FI_REMOTE_COMM)
+
+static struct fi_provider uet_fi_provider;
+
+static void uet_fi_addr_init(struct uet_addr *addr)
+{
+	memset(addr, 0, sizeof(*addr));
+	addr->ver = UET_ADDR_VERSION;
+	addr->flags = UET_ADDR_FEP_CAP_V | UET_ADDR_FA_V |
+		      UET_ADDR_PID_ON_FEP_V | UET_ADDR_INDEX_V |
+		      UET_ADDR_INITIATOR_V | UET_ADDR_RELATIVE_MODE |
+		      UET_ADDR_IPV4 | UET_ADDR_BIG_MSG_SIZE;
+	addr->fep_cap = UET_FEP_CAP_AI_FULL | UET_FEP_CAP_HPC;
+	addr->pid_on_fep = UET_ADDR_DEF_PID_ON_FEP;
+	addr->start_index = UET_ADDR_DEF_INDEX;
+	addr->num_indices = 1;
+	addr->initiator_id = UET_ADDR_DEF_INITIATOR_ID;
+}
+
+static int uet_fi_parse_node(const char *node, struct uet_addr *addr)
+{
+	struct in_addr in4;
+	struct in6_addr in6;
+
+	uet_fi_addr_init(addr);
+	if (!node || !node[0])
+		return FI_SUCCESS;
+
+	if (inet_pton(AF_INET, node, &in4) == 1) {
+		addr->fa.v4 = ntohl(in4.s_addr);
+		return FI_SUCCESS;
+	}
+
+	if (inet_pton(AF_INET6, node, &in6) == 1) {
+		addr->flags &= ~UET_ADDR_IPV4;
+		addr->flags |= UET_ADDR_IPV6;
+		memcpy(addr->fa.v6, &in6, sizeof(in6));
+		return FI_SUCCESS;
+	}
+
+	return -FI_ENODATA;
+}
+
+static int uet_fi_check_hints(const struct fi_info *hints)
+{
+	if (!hints)
+		return FI_SUCCESS;
+
+	if (hints->caps & ~UET_FI_CAPS)
+		return -FI_ENODATA;
+
+	if (hints->addr_format != FI_FORMAT_UNSPEC)
+		return -FI_ENODATA;
+	if ((hints->src_addr && hints->src_addrlen != sizeof(struct uet_addr)) ||
+	    (hints->dest_addr &&
+	     hints->dest_addrlen != sizeof(struct uet_addr)))
+		return -FI_ENODATA;
+	if ((hints->src_addr &&
+	     ((struct uet_addr *)hints->src_addr)->ver != UET_ADDR_VERSION) ||
+	    (hints->dest_addr &&
+	     ((struct uet_addr *)hints->dest_addr)->ver != UET_ADDR_VERSION))
+		return -FI_ENODATA;
+
+	if (hints->ep_attr && hints->ep_attr->type != FI_EP_UNSPEC &&
+	    hints->ep_attr->type != FI_EP_RDM)
+		return -FI_ENODATA;
+
+	if (hints->domain_attr) {
+		if (hints->domain_attr->threading != FI_THREAD_UNSPEC &&
+		    hints->domain_attr->threading != FI_THREAD_SAFE &&
+		    hints->domain_attr->threading != FI_THREAD_FID &&
+		    hints->domain_attr->threading != FI_THREAD_ENDPOINT)
+			return -FI_ENODATA;
+		if (hints->domain_attr->control_progress != FI_PROGRESS_UNSPEC &&
+		    hints->domain_attr->control_progress != FI_PROGRESS_MANUAL)
+			return -FI_ENODATA;
+		if (hints->domain_attr->data_progress != FI_PROGRESS_UNSPEC &&
+		    hints->domain_attr->data_progress != FI_PROGRESS_MANUAL)
+			return -FI_ENODATA;
+		if (hints->domain_attr->av_type != FI_AV_UNSPEC &&
+		    hints->domain_attr->av_type != FI_AV_TABLE)
+			return -FI_ENODATA;
+	}
+
+	return FI_SUCCESS;
+}
+
+static int uet_fi_set_names(struct fi_info *info)
+{
+	info->fabric_attr->name = strdup(UET_FI_FABRIC_NAME);
+	info->domain_attr->name = strdup(UET_FI_DOMAIN_NAME);
+	/* The libfabric core adds the provider name to returned fi_info. Setting
+	 * it here would make the provider look like a utility stack (uet;uet).
+	 */
+	if (!info->fabric_attr->name || !info->domain_attr->name)
+		return -FI_ENOMEM;
+	return FI_SUCCESS;
+}
+
+static int uet_fi_copy_addr(void **dst, size_t *dstlen, const void *src,
+			    size_t srclen)
+{
+	if (!src)
+		return FI_SUCCESS;
+	*dst = malloc(srclen);
+	if (!*dst)
+		return -FI_ENOMEM;
+	memcpy(*dst, src, srclen);
+	*dstlen = srclen;
+	return FI_SUCCESS;
+}
+
+static int uet_fi_getinfo(uint32_t version, const char *node,
+			  const char *service, uint64_t flags,
+			  const struct fi_info *hints, struct fi_info **info_out)
+{
+	struct fi_info *info;
+	struct uet_addr addr;
+	void **addr_out;
+	size_t *addrlen_out;
+	uint64_t caps;
+	bool have_node;
+	int rc;
+
+	(void)service; /* UET addressing has no port/service component. */
+
+	rc = uet_fi_check_hints(hints);
+	if (rc)
+		return rc;
+
+	info = fi_allocinfo();
+	if (!info)
+		return -FI_ENOMEM;
+
+	rc = uet_fi_set_names(info);
+	if (rc)
+		goto err;
+
+	caps = hints && hints->caps ? hints->caps : UET_FI_CAPS;
+	if (caps & (FI_MSG | FI_TAGGED))
+		caps |= FI_SEND | FI_RECV;
+	info->caps = caps;
+	info->mode = hints ? hints->mode & (FI_CONTEXT | FI_CONTEXT2) : 0;
+	info->addr_format = FI_FORMAT_UNSPEC;
+
+	info->tx_attr->caps = caps & (FI_MSG | FI_TAGGED | FI_SEND |
+				      FI_LOCAL_COMM | FI_REMOTE_COMM);
+	info->tx_attr->mode = info->mode;
+	info->tx_attr->msg_order = FI_ORDER_SAS;
+	info->tx_attr->size = UET_FI_DEFAULT_QUEUE;
+	info->tx_attr->iov_limit = UET_FI_IOV_LIMIT;
+	info->tx_attr->rma_iov_limit = UET_FI_IOV_LIMIT;
+	info->tx_attr->tclass = FI_TC_BEST_EFFORT;
+
+	info->rx_attr->caps = caps & (FI_MSG | FI_TAGGED | FI_RECV |
+				      FI_DIRECTED_RECV | FI_LOCAL_COMM |
+				      FI_REMOTE_COMM);
+	info->rx_attr->mode = info->mode;
+	info->rx_attr->msg_order = FI_ORDER_SAS;
+	info->rx_attr->size = UET_FI_DEFAULT_QUEUE;
+	info->rx_attr->iov_limit = UET_FI_IOV_LIMIT;
+
+	info->ep_attr->type = FI_EP_RDM;
+	info->ep_attr->protocol = FI_PROTO_UNSPEC;
+	info->ep_attr->protocol_version = 0;
+	info->ep_attr->max_msg_size = UET_FI_MAX_MSG_SIZE;
+	info->ep_attr->mem_tag_format = UINT64_MAX;
+	info->ep_attr->tx_ctx_cnt = 1;
+	info->ep_attr->rx_ctx_cnt = 1;
+
+	info->domain_attr->threading = FI_THREAD_SAFE;
+	info->domain_attr->control_progress = FI_PROGRESS_MANUAL;
+	info->domain_attr->data_progress = FI_PROGRESS_MANUAL;
+	info->domain_attr->resource_mgmt = FI_RM_ENABLED;
+	info->domain_attr->av_type = FI_AV_TABLE;
+	info->domain_attr->mr_mode = FI_MR_ENDPOINT | FI_MR_PROV_KEY;
+	info->domain_attr->mr_key_size = sizeof(uint64_t);
+	info->domain_attr->cq_cnt = 2;
+	info->domain_attr->ep_cnt = 1;
+	info->domain_attr->tx_ctx_cnt = 1;
+	info->domain_attr->rx_ctx_cnt = 1;
+	info->domain_attr->max_ep_tx_ctx = 1;
+	info->domain_attr->max_ep_rx_ctx = 1;
+	info->domain_attr->mr_iov_limit = UET_FI_IOV_LIMIT;
+	info->domain_attr->caps = caps;
+	info->domain_attr->mode = info->mode;
+	info->domain_attr->mr_cnt = UET_DEF_MR_CNT;
+	info->fabric_attr->prov_version = uet_fi_provider.version;
+	info->fabric_attr->api_version = version;
+
+	have_node = node && node[0];
+	if (!have_node && hints) {
+		rc = uet_fi_copy_addr(&info->src_addr, &info->src_addrlen,
+				      hints->src_addr, hints->src_addrlen);
+		if (rc)
+			goto err;
+		rc = uet_fi_copy_addr(&info->dest_addr, &info->dest_addrlen,
+				      hints->dest_addr, hints->dest_addrlen);
+		if (rc)
+			goto err;
+	}
+	if (have_node) {
+		rc = uet_fi_parse_node(node, &addr);
+		if (rc)
+			goto err;
+
+		if (flags & FI_SOURCE) {
+			addr_out = &info->src_addr;
+			addrlen_out = &info->src_addrlen;
+		} else {
+			addr_out = &info->dest_addr;
+			addrlen_out = &info->dest_addrlen;
+		}
+
+		*addr_out = malloc(sizeof(addr));
+		if (!*addr_out) {
+			rc = -FI_ENOMEM;
+			goto err;
+		}
+		memcpy(*addr_out, &addr, sizeof(addr));
+		*addrlen_out = sizeof(addr);
+	}
+
+	/* When a destination was supplied, retain its address family as a source
+	 * selector. With no node, leave the source unset so the selected engine
+	 * can choose from the addresses actually present on its interface.
+	 * fi_getname() returns the concrete address after endpoint creation.
+	 */
+	if (have_node && !(flags & FI_SOURCE)) {
+		info->src_addr = malloc(sizeof(addr));
+		if (!info->src_addr) {
+			rc = -FI_ENOMEM;
+			goto err;
+		}
+		uet_fi_addr_init(info->src_addr);
+		if (uet_addr_is_ipv6(&addr)) {
+			((struct uet_addr *)info->src_addr)->flags &= ~UET_ADDR_IPV4;
+			((struct uet_addr *)info->src_addr)->flags |= UET_ADDR_IPV6;
+		}
+		info->src_addrlen = sizeof(addr);
+	}
+
+	*info_out = info;
+	return FI_SUCCESS;
+
+err:
+	fi_freeinfo(info);
+	return rc;
+}
+
+static int uet_fi_fabric_close(struct fid *fid)
+{
+	struct uet_fi_fabric *fabric;
+	int rc;
+
+	fabric = UET_FI_CONTAINER(fid, struct uet_fi_fabric, fabric_fid.fid);
+	if (atomic_load_explicit(&fabric->refs, memory_order_acquire))
+		return -FI_EBUSY;
+
+	rc = fabric->engine.finalize(fabric->uet);
+	if (rc)
+		return rc;
+	uet_fi_engine_unload(&fabric->engine);
+	free(fabric);
+	return FI_SUCCESS;
+}
+
+static struct fi_ops uet_fi_fabric_fid_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = uet_fi_fabric_close,
+	.bind = uet_fi_no_bind,
+	.control = uet_fi_no_control,
+	.ops_open = uet_fi_no_ops_open,
+	.tostr = uet_fi_no_tostr,
+	.ops_set = uet_fi_no_ops_set,
+};
+
+static struct fi_ops_fabric uet_fi_fabric_ops = {
+	.size = sizeof(struct fi_ops_fabric),
+	.domain = uet_fi_domain_open,
+	.passive_ep = uet_fi_no_passive_ep,
+	.eq_open = uet_fi_eq_open,
+	.wait_open = uet_fi_no_wait_open,
+	.trywait = uet_fi_no_trywait,
+	.domain2 = uet_fi_no_domain2,
+};
+
+static int uet_fi_fabric_open(struct fi_fabric_attr *attr,
+			      struct fid_fabric **fabric_out, void *context)
+{
+	struct uet_fi_fabric *fabric;
+	int rc;
+
+	if (!attr || (attr->name && strcmp(attr->name, UET_FI_FABRIC_NAME)) ||
+	    (attr->prov_name && strcmp(attr->prov_name, UET_FI_PROV_NAME)))
+		return -FI_ENODATA;
+
+	fabric = calloc(1, sizeof(*fabric));
+	if (!fabric)
+		return -FI_ENOMEM;
+
+	rc = uet_fi_engine_load(&fabric->engine);
+	if (rc)
+		goto err_free;
+
+	rc = fabric->engine.initialize(&fabric->uet);
+	if (rc)
+		goto err_unload;
+
+	fabric->fabric_fid.fid.fclass = FI_CLASS_FABRIC;
+	fabric->fabric_fid.fid.context = context;
+	fabric->fabric_fid.fid.ops = &uet_fi_fabric_fid_ops;
+	fabric->fabric_fid.ops = &uet_fi_fabric_ops;
+	fabric->fabric_fid.api_version = attr->api_version;
+	atomic_init(&fabric->refs, 0);
+	atomic_init(&fabric->domain_open, false);
+	*fabric_out = &fabric->fabric_fid;
+	return FI_SUCCESS;
+
+err_unload:
+	uet_fi_engine_unload(&fabric->engine);
+err_free:
+	free(fabric);
+	return rc;
+}
+
+static void uet_fi_cleanup(void)
+{
+}
+
+static struct fi_provider uet_fi_provider = {
+	.version = FI_VERSION(0, 1),
+	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
+	.name = UET_FI_PROV_NAME,
+	.getinfo = uet_fi_getinfo,
+	.fabric = uet_fi_fabric_open,
+	.cleanup = uet_fi_cleanup,
+};
+
+FI_EXT_INI
+{
+	return &uet_fi_provider;
+}

--- a/libfabric-provider/uet_fi_provider.c
+++ b/libfabric-provider/uet_fi_provider.c
@@ -86,6 +86,8 @@ static int uet_fi_check_hints(const struct fi_info *hints)
 		if (hints->domain_attr->threading != FI_THREAD_UNSPEC &&
 		    hints->domain_attr->threading != FI_THREAD_SAFE &&
 		    hints->domain_attr->threading != FI_THREAD_FID &&
+		    hints->domain_attr->threading != FI_THREAD_DOMAIN &&
+		    hints->domain_attr->threading != FI_THREAD_COMPLETION &&
 		    hints->domain_attr->threading != FI_THREAD_ENDPOINT)
 			return -FI_ENODATA;
 		if (hints->domain_attr->control_progress != FI_PROGRESS_UNSPEC &&

--- a/nic_shim/uet_nic.c
+++ b/nic_shim/uet_nic.c
@@ -371,7 +371,8 @@ int uet_nic_initialize(struct uet_nic *nic)
 		nic->nic_finalize    = nic_rawsock_finalize;
 		nic->nic_initialize  = nic_rawsock_initialize;
 #if ENABLE_XDP
-	} else if (strcmp(nic_shim, "xdp") == 0) {
+	} else if ((strcmp(nic_shim, "xdp") == 0) ||
+		   (strcmp(nic_shim, "af_xdp") == 0)) {
 		nic->nic_getinfo     = nic_xdp_getinfo;
 		nic->nic_tx_pkt      = nic_xdp_tx_pkt;
 		nic->nic_rx_pkt      = nic_xdp_rx_pkt;

--- a/uet_api.c
+++ b/uet_api.c
@@ -34,7 +34,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
-#include <string.h>
 #include <time.h>
 
 #include "uet_addr.h"
@@ -203,6 +202,11 @@ static void uet_dealloc_mr_desc(struct uet_domain *uet_dom,
 	size_t offset;
 	size_t mr_index;
 
+	if ((mr_desc->state != UET_MR_DESC_STATE_INACTIVE) &&
+	    (mr_desc->buf_desc.type == UET_MR_BUF_TYPE_IOV))
+		free((void *)mr_desc->buf_desc.iov.iov);
+
+	memset(mr_desc, 0, sizeof(*mr_desc));
 	mr_desc->state = UET_MR_DESC_STATE_INACTIVE;
 
 	offset = ((uint8_t *) mr_desc) - ((uint8_t *) uet_dom->mr_desc);
@@ -1985,17 +1989,20 @@ static bool uet_domain_has_ep(struct uet_domain *uet_dom)
 static void uet_domain_free(struct uet_domain *uet_dom)
 {
 	struct dlist_entry *item;
-	struct iovec *iov;
+	size_t i;
 
 	item = &uet_dom->domain_list_entry;
-	iov = (struct iovec *)uet_dom->mr_desc->buf_desc.iov.iov;
 	dlist_remove(item);
 	if (uet_dom->mr_desc_alloc_cb.state)
 		free(uet_dom->mr_desc_alloc_cb.state);
 	if (uet_dom->mr_desc) {
-		if (iov)
-			free(iov);
-
+		for (i = 0; i < uet_dom->num_mr; i++) {
+			if ((uet_dom->mr_desc[i].state !=
+			     UET_MR_DESC_STATE_INACTIVE) &&
+			    (uet_dom->mr_desc[i].buf_desc.type ==
+			     UET_MR_BUF_TYPE_IOV))
+				free((void *)uet_dom->mr_desc[i].buf_desc.iov.iov);
+		}
 		free(uet_dom->mr_desc);
 	}
 	free(uet_dom);
@@ -5733,16 +5740,104 @@ static int uet_fid_nic_close(struct fid *fid)
 	if (nic == NULL)
 		return 0;
 
-	if (nic->device_attr != NULL)
+	if (nic->device_attr != NULL) {
+		free(nic->device_attr->name);
+		free(nic->device_attr->device_id);
+		free(nic->device_attr->device_version);
+		free(nic->device_attr->vendor_id);
+		free(nic->device_attr->driver);
+		free(nic->device_attr->firmware);
 		free(nic->device_attr);
-	if (nic->link_attr != NULL)
+	}
+	free(nic->bus_attr);
+	if (nic->link_attr != NULL) {
+		free(nic->link_attr->network_type);
+		free(nic->link_attr->address);
 		free(nic->link_attr);
-	if (nic->fid.ops != NULL)
-		free(nic->fid.ops);
+	}
 	free(nic);
 
 	return 0;
 }
+
+static int uet_fid_nic_control(struct fid *fid, int command, void *arg)
+{
+	struct fid_nic *nic = (struct fid_nic *)fid;
+	struct fid_nic *dup;
+
+	if (command != FI_DUP)
+		return -FI_ENOSYS;
+	if (arg == NULL)
+		return -FI_EINVAL;
+
+	dup = calloc(1, sizeof(*dup));
+	if (dup == NULL)
+		return -FI_ENOMEM;
+	dup->fid = nic->fid;
+	dup->prov_attr = nic->prov_attr;
+
+	if (nic->device_attr != NULL) {
+		dup->device_attr = calloc(1, sizeof(*dup->device_attr));
+		if (dup->device_attr == NULL)
+			goto err;
+#define UET_DUP_NIC_STRING(_field)                                      \
+		do {                                                        \
+			if (nic->device_attr->_field != NULL) {              \
+				dup->device_attr->_field =                      \
+					strdup(nic->device_attr->_field);        \
+				if (dup->device_attr->_field == NULL)            \
+					goto err;                                 \
+			}                                                   \
+		} while (0)
+		UET_DUP_NIC_STRING(name);
+		UET_DUP_NIC_STRING(device_id);
+		UET_DUP_NIC_STRING(device_version);
+		UET_DUP_NIC_STRING(vendor_id);
+		UET_DUP_NIC_STRING(driver);
+		UET_DUP_NIC_STRING(firmware);
+#undef UET_DUP_NIC_STRING
+	}
+
+	if (nic->bus_attr != NULL) {
+		dup->bus_attr = malloc(sizeof(*dup->bus_attr));
+		if (dup->bus_attr == NULL)
+			goto err;
+		*dup->bus_attr = *nic->bus_attr;
+	}
+
+	if (nic->link_attr != NULL) {
+		dup->link_attr = calloc(1, sizeof(*dup->link_attr));
+		if (dup->link_attr == NULL)
+			goto err;
+		*dup->link_attr = *nic->link_attr;
+		dup->link_attr->network_type = NULL;
+		dup->link_attr->address = NULL;
+		if (nic->link_attr->network_type != NULL) {
+			dup->link_attr->network_type =
+				strdup(nic->link_attr->network_type);
+			if (dup->link_attr->network_type == NULL)
+				goto err;
+		}
+		if (nic->link_attr->address != NULL) {
+			dup->link_attr->address = strdup(nic->link_attr->address);
+			if (dup->link_attr->address == NULL)
+				goto err;
+		}
+	}
+
+	*(struct fid_nic **)arg = dup;
+	return FI_SUCCESS;
+
+err:
+	uet_fid_nic_close(&dup->fid);
+	return -FI_ENOMEM;
+}
+
+static struct fi_ops uet_fid_nic_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = uet_fid_nic_close,
+	.control = uet_fid_nic_control,
+};
 
 int uet_getinfo(uet_handle_t handle, struct uet_addr *node,
 		const struct fi_info *hints, struct fi_info **info)
@@ -5793,15 +5888,7 @@ int uet_getinfo(uet_handle_t handle, struct uet_addr *node,
 	nic->fid.fclass = FI_CLASS_NIC;
 	nic->fid.context = uet;
 
-	nic->fid.ops = calloc(1, sizeof(struct fi_ops));
-	if (nic->link_attr == NULL) {
-		UET_API_PRINT_ERRNO("calloc");
-		rc = -FI_ENOMEM;
-		goto err_return;
-	}
-
-	nic->fid.ops->size = sizeof(struct fi_ops);
-	nic->fid.ops->close = uet_fid_nic_close;
+	nic->fid.ops = &uet_fid_nic_ops;
 
 	rc = uet_nic_getinfo(UET_NIC(uet), &nic_info);
 	if (rc != FI_SUCCESS) {
@@ -5809,9 +5896,16 @@ int uet_getinfo(uet_handle_t handle, struct uet_addr *node,
 		goto err_return;
 	}
 
-	nic->device_attr->name       = nic_info.ifname;
-	nic->link_attr->network_type = nic_info.network_type;
-	nic->link_attr->address      = nic_info.mac_addr_str;
+	nic->device_attr->name = strdup(nic_info.ifname);
+	nic->link_attr->network_type = strdup(nic_info.network_type);
+	nic->link_attr->address = strdup(nic_info.mac_addr_str);
+	if (nic->device_attr->name == NULL ||
+	    nic->link_attr->network_type == NULL ||
+	    nic->link_attr->address == NULL) {
+		UET_API_PRINT_ERRNO("strdup");
+		rc = -FI_ENOMEM;
+		goto err_return;
+	}
 	nic->link_attr->mtu          = nic_info.mtu;
 	nic->link_attr->state        =
 		(nic_info.link_state == UET_NIC_LINK_STATE_DOWN)
@@ -5877,15 +5971,8 @@ int uet_getinfo(uet_handle_t handle, struct uet_addr *node,
 	return FI_SUCCESS;
 
 err_return:
-	if (nic != NULL) {
-		if (nic->device_attr != NULL)
-			free(nic->device_attr);
-		if (nic->link_attr != NULL)
-			free(nic->link_attr);
-		if (nic->fid.ops != NULL)
-			free(nic->fid.ops);
-		free(nic);
-	}
+	if (nic != NULL)
+		uet_fid_nic_close(&nic->fid);
 	if (new_info != NULL) {
 #if ENABLE_VERBS
 		uet_verbs_fi_freeinfo(new_info);
@@ -6832,16 +6919,23 @@ int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
 			return rc;
 	}
 
-	/* allocate iov and init */
-	iov_handle = calloc(iov_count, sizeof(struct iovec));
-	if (iov_handle == NULL) {
-		uet_dealloc_mr_desc(uet_dom, &uet_dom->mr_desc[mr_index]);
-		return -FI_ENOMEM;
+	/* A contiguous registration stores the buffer directly. Only retain a
+	 * private iovec copy for a real scatter/gather registration.
+	 */
+	iov_handle = NULL;
+	if (iov_count > 1) {
+		iov_handle = calloc(iov_count, sizeof(struct iovec));
+		if (iov_handle == NULL) {
+			uet_dealloc_mr_desc(uet_dom,
+					    &uet_dom->mr_desc[mr_index]);
+			return -FI_ENOMEM;
+		}
 	}
 
 	for (int i = 0; i < iov_count; i++) {
 		msg_len += iov[i].iov_len;
-		iov_handle[i] = iov[i];
+		if (iov_handle)
+			iov_handle[i] = iov[i];
 	}
 
 	/* init memory region descriptor */
@@ -7023,6 +7117,12 @@ int uet_mr_close(uet_mr_handle_t mr_handle)
 		UET_API_ERR("Can not close unregistered MR");
 		return -FI_EINVAL;
 	case UET_MR_DESC_STATE_DISABLED_BIND:
+		/* Binding is a control-plane association and has no outstanding
+		 * dataplane state until enable. Permit normal libfabric cleanup of
+		 * a registered-and-bound MR that was never enabled.
+		 */
+		mr_desc->uet_ep = NULL;
+		break;
 	case UET_MR_DESC_STATE_ENABLED:
 		UET_API_ERR("Can not close MR that is bound to EP");
 		return -FI_EINVAL;

--- a/uet_api.c
+++ b/uet_api.c
@@ -879,6 +879,10 @@ static void uet_ep_key_init(struct uet_ep_key *key,
 		key->ip_addr.v4 = ntohl(ipv4->daddr);
 	}
 
+	key->absolute = !(ses->cmn.ver_flags & UET_SES_REQ_FLAG_REL);
+	if (!key->absolute)
+		key->job_id = uet_get_std_req_job_id(ses);
+
 	key->pid_on_fep =
 		(ntohs(ses->cmn.rsvd_pid_on_fep) & UET_SES_REQ_PID_ON_FEP_MASK)
 		>> UET_SES_REQ_PID_ON_FEP_SHIFT;
@@ -887,17 +891,61 @@ static void uet_ep_key_init(struct uet_ep_key *key,
 		UET_SES_REQ_RES_INDEX_SHIFT;
 }
 
-/* insert entry into ip endpoint hash table */
-static void uet_ep_hash_insert(struct uet_ep *uet_ep)
+static void uet_ep_key_init_local(struct uet_ep *uet_ep, uint16_t index)
+{
+	struct uet_ep_key *key = &uet_ep->ep_key;
+
+	memset(key, 0, sizeof(*key));
+	key->ipv6_addr = uet_addr_is_ipv6(&uet_ep->uet_addr);
+	key->absolute = uet_ep->absolute;
+	memcpy(&key->ip_addr, &uet_ep->ip_addr, sizeof(key->ip_addr));
+	if (!key->absolute)
+		key->job_id = uet_ep->job_id;
+	key->pid_on_fep = uet_ep->uet_addr.pid_on_fep;
+	key->index = index;
+}
+
+/*
+ * Insert an endpoint in the receive lookup table.  Software backends do not
+ * yet have an external address allocator, so allocate the first free resource
+ * index starting at the advertised index.  Explicit (verbs) addresses must be
+ * unique and are rejected rather than silently creating an ambiguous hash
+ * entry.
+ */
+static int uet_ep_hash_insert(struct uet_ep *uet_ep, bool allocate_index)
 {
 	struct uet_instance *uet;
+	struct uet_ep *existing;
+	uint32_t candidate, max_index;
 
 	uet = uet_ep->uet_domain->uet;
+	max_index = UET_SES_REQ_RES_INDEX_MASK >> UET_SES_REQ_RES_INDEX_SHIFT;
+	candidate = uet_ep->uet_addr.start_index;
 
 	uet_rw_lock(&uet->ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
+	for (; candidate <= max_index; candidate++) {
+		uet_ep_key_init_local(uet_ep, (uint16_t)candidate);
+		HASH_FIND(ep_hh, uet->ep_hash_table, &uet_ep->ep_key,
+			  sizeof(struct uet_ep_key), existing);
+		if (existing == NULL)
+			break;
+		if (!allocate_index) {
+			uet_rw_unlock(&uet->ep_lkup_lock,
+				       UET_RW_LOCK_WR_ACCESS);
+			return -FI_EADDRINUSE;
+		}
+	}
+	if (candidate > max_index) {
+		uet_rw_unlock(&uet->ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
+		return -FI_ENOSPC;
+	}
+
+	uet_ep->uet_addr.start_index = (uint16_t)candidate;
 	HASH_ADD(ep_hh, uet->ep_hash_table, ep_key,
 		 sizeof(struct uet_ep_key), uet_ep);
 	uet_rw_unlock(&uet->ep_lkup_lock, UET_RW_LOCK_WR_ACCESS);
+
+	return FI_SUCCESS;
 }
 
 /* remove entry from ip endpoint hash table */
@@ -6107,6 +6155,7 @@ int uet_endpoint(uet_domain_handle_t domain_handle,
 {
 	int rc;
 	size_t i;
+	bool data_lock_initialized = false;
 	struct uet_domain *uet_dom;
 	struct uet_ep *uet_ep;
 	struct uet_pds *pds;
@@ -6122,7 +6171,12 @@ int uet_endpoint(uet_domain_handle_t domain_handle,
 		goto err_exit;
 	}
 
-	pthread_mutex_init(&uet_ep->data_lock, NULL);
+	rc = pthread_mutex_init(&uet_ep->data_lock, NULL);
+	if (rc != 0) {
+		rc = -FI_EOTHER;
+		goto err_exit;
+	}
+	data_lock_initialized = true;
 
 	/* init ep object */
 	memcpy(&uet_ep->uet_addr, info->src_addr, info->src_addrlen);
@@ -6156,6 +6210,16 @@ int uet_endpoint(uet_domain_handle_t domain_handle,
 	}
 #endif
 	memcpy(&uet_ep->ip_addr, &uet_ep->uet_addr.fa, sizeof(struct uet_fa));
+	if (uet_ep->uet_addr.pid_on_fep >
+	    (UET_SES_REQ_PID_ON_FEP_MASK >> UET_SES_REQ_PID_ON_FEP_SHIFT) ||
+	    uet_ep->uet_addr.start_index >
+	    (UET_SES_REQ_RES_INDEX_MASK >> UET_SES_REQ_RES_INDEX_SHIFT) ||
+	    (!uet_ep->absolute &&
+	     uet_ep->job_id >
+	     (UET_SES_REQ_JOB_ID_MASK >> UET_SES_REQ_JOB_ID_SHIFT))) {
+		rc = -FI_EINVAL;
+		goto err_exit;
+	}
 
 	uet_ep->num_rx_desc = info->rx_attr->size;
 	uet_ep->rx_desc = calloc(uet_ep->num_rx_desc,
@@ -6217,13 +6281,16 @@ int uet_endpoint(uet_domain_handle_t domain_handle,
 	uet_ep->send_cq.cq_state = UET_CQ_DOWN;
 	uet_ep->recv_cq.cq_state = UET_CQ_DOWN;
 
-	if (uet_ep->uet_addr.flags & UET_ADDR_IPV6)
-		uet_ep->ep_key.ipv6_addr = true;
-	memcpy(&uet_ep->ep_key.ip_addr, &uet_ep->ip_addr,
-	       sizeof(struct uet_fa));
-	uet_ep->ep_key.pid_on_fep = uet_ep->uet_addr.pid_on_fep;
-	uet_ep->ep_key.index = uet_ep->uet_addr.start_index;
-	uet_ep_hash_insert(uet_ep);
+	rc = uet_ep_hash_insert(uet_ep, !ENABLE_VERBS);
+	if (rc != FI_SUCCESS) {
+		if (rc == -FI_EADDRINUSE)
+			UET_API_ERR("endpoint address is already in use");
+		else if (rc == -FI_ENOSPC)
+			UET_API_ERR("no endpoint Resource Index is available");
+		else
+			UET_API_ERR("failed to allocate endpoint address");
+		goto err_exit;
+	}
 
 	switch (info->tx_attr->tclass) {
 	case FI_TC_BEST_EFFORT:
@@ -6247,6 +6314,8 @@ int uet_endpoint(uet_domain_handle_t domain_handle,
 err_exit:
 	if (uet_ep) {
 		uet_desc_free(uet_ep);
+		if (data_lock_initialized)
+			pthread_mutex_destroy(&uet_ep->data_lock);
 		free(uet_ep);
 	}
 	return rc;

--- a/uet_api.c
+++ b/uet_api.c
@@ -5808,6 +5808,18 @@ static int uet_fid_nic_close(struct fid *fid)
 	return 0;
 }
 
+static int uet_dup_string(char **destination, const char *source)
+{
+	if (source == NULL)
+		return FI_SUCCESS;
+
+	*destination = strdup(source);
+	if (*destination == NULL)
+		return -FI_ENOMEM;
+
+	return FI_SUCCESS;
+}
+
 static int uet_fid_nic_control(struct fid *fid, int command, void *arg)
 {
 	struct fid_nic *nic = (struct fid_nic *)fid;
@@ -5828,22 +5840,19 @@ static int uet_fid_nic_control(struct fid *fid, int command, void *arg)
 		dup->device_attr = calloc(1, sizeof(*dup->device_attr));
 		if (dup->device_attr == NULL)
 			goto err;
-#define UET_DUP_NIC_STRING(_field)                                      \
-		do {                                                        \
-			if (nic->device_attr->_field != NULL) {              \
-				dup->device_attr->_field =                      \
-					strdup(nic->device_attr->_field);        \
-				if (dup->device_attr->_field == NULL)            \
-					goto err;                                 \
-			}                                                   \
-		} while (0)
-		UET_DUP_NIC_STRING(name);
-		UET_DUP_NIC_STRING(device_id);
-		UET_DUP_NIC_STRING(device_version);
-		UET_DUP_NIC_STRING(vendor_id);
-		UET_DUP_NIC_STRING(driver);
-		UET_DUP_NIC_STRING(firmware);
-#undef UET_DUP_NIC_STRING
+		if (uet_dup_string(&dup->device_attr->name,
+				   nic->device_attr->name) != FI_SUCCESS ||
+		    uet_dup_string(&dup->device_attr->device_id,
+				   nic->device_attr->device_id) != FI_SUCCESS ||
+		    uet_dup_string(&dup->device_attr->device_version,
+				   nic->device_attr->device_version) != FI_SUCCESS ||
+		    uet_dup_string(&dup->device_attr->vendor_id,
+				   nic->device_attr->vendor_id) != FI_SUCCESS ||
+		    uet_dup_string(&dup->device_attr->driver,
+				   nic->device_attr->driver) != FI_SUCCESS ||
+		    uet_dup_string(&dup->device_attr->firmware,
+				   nic->device_attr->firmware) != FI_SUCCESS)
+			goto err;
 	}
 
 	if (nic->bus_attr != NULL) {
@@ -5860,17 +5869,11 @@ static int uet_fid_nic_control(struct fid *fid, int command, void *arg)
 		*dup->link_attr = *nic->link_attr;
 		dup->link_attr->network_type = NULL;
 		dup->link_attr->address = NULL;
-		if (nic->link_attr->network_type != NULL) {
-			dup->link_attr->network_type =
-				strdup(nic->link_attr->network_type);
-			if (dup->link_attr->network_type == NULL)
-				goto err;
-		}
-		if (nic->link_attr->address != NULL) {
-			dup->link_attr->address = strdup(nic->link_attr->address);
-			if (dup->link_attr->address == NULL)
-				goto err;
-		}
+		if (uet_dup_string(&dup->link_attr->network_type,
+				   nic->link_attr->network_type) != FI_SUCCESS ||
+		    uet_dup_string(&dup->link_attr->address,
+				   nic->link_attr->address) != FI_SUCCESS)
+			goto err;
 	}
 
 	*(struct fid_nic **)arg = dup;

--- a/uet_api_private.h
+++ b/uet_api_private.h
@@ -489,7 +489,9 @@ struct uet_tx_rtr_token_cb {
 /* key for endpoint lookup */
 struct uet_ep_key {
 	bool ipv6_addr;
+	bool absolute;
 	struct uet_fa ip_addr;
+	uint32_t job_id;
 	uint16_t pid_on_fep;
 	uint16_t index;
 };

--- a/util/uet_util.h
+++ b/util/uet_util.h
@@ -174,6 +174,7 @@ void uet_update_ipv6_pl(struct ipv6hdr *ipv6, uint16_t payload_len);
 void uet_build_eth_hdr(struct ethhdr *eth, uint8_t *dmac, uint8_t *smac,
 		       bool is_ipv6);
 void uet_pkt_hex_dump(void *pkt, uint32_t length, uint64_t addr, bool is_tx);
+void uet_rw_lock_init(struct uet_rw_lock *lock);
 void uet_rw_lock(struct uet_rw_lock *lock, uet_rw_lock_access_t access);
 void uet_rw_unlock(struct uet_rw_lock *lock, uet_rw_lock_access_t access);
 uint16_t uet_get_ses_req_payload_len(struct uet_parsed_pkt *pp,


### PR DESCRIPTION
## Summary

Add an external libfabric provider named `uet` so an unchanged libfabric
application can use the existing UET reference transport through standard
provider discovery.

The provider:

- exposes `FI_EP_RDM`, `FI_MSG`, `FI_TAGGED`, `FI_AV_TABLE`, completion queues
  and endpoint-bound memory registration;
- runs in the application process and loads the existing raw-socket or AF_XDP
  engine selected by `UET_NIC_SHIM`;
- supports multiple endpoints, distinct software Resource Indices and
  endpoint-index reuse after close;
- keeps backend-specific dependencies out of the provider; and
- adds build documentation, lifecycle coverage and an end-to-end CI exchange
  with an unmodified libfabric application.

## Why a separate provider layer

The existing shared libraries expose the UET engine API, but they are not
discoverable libfabric providers. Implementing the libfabric object model once
keeps application behavior independent of the packet-I/O backend and avoids
duplicating fabric/domain/AV/CQ/EP/MR handling in each engine library.

The transport implementation remains in the existing engine. The provider is
an adapter, not a second transport implementation.

## Generic prerequisites included here

- retain scatter/gather storage owned by memory-region descriptors;
- deep-copy `fid_nic` strings for safe `FI_DUP` and teardown;
- allocate distinct software endpoint indices;
- include addressing mode and JobID in relative receive lookup keys and reject
  duplicate explicit addresses; and
- align advertised threading, endpoint, completion and memory-region resource
  contracts with the implementation.

`FI_DIRECTED_RECV` is intentionally not advertised until remote source
identity is unambiguous for endpoints that may share an Initiator ID.

## Validation

- provider build and `fi_info` discovery with libfabric 1.20.1 and 2.6;
- IPv4 and IPv6 lifecycle smoke tests;
- 32 simultaneous registered memory regions and endpoint-index reuse;
- unmodified `fi_pingpong` MSG and TAGGED data-integrity exchanges;
- raw-socket-to-raw-socket and AF_XDP-to-raw-socket functional paths;
- ASan and UBSan lifecycle run; and
- patch audit with zero `checkpatch` errors.

The CI added by this PR builds the provider in both address-family jobs, runs
the lifecycle smoke test and performs 100 checked MSG exchanges across two
isolated raw-socket endpoints.

## Current scope

RMA, atomics, inject operations, counters, scalable endpoints, shared contexts
and connection-oriented endpoints are not advertised. Progress is manual and
the current engine lifecycle permits one active domain per fabric.
