### PR TITLE
core: fix type-incorrect state handling

### DIFF
--- a/uet_api.c
+++ b/uet_api.c
@@ -2719,7 +2719,7 @@ static uet_ses_rc_t uet_rx_atomic_req_pkt(
 	if (sync_defer_atomic) {
 		entry->atomic_parms.opcode = UET_AMO_SUM;
 		entry->atomic_parms.data_type = UET_TYPE_UINT64;
-		entry->atomic_parms.addr = (uint64_t) addr;
+		entry->atomic_parms.addr = addr;
 		entry->atomic_parms.data = data;
 	} else
 		__atomic_fetch_add(addr, data, __ATOMIC_SEQ_CST);

--- a/util/uet_util.c
+++ b/util/uet_util.c
@@ -1115,7 +1115,7 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 				return rc;
 			if (ntohs(udp->dest) != uet->uet_udp_port)
 				goto err_exit;
-			pp->entropy = ntohs(udp->source);
+			pp->entropy_val = ntohs(udp->source);
 			pp->udp = p;
 			pp->udp_len = sizeof(struct udphdr);
 			cur_len += pp->udp_len;
@@ -1404,4 +1404,3 @@ int uet_parse_pkt(struct uet_instance *uet, void *pkt, size_t pkt_len,
 err_exit:
 	return -EINVAL;
 }
-

--- a/util/uet_util.h
+++ b/util/uet_util.h
@@ -174,6 +174,7 @@ void uet_update_ipv6_pl(struct ipv6hdr *ipv6, uint16_t payload_len);
 void uet_build_eth_hdr(struct ethhdr *eth, uint8_t *dmac, uint8_t *smac,
 		       bool is_ipv6);
 void uet_pkt_hex_dump(void *pkt, uint32_t length, uint64_t addr, bool is_tx);
+void uet_rw_lock_init(struct uet_rw_lock *lock);
 void uet_rw_lock(struct uet_rw_lock *lock, uet_rw_lock_access_t access);
 void uet_rw_unlock(struct uet_rw_lock *lock, uet_rw_lock_access_t access);
 uint16_t uet_get_ses_req_payload_len(struct uet_parsed_pkt *pp,


### PR DESCRIPTION
This PR contains the three type-safety fixes split out of #148 at the maintainer's request, leaving #148 focused on the new strict diagnostics build target.

The fixes are:

- store the UDP source port in `entropy_val`, not in the entropy-header pointer
- assign the deferred atomic target as a pointer without an integer round trip
- declare `uet_rw_lock_init` in the utility header

The UDP correction preserves the source-port entropy value while correctly leaving the absent entropy-header pointer null.

Validation performed for the original patch:

- reproduced the UDP parser failure against unmodified `main`
- verified UDP source-port entropy parsing after the fix
- completed a full Linux build with `implicit-function-declaration` and `int-conversion` promoted to errors
- completed the normal full Linux build

The replacement branch is based on the current public upstream `main` after #144-#147.
