### PR TITLE
api: derive transport entropy from endpoint identity

### DIFF
--- a/uet_api.c
+++ b/uet_api.c
@@ -883,6 +883,19 @@ static void uet_ep_key_init(struct uet_ep_key *key,
 		UET_SES_REQ_RES_INDEX_SHIFT;
 }
 
+static uint16_t uet_ep_entropy_init(const struct uet_ep *uet_ep)
+{
+	uint32_t hash = 2166136261U;
+	uint16_t entropy;
+
+	hash = (hash ^ uet_ep->uet_addr.pid_on_fep) * 16777619U;
+	hash = (hash ^ uet_ep->uet_addr.start_index) * 16777619U;
+	hash = (hash ^ uet_ep->uet_addr.initiator_id) * 16777619U;
+	hash = (hash ^ uet_ep->job_id) * 16777619U;
+	entropy = (uint16_t)(hash ^ (hash >> 16));
+	return entropy ? entropy : 1;
+}
+
 /* insert entry into ip endpoint hash table */
 static void uet_ep_hash_insert(struct uet_ep *uet_ep)
 {
@@ -6149,6 +6162,7 @@ int uet_endpoint(uet_domain_handle_t domain_handle,
 	uet_ep->ep_key.pid_on_fep = uet_ep->uet_addr.pid_on_fep;
 	uet_ep->ep_key.index = uet_ep->uet_addr.start_index;
 	uet_ep_hash_insert(uet_ep);
+	uet_ep->entropy = uet_ep_entropy_init(uet_ep);
 
 	switch (info->tx_attr->tclass) {
 	case FI_TC_BEST_EFFORT:

--- a/uet_api_private.h
+++ b/uet_api_private.h
@@ -629,6 +629,7 @@ struct uet_ep {
 	struct dlist_entry mr_list_head;
 	void *pds;                                               /* pds state */
 	uint32_t job_id;                                /* ses job identifier */
+	uint16_t entropy;             /* stable endpoint entropy value (EV) */
 	bool absolute;       /* endpoint uses absolute addressing (any JobID) */
 			     /* relative endpoints demux/authorize by JobID   */
 	uint8_t untagged_gen;            /* ses generation for untagged msg's */

--- a/uet_pds.c
+++ b/uet_pds.c
@@ -1922,7 +1922,7 @@ int uet_pds_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 
 	/* fill in the entropy header */
 	/* TODO: UDP support */
-	entropy_hdr->entropy = htons(UET_DEFAULT_ENTROPY);
+	entropy_hdr->entropy = htons(uet_ep->entropy);
 
 	/* fill in the PDS header */
 

--- a/uet_pds_rudi.c
+++ b/uet_pds_rudi.c
@@ -34,8 +34,6 @@
 #include "imp_shim.h"
 #include "crc32c.h"
 
-#define UET_RUDI_ENTROPY 0x4242
-
 /* Per outstanding RUDI request (initiator side). Holds the built cleartext
  * frame for retransmit. On the security path the cleartext lives in the lower
  * half of pkt_buf (see uet_sec_enc_pkt) and only the TSC is refreshed on
@@ -209,6 +207,7 @@ static int uet_rudi_send(struct uet_instance *uet,
  */
 static int uet_rudi_build_frame(struct uet_instance *uet,
 				uint8_t tos,
+				uint16_t entropy,
 				const uint8_t *dst_mac,
 				const struct uet_fa *dst_fa,
 				bool is_ipv6, bool sec_enabled,
@@ -268,7 +267,7 @@ static int uet_rudi_build_frame(struct uet_instance *uet,
 	rp->pkt_len = (hdr_len + payload_len);
 
 	/* fill in the entropy */
-	entropy_hdr->entropy = htons(UET_RUDI_ENTROPY);
+	entropy_hdr->entropy = htons(entropy);
 	entropy_hdr->rsvd = 0;
 
 	/* fill in the RUDI header */
@@ -347,7 +346,8 @@ int uet_pds_rudi_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 
 	pkt_id = rudi.next_pkt_id++;
 
-	rc = uet_rudi_build_frame(uet, uet_ep->msg_ip_tos, av->nh_mac_addr,
+	rc = uet_rudi_build_frame(uet, uet_ep->msg_ip_tos, uet_ep->entropy,
+				  av->nh_mac_addr,
 				  &av->addr->fa, is_ipv6, sec_enabled,
 				  UET_PDS_TYPE_RUDI_REQ, next_hdr, pkt_id,
 				  ses, ses_len, pkt, pkt_len, rp);
@@ -449,7 +449,8 @@ static int uet_rudi_rx_req(struct uet_instance *uet,
 
 	/* FIXME: RUDI responses should use the DSCP controll codepoint */
 	memset(&rsp, 0, sizeof(rsp));
-	rc = uet_rudi_build_frame(uet, uet->default_msg_ip_tos, dst_mac,
+	rc = uet_rudi_build_frame(uet, uet->default_msg_ip_tos,
+				  pp->entropy_val, dst_mac,
 				  &dst_fa, pp->is_ipv6, sec_enabled,
 				  UET_PDS_TYPE_RUDI_RESP, rsp_next_hdr,
 				  pp->pds_rudi_pkt_id, rsp_ses_hdr,
@@ -575,4 +576,3 @@ int uet_pds_rudi_progress_tx(struct uet_ep *uet_ep,
 
 	return 0;
 }
-

--- a/uet_pds_sng.c
+++ b/uet_pds_sng.c
@@ -658,6 +658,7 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt,
 	uint8_t *uet_pkt;
 	struct uet_av_entry *av_entry;
 	struct uet_addr *dst_addr;
+	struct uet_entropy *entropy_hdr;
 	struct uet_pds_req *pds;
 	struct uet_pds_sng_tx_state *state;
 	struct uet_pds_hdr_overlay *pds_overlay;
@@ -692,6 +693,10 @@ int uet_pds_sng_tx_pkt(uet_pkt_handle_t tx_pkt_handle, uint64_t pkt_cnt,
 
 	uet_build_eth_hdr((struct ethhdr *)uet_pkt, av_entry->nh_mac_addr,
 			  uet->nic.mac_addr, is_ipv6);
+	entropy_hdr = (struct uet_entropy *)(uet_pkt + sizeof(struct ethhdr) +
+						  ip_hdr_size);
+	entropy_hdr->entropy = htons(uet_ep->entropy);
+	entropy_hdr->rsvd = 0;
 
 	switch (next_hdr) {
 	case UET_HDR_REQ_STD:

--- a/uet_pds_uud.c
+++ b/uet_pds_uud.c
@@ -30,8 +30,6 @@
 #include "imp_shim.h"
 #include "crc32c.h"
 
-#define UET_UUD_ENTROPY 0x5555
-
 /* scratch structure for building/transmitting one UUD datagram. */
 struct uet_uud_pkt {
 	uint8_t  *pkt_buf; /* full buffer (incl sec headroom) */
@@ -139,6 +137,7 @@ static int uet_uud_send(struct uet_instance *uet, struct uet_uud_pkt *up)
  */
 static int uet_uud_build_frame(struct uet_instance *uet,
 			       uint8_t tos,
+			       uint16_t entropy,
 			       const uint8_t *dst_mac,
 			       const struct uet_fa *dst_fa,
 			       bool is_ipv6, bool sec_enabled,
@@ -196,7 +195,7 @@ static int uet_uud_build_frame(struct uet_instance *uet,
 	up->pkt_len = (hdr_len + payload_len);
 
 	/* fill in the entropy */
-	entropy_hdr->entropy = htons(UET_UUD_ENTROPY);
+	entropy_hdr->entropy = htons(entropy);
 	entropy_hdr->rsvd = 0;
 
 	/* fill in the UUD header */
@@ -271,7 +270,8 @@ int uet_pds_uud_tx_pkt(uet_pkt_handle_t tx_pkt_handle,
 	up.ssi         = ssi;
 	up.is_ipv6     = is_ipv6;
 
-	rc = uet_uud_build_frame(uet, uet_ep->msg_ip_tos, av->nh_mac_addr,
+	rc = uet_uud_build_frame(uet, uet_ep->msg_ip_tos, uet_ep->entropy,
+				 av->nh_mac_addr,
 				 &av->addr->fa, is_ipv6, sec_enabled, next_hdr,
 				 ses, ses_len, pkt, pkt_len, &up);
 	if (rc != 0)


### PR DESCRIPTION
This is the standalone entropy correction requested during review of #143.

The software transport currently uses fixed entropy values for several packet-delivery modes. Traffic from independent endpoints can therefore collapse onto the same RSS or software-worker path.

This change:

- derives a stable, non-zero 16-bit entropy value from endpoint identity;
- uses it for SNG and ROD/RUD requests;
- replaces the fixed RUDI and UUD entropy constants; and
- echoes the received entropy in RUDI responses.

The change is backend-neutral and does not contain the VPP NIC shim, plugin, client, provider code or CI changes. Distinct software Resource Indices are handled separately in #153.
