### PR TITLE
[Superseded by #149] api: own PDS lifetime at the UET instance

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -66,6 +66,16 @@ jobs:
         run: |
           make
 
+      - name: Check PDS instance lifecycle
+        run: |
+          make pds-lifecycle-test
+          for pds in pds sng; do
+            sudo env \
+              LD_LIBRARY_PATH="$PWD:$PWD/../libfabric/src/.libs" \
+              UET_PDS="$pds" \
+              ./obj_tests/test_pds_lifecycle brm
+          done
+
       - name: Check network brm to vm
         run: |
           ping -c1 10.1.0.2
@@ -126,4 +136,3 @@ jobs:
               echo "::endgroup::"
             done
           done
-

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,9 @@ XDP_MAIN_OBJ=$(XDP_OBJ_DIR)/uet.o
 XDP_KERN_SRC=$(wildcard nic_shim/*xdp_kern*)
 XDP_KERN_BIN=uet_xdp_kern.o
 
+TEST_OBJ_DIR=obj_tests
+PDS_LIFECYCLE_TEST_BIN=$(TEST_OBJ_DIR)/test_pds_lifecycle
+
 xdp: CFLAGS+=-DENABLE_XDP -DXDP_PROG=$(XDP_KERN_BIN)
 xdp: LDFLAGS+=-lbpf -lxdp
 
@@ -151,6 +154,14 @@ $(BIN): $(FABRIC_LIB) $(MAIN_OBJ)
 	@echo 'Building program: $@'
 	@$(CC) $(MAIN_OBJ) -o $@ -L. -l$(FABRIC_LIBNAME) $(LDFLAGS) $(LF_LIBS)
 
+$(PDS_LIFECYCLE_TEST_BIN): tests/test_pds_lifecycle.c $(FABRIC_LIB)
+	@mkdir -p $(TEST_OBJ_DIR)
+	@echo 'Building PDS lifecycle test: $@'
+	@$(CC) $(CFLAGS) -DENABLE_VERBS=0 $(INCS) $(LF_HDRS) \
+		-o $@ $< -L. -l$(FABRIC_LIBNAME) $(LDFLAGS) $(LF_LIBS)
+
+pds-lifecycle-test: $(PDS_LIFECYCLE_TEST_BIN)
+
 # XDP executable object file (w/ extra CFLAGS)
 $(XDP_OBJ_DIR)/%.o: %.c $(HDRS)
 	@mkdir -p $(XDP_OBJ_DIR)/$(dir $<)
@@ -184,7 +195,7 @@ clean:
 		$(XDP_LIB_OBJ_DIR) $(XDP_LIB) \
 		$(XDP_OBJ_DIR) $(XDP_BIN) \
 		$(XDP_KERN_BIN) \
+		$(TEST_OBJ_DIR) \
 		$(CC_SIM_OBJ_DIR) $(CC_SIM_BIN)
 
-.PHONY: all xdp cc_sim clean
-
+.PHONY: all xdp pds-lifecycle-test cc_sim clean

--- a/tests/test_pds_lifecycle.c
+++ b/tests/test_pds_lifecycle.c
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rdma/fi_errno.h>
+#include <rdma/fabric.h>
+
+#include "uet_api.h"
+
+static int expect_rc(const char *operation, int rc, int expected)
+{
+	if (rc == expected)
+		return 0;
+
+	fprintf(stderr, "%s returned %d, expected %d\n",
+		operation, rc, expected);
+	return -1;
+}
+
+static int test_failed_initialize(const char *ifname)
+{
+	uet_handle_t uet = NULL;
+	int rc;
+
+	if (setenv("UET_IFNAME", "uetbad0", 1)) {
+		perror("setenv");
+		return -1;
+	}
+
+	rc = uet_initialize(&uet);
+	if (rc == FI_SUCCESS) {
+		fprintf(stderr,
+			"initialization accepted a missing interface\n");
+		uet_finalize(uet);
+		return -1;
+	}
+
+	if (setenv("UET_IFNAME", ifname, 1)) {
+		perror("setenv");
+		return -1;
+	}
+	return 0;
+}
+
+static int test_domain_lifecycle(void)
+{
+	struct fid_fabric fabric = { 0 };
+	struct fid_domain fid_domain[2] = { 0 };
+	struct fid_ep fid_ep[2] = { 0 };
+	uet_domain_handle_t domain[2] = { NULL, NULL };
+	uet_ep_handle_t ep = NULL;
+	uet_handle_t uet = NULL;
+	struct fi_info *info = NULL;
+	int rc;
+
+	rc = uet_initialize(&uet);
+	if (expect_rc("uet_initialize", rc, FI_SUCCESS))
+		return -1;
+
+	rc = uet_getinfo(uet, NULL, NULL, &info);
+	if (expect_rc("uet_getinfo", rc, FI_SUCCESS))
+		return -1;
+
+	for (size_t i = 0; i < 2; i++) {
+		rc = uet_domain(uet, &fabric, info, &fid_domain[i], NULL,
+				NULL, NULL, &domain[i]);
+		if (expect_rc("uet_domain", rc, FI_SUCCESS))
+			return -1;
+	}
+
+	rc = uet_endpoint(domain[0], info, &fid_ep[0], NULL, &ep);
+	if (expect_rc("uet_endpoint(first domain)", rc, FI_SUCCESS))
+		return -1;
+
+	rc = uet_domain_close(domain[0]);
+	if (expect_rc("uet_domain_close(busy)", rc, -FI_EBUSY))
+		return -1;
+
+	/* A rejected domain close must not tear down the shared PDS state. */
+	rc = uet_ep_close(ep);
+	if (expect_rc("uet_ep_close(first domain)", rc, FI_SUCCESS))
+		return -1;
+	ep = NULL;
+
+	rc = uet_domain_close(domain[0]);
+	if (expect_rc("uet_domain_close(first domain)", rc, FI_SUCCESS))
+		return -1;
+	domain[0] = NULL;
+
+	/* Closing one domain must leave the instance usable by another domain. */
+	rc = uet_endpoint(domain[1], info, &fid_ep[1], NULL, &ep);
+	if (expect_rc("uet_endpoint(second domain)", rc, FI_SUCCESS))
+		return -1;
+
+	rc = uet_ep_close(ep);
+	if (expect_rc("uet_ep_close(second domain)", rc, FI_SUCCESS))
+		return -1;
+	ep = NULL;
+
+	rc = uet_domain_close(domain[1]);
+	if (expect_rc("uet_domain_close(second domain)", rc, FI_SUCCESS))
+		return -1;
+	domain[1] = NULL;
+
+	rc = uet_finalize(uet);
+	if (expect_rc("uet_finalize", rc, FI_SUCCESS))
+		return -1;
+	uet = NULL;
+
+	fi_freeinfo(info);
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	const char *pds;
+
+	if (argc != 2) {
+		fprintf(stderr, "usage: %s <interface>\n", argv[0]);
+		return EXIT_FAILURE;
+	}
+
+	pds = getenv("UET_PDS");
+	if (!pds || (strcmp(pds, "pds") && strcmp(pds, "sng"))) {
+		fprintf(stderr, "UET_PDS must be pds or sng\n");
+		return EXIT_FAILURE;
+	}
+
+	if (test_failed_initialize(argv[1]) || test_domain_lifecycle())
+		return EXIT_FAILURE;
+
+	printf("PDS instance lifecycle test passed (%s)\n", pds);
+	return EXIT_SUCCESS;
+}

--- a/uet_api.c
+++ b/uet_api.c
@@ -2027,6 +2027,7 @@ static void uet_finalize_core(struct uet_instance *uet)
 	imp_shim_finalize();
 	uet_nic_finalize(UET_NIC(uet));
 	uet_domain_free_all(uet);
+	uet->pds.downcall.finalize(uet);
 }
 
 /* init rx descriptor used to track errored msg */
@@ -5688,7 +5689,7 @@ int uet_initialize(uet_handle_t *handle)
 	UET_NIC(uet)->uet_ipproto = uet->uet_ipproto;
 	rc = uet_nic_initialize(UET_NIC(uet));
 	if (rc != FI_SUCCESS)
-		goto err_return;
+		goto err_pds;
 
 	rc = imp_shim_init(UET_NIC(uet));
 	if (rc != 0)
@@ -5708,6 +5709,9 @@ err_sec:
 
 err_imp_shim:
 	uet_nic_finalize(UET_NIC(uet));
+
+err_pds:
+	uet->pds.downcall.finalize(uet);
 
 err_return:
 	if (uet != NULL)
@@ -5989,12 +5993,8 @@ err_exit:
 int uet_domain_close(uet_domain_handle_t domain_handle)
 {
 	struct uet_domain *uet_dom;
-	struct uet_pds *pds;
 
 	uet_dom = (struct uet_domain *) domain_handle;
-	pds = &uet_dom->uet->pds;
-
-	pds->downcall.finalize(uet_dom->uet);
 
 	if (uet_domain_has_ep(uet_dom)) {
 		UET_API_ERR("EPs associated with domain being closed");


### PR DESCRIPTION
## Problem

PDS is initialized for a UET instance and shared by its domains, but `uet_domain_close()` currently finalizes it before checking whether the domain still owns endpoints. A rejected close therefore destroys active PDS state, and successfully closing one domain also invalidates other domains on the same instance.

PDS is also left initialized if NIC initialization fails.

## Fix

- finalize PDS during UET instance teardown, after endpoints and domains are released
- finalize PDS when a later initialization stage fails
- add a regression test for a rejected busy close, reuse by a second domain, and failed initialization
- exercise both PDS and SNG in CI

## Validation

- reproduced the failure on current `main`: the busy close returns `-FI_EBUSY`, then endpoint close fails because PDS is no longer ready
- full fabric, verbs, and executable build against libfabric 1.20.1
- regression test passes with `UET_PDS=pds` and `UET_PDS=sng`
- the same two cases pass under ASan+UBSan with leak detection enabled
- `git diff --check` and `checkpatch.pl` clean