### PR TITLE
[Superseded by #148 and #150] core: fix type-incorrect state handling

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -64,6 +64,7 @@ jobs:
 
       - name: Compile uet-ref-prov
         run: |
+          make strict-core
           make
 
       - name: Check network brm to vm
@@ -126,4 +127,3 @@ jobs:
               echo "::endgroup::"
             done
           done
-

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,17 @@ VERBS_LIB=lib$(VERBS_LIBNAME).so
 VERBS_LIB_OBJ_DIR=obj_libuet_verbs
 VERBS_LIB_OBJ=$(patsubst %.c, $(VERBS_LIB_OBJ_DIR)/%.o, $(LIB_SRC))
 
+# Compile-only objects used to enforce diagnostics on project sources without
+# inheriting compatibility suppressions needed by the standalone application.
+STRICT_CFLAGS=$(filter-out -Wno-implicit-function-declaration \
+	-Wno-int-conversion,$(CFLAGS)) \
+	-Werror=implicit-function-declaration \
+	-Werror=int-conversion
+STRICT_FABRIC_OBJ_DIR=obj_strict_libuet_fabric
+STRICT_FABRIC_OBJ=$(patsubst %.c, $(STRICT_FABRIC_OBJ_DIR)/%.o, $(LIB_SRC))
+STRICT_VERBS_OBJ_DIR=obj_strict_libuet_verbs
+STRICT_VERBS_OBJ=$(patsubst %.c, $(STRICT_VERBS_OBJ_DIR)/%.o, $(LIB_SRC))
+
 # Main executable
 BIN=uet
 MAIN_SRC=uet.c
@@ -104,6 +115,10 @@ all: $(FABRIC_LIB) $(VERBS_LIB) $(BIN)
 # XDP target
 xdp: $(XDP_BIN) $(XDP_KERN_BIN)
 
+# Check project sources with diagnostics that are suppressed for some external
+# libfabric headers used by the standalone application.
+strict-core: $(STRICT_FABRIC_OBJ) $(STRICT_VERBS_OBJ)
+
 # CC sim target
 cc_sim: $(CC_SIM_BIN)
 
@@ -128,6 +143,18 @@ $(VERBS_LIB_OBJ_DIR)/%.o: %.c $(HDRS)
 $(VERBS_LIB): $(VERBS_LIB_OBJ)
 	@echo 'Building verbs shared library: $@'
 	@$(CC) -shared $(VERBS_LIB_OBJ) -o $@ $(LDFLAGS)
+
+$(STRICT_FABRIC_OBJ_DIR)/%.o: %.c $(HDRS)
+	@mkdir -p $(STRICT_FABRIC_OBJ_DIR)/$(dir $<)
+	@echo 'Strict-checking fabric library object: $<'
+	@$(CC) $(STRICT_CFLAGS) -DENABLE_VERBS=0 $(INCS) $(LF_LOCAL_HDRS) \
+		-fPIC -c -o $@ $<
+
+$(STRICT_VERBS_OBJ_DIR)/%.o: %.c $(HDRS)
+	@mkdir -p $(STRICT_VERBS_OBJ_DIR)/$(dir $<)
+	@echo 'Strict-checking verbs library object: $<'
+	@$(CC) $(STRICT_CFLAGS) -DENABLE_VERBS=1 $(INCS) $(LF_LOCAL_HDRS) \
+		-fPIC -c -o $@ $<
 
 # XDP shared library object files (compiled with -fPIC) (w/ extra CFLAGS)
 $(XDP_LIB_OBJ_DIR)/%.o: %.c $(HDRS)
@@ -180,11 +207,11 @@ $(CC_SIM_BIN): $(CC_SIM_OBJ)
 clean:
 	@rm -rf $(FABRIC_LIB_OBJ_DIR) $(FABRIC_LIB) \
 		$(VERBS_LIB_OBJ_DIR) $(VERBS_LIB) \
+		$(STRICT_FABRIC_OBJ_DIR) $(STRICT_VERBS_OBJ_DIR) \
 		$(OBJ_DIR) $(BIN) \
 		$(XDP_LIB_OBJ_DIR) $(XDP_LIB) \
 		$(XDP_OBJ_DIR) $(XDP_BIN) \
 		$(XDP_KERN_BIN) \
 		$(CC_SIM_OBJ_DIR) $(CC_SIM_BIN)
 
-.PHONY: all xdp cc_sim clean
-
+.PHONY: all xdp strict-core cc_sim clean

--- a/uet_api.c
+++ b/uet_api.c
@@ -2719,7 +2719,7 @@ static uet_ses_rc_t uet_rx_atomic_req_pkt(
 	if (sync_defer_atomic) {
 		entry->atomic_parms.opcode = UET_AMO_SUM;
 		entry->atomic_parms.data_type = UET_TYPE_UINT64;
-		entry->atomic_parms.addr = (uint64_t) addr;
+		entry->atomic_parms.addr = addr;
 		entry->atomic_parms.data = data;
 	} else
 		__atomic_fetch_add(addr, data, __ATOMIC_SEQ_CST);

--- a/util/uet_util.c
+++ b/util/uet_util.c
@@ -1115,7 +1115,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 				return rc;
 			if (ntohs(udp->dest) != uet->uet_udp_port)
 				goto err_exit;
-			pp->entropy = ntohs(udp->source);
+			pp->entropy_val = ntohs(udp->source);
 			pp->udp = p;
 			pp->udp_len = sizeof(struct udphdr);
 			cur_len += pp->udp_len;
@@ -1404,4 +1404,3 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 err_exit:
 	return -EINVAL;
 }
-

--- a/util/uet_util.h
+++ b/util/uet_util.h
@@ -174,6 +174,7 @@ void uet_update_ipv6_pl(struct ipv6hdr *ipv6, uint16_t payload_len);
 void uet_build_eth_hdr(struct ethhdr *eth, uint8_t *dmac, uint8_t *smac,
 		       bool is_ipv6);
 void uet_pkt_hex_dump(void *pkt, uint32_t length, uint64_t addr, bool is_tx);
+void uet_rw_lock_init(struct uet_rw_lock *lock);
 void uet_rw_lock(struct uet_rw_lock *lock, uet_rw_lock_access_t access);
 void uet_rw_unlock(struct uet_rw_lock *lock, uet_rw_lock_access_t access);
 uint16_t uet_get_ses_req_payload_len(struct uet_parsed_pkt *pp,


### PR DESCRIPTION
Correct three type-safety issues hidden by the current warning suppressions:

- store the UDP source port in `entropy_val`, not in the entropy-header pointer
- assign the deferred atomic target as a pointer without an integer round trip
- declare `uet_rw_lock_init` in the utility header

The UDP correction preserves the source-port entropy value while correctly leaving the absent entropy-header pointer null.

Validation:
- reproduced the UDP parser failure against unmodified `main`
- verified UDP source-port entropy parsing after the fix
- completed a full Linux build with `implicit-function-declaration` and `int-conversion` promoted to errors
- completed the normal full Linux build