### PR TITLE
ses: initialize malformed-version response state

### DIFF
--- a/uet_api.c
+++ b/uet_api.c
@@ -3647,6 +3647,15 @@ static int uet_pds_to_ses_rx_req(uet_pkt_handle_t rx_pkt_handle,
 
 	ses_std_req = (struct uet_ses_req_std *) pp->ses;
 	rx_ses_rsp_d = (struct uet_ses_rsp_d *) pp->ses;
+	ses_rsp = (struct uet_ses_rsp *) rsp_ses_hdr;
+	ses_rsp_d = (struct uet_ses_rsp_d *) rsp_ses_hdr;
+
+	list = UET_EXPECTED;
+	*ses_nack = false;
+	ep_gen = 0;
+
+	ses_rsp->cmn.msg_id = ses_std_req->cmn.msg_id;
+	ses_rsp->cmn.ri_gen_job_id = ses_std_req->cmn.ri_gen_job_id;
 
 	ver = (ses_std_req->cmn.ver_flags & UET_SES_VER_MASK) >>
 		UET_SES_VER_SHIFT;
@@ -3657,16 +3666,6 @@ static int uet_pds_to_ses_rx_req(uet_pkt_handle_t rx_pkt_handle,
 		ses_rc = UET_RC_UNCOR;
 		goto build_response;
 	}
-
-	ses_rsp = (struct uet_ses_rsp *) rsp_ses_hdr;
-	ses_rsp_d = (struct uet_ses_rsp_d *) rsp_ses_hdr;
-
-	list = UET_EXPECTED;
-	*ses_nack = false;
-	ep_gen = 0;
-
-	ses_rsp->cmn.msg_id = ses_std_req->cmn.msg_id;
-	ses_rsp->cmn.ri_gen_job_id = ses_std_req->cmn.ri_gen_job_id;
 
 	switch (pp->next_hdr) {
 	case UET_HDR_REQ_STD:


### PR DESCRIPTION
> **Public-fork replacement for #137**
> The original PR referenced the detached private fork, which no longer exists. This replacement replays the same patch onto the current `main` after #133. Review should continue on this public-fork PR.
> The stable patch-id remains `3c0f5f34e0bf2386bbc3405eebc440ccfbfc16b5`; there is no functional change. The original IPv4 and IPv6 CI checks passed.

An unsupported SES version jumps directly to response construction before the response pointer and list state are initialized. This can dereference an indeterminate pointer instead of returning the intended error response.

Move the common response initialization before version validation. The malformed-version path now returns a guaranteed-delivery `UET_RC_UNCOR` response while preserving the request message ID and RI generation/Job ID.

Validation:
- reproduced the original crash with AddressSanitizer
- verified the corrected malformed-version response fields and return code
- verified the focused compiler diagnostics for `ses_rsp` and `list` disappear
- completed a full Linux build