### PR TITLE
security: handle overlapping header insertion

### DIFF
--- a/uet_sec.c
+++ b/uet_sec.c
@@ -83,7 +83,7 @@ int uet_sec_build_hdr(uint32_t sdi,
 
 		*new_pkt     = (pkt - sizeof(struct uet_sec_ssi));
 		*new_pkt_len = (pkt_len + sizeof(struct uet_sec_ssi));
-		memcpy(*new_pkt, pkt, copy_len);
+		memmove(*new_pkt, pkt, copy_len);
 	} else {
 		if ((pkt - sizeof(struct uet_sec)) < pkt_buf) {
 			UET_TSS_ERR("no headroom for uet_sec header\n");
@@ -92,7 +92,7 @@ int uet_sec_build_hdr(uint32_t sdi,
 
 		*new_pkt     = (pkt - sizeof(struct uet_sec));
 		*new_pkt_len = (pkt_len + sizeof(struct uet_sec));
-		memcpy(*new_pkt, pkt, copy_len);
+		memmove(*new_pkt, pkt, copy_len);
 	}
 
 	sec = (struct uet_sec *)(*new_pkt + copy_len);
@@ -755,4 +755,3 @@ int uet_sec_dec_pkt(struct uet_instance *uet,
 
 	return 0;
 }
-


### PR DESCRIPTION
> **Public-fork replacement for #136**
> The original PR referenced the detached private fork, which no longer exists. This replacement replays the same patch onto the current `main` after #133. @insanum approved #136 on 2026-09-01 before GitHub closed the legacy PR.
> The stable patch-id remains `efa61074a53dbec6b0096d99def615e94a5d9bf5`; there is no functional change. The original IPv4 and IPv6 CI checks passed.

## Summary

- use memmove while shifting Ethernet, IP, and entropy headers into packet headroom
- preserve the existing packet layout and security-header construction
- avoid undefined behavior from overlapping memcpy ranges in both SSI and non-SSI modes

## Reproducer

A focused harness calls the production uet_sec_build_hdr function with AddressSanitizer enabled.

- current main stops with memcpy-param-overlap at uet_sec.c:95
- this change exits successfully and preserves the shifted headers byte-for-byte

## Validation

- focused AddressSanitizer reproducer before and after the fix
- complete Linux build of the fabric and verbs libraries and the uet binary
- GitHub IPv4 and IPv6 sanity suites
- git diff --check