### PR TITLE
api: own PDS lifetime at the UET instance

### DIFF
--- a/uet_api.c
+++ b/uet_api.c
@@ -2035,6 +2035,7 @@ static void uet_finalize_core(struct uet_instance *uet)
 	imp_shim_finalize();
 	uet_nic_finalize(UET_NIC(uet));
 	uet_domain_free_all(uet);
+	uet->pds.downcall.finalize(uet);
 }
 
 /* init rx descriptor used to track errored msg */
@@ -5708,7 +5709,7 @@ int uet_initialize(uet_handle_t *handle)
 	UET_NIC(uet)->uet_ipproto = uet->uet_ipproto;
 	rc = uet_nic_initialize(UET_NIC(uet));
 	if (rc != FI_SUCCESS)
-		goto err_return;
+		goto err_pds;
 
 	rc = imp_shim_init(UET_NIC(uet));
 	if (rc != 0)
@@ -5728,6 +5729,9 @@ err_sec:
 
 err_imp_shim:
 	uet_nic_finalize(UET_NIC(uet));
+
+err_pds:
+	uet->pds.downcall.finalize(uet);
 
 err_return:
 	if (uet != NULL)
@@ -6089,12 +6093,8 @@ err_exit:
 int uet_domain_close(uet_domain_handle_t domain_handle)
 {
 	struct uet_domain *uet_dom;
-	struct uet_pds *pds;
 
 	uet_dom = (struct uet_domain *) domain_handle;
-	pds = &uet_dom->uet->pds;
-
-	pds->downcall.finalize(uet_dom->uet);
 
 	if (uet_domain_has_ep(uet_dom)) {
 		UET_API_ERR("EPs associated with domain being closed");


### PR DESCRIPTION
## Problem

PDS is initialized for a UET instance and shared by its domains, but `uet_domain_close()` currently finalizes it before checking whether the domain still owns endpoints. A rejected close therefore destroys active PDS state, and successfully closing one domain also invalidates other domains on the same instance.

PDS is also left initialized if NIC initialization fails.

## Fix

- finalize PDS during UET instance teardown, after endpoints and domains are released
- finalize PDS when a later initialization stage fails
- leave domain close responsible only for domain-owned state

At the maintainer request, this PR was rebuilt on the current `main` as a single commit containing only the lifecycle fix; the standalone regression-test program is no longer part of the contribution.

## Validation

- full fabric, verbs, and standalone build against libfabric 1.20.1 on a dedicated Linux test host
- before its removal from the PR, the focused regression test passed with both `UET_PDS=pds` and `UET_PDS=sng`, including under ASan+UBSan
- `git diff --check` passed