### PR TITLE
vpp: add host dataplane plugin and client API

### DIFF
--- a/vpp-plugin/CMakeLists.txt
+++ b/vpp-plugin/CMakeLists.txt
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.16)
+
+project(uet-vpp-plugin VERSION 0.10.0 LANGUAGES C)
+
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release RelWithDebInfo MinSizeRel)
+endif()
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+find_package(VPP REQUIRED)
+
+include_directories(${CMAKE_SOURCE_DIR})
+include_directories(${CMAKE_BINARY_DIR})
+
+add_subdirectory(uet)
+add_subdirectory(client)
+add_subdirectory(tools)
+
+option(UET_VPP_ENABLE_PACKAGING "Generate native VPP plugin packages" OFF)
+
+if(UET_VPP_ENABLE_PACKAGING)
+  add_vpp_packaging(
+    NAME "uet-vpp-plugin"
+    VENDOR "Ultra Ethernet Consortium"
+    DESCRIPTION "UET host dataplane plugin for VPP"
+  )
+endif()

--- a/vpp-plugin/README.md
+++ b/vpp-plugin/README.md
@@ -1,0 +1,387 @@
+# UET VPP plugin
+
+This directory contains an experimental out-of-tree VPP UET host-dataplane
+plugin and its external-process client library. The current milestone supports
+one VPP main thread and one independent external SPSC channel per VPP worker.
+It uses VPP's normal device and interface graphs and has no dependency on a
+specific NIC driver. Hardware-specific validation is maintained separately
+from the driver-independent plugin sources and tests.
+
+The plugin and `libuet_vpp_client` are self-contained in this directory. A
+separate, follow-on NIC-shim contribution connects the existing UET transport
+to the client API; application-facing libfabric integration belongs in the
+dedicated `uet-libfabric` repository.
+
+## Why VPP
+
+The integration has two first-order benefits:
+
+- Independent per-worker queues and lockless SPSC channels provide a natural
+  path from one queue/core to a multiqueue, multicore UET dataplane.
+- UET becomes observable through the mature VPP operations environment.
+  Packet traces show the path and disposition of individual packets; node
+  errors and counters identify drops and resource pressure; structured logs
+  expose lifecycle and authorization events; `show uet` reports aggregate and
+  per-worker state; and the binary API makes the same controls and telemetry
+  available to automation.
+
+These facilities are part of the design rather than benchmark-only
+instrumentation. They make routing, filtering, queue ownership, saturation,
+and client-lifecycle problems diagnosable with the standard VPP CLI, logging,
+and tracing workflow.
+
+## Routing and local delivery
+
+RX traffic follows the normal VPP Ethernet and IP graphs. The plugin registers
+IP protocol 253 and UDP destination port 49150 with the IPv4 and IPv6 local
+dispatch tables. Consequently, the UET nodes are reached only after the FIB
+has selected a local/Receive DPO for the destination address:
+
+```text
+VPP interface RX -> ethernet-input -> ip4-input/ip6-input -> FIB/local DPO
+  -> protocol 253: uet4-ip-input/uet6-ip-input
+  -> UDP 49150:   ip4-udp-lookup/ip6-udp-lookup
+                  -> uet4-udp-input/uet6-udp-input
+```
+
+A packet for a routed destination remains transit traffic even when its IP
+protocol or UDP port matches UET. A local UDP packet for another port also
+does not enter the plugin.
+
+By default, RX delivery keeps the worker selected by the normal VPP input
+graph (`uet rx placement current-worker`). This preserves hardware RSS
+placement without adding a cross-worker hop. On a device that cannot include
+native UET entropy in its RSS hash, `uet rx placement entropy-handoff`
+extracts the native EV, or the UDP source port, after local IP/UDP dispatch and
+hands the packet to a stable VPP worker before publishing it to SVM. This mode
+is driver-independent and allows different endpoint entropy values to use
+different worker channels. The original worker still performs device input
+and IP local lookup, so this software handoff is not a substitute for
+programmable hardware RSS when line-rate ingress scaling is required.
+
+Client TX starts with a complete IPv4 or IPv6 packet, not an Ethernet frame.
+The worker validates the IP length and UET protocol/port, then enqueues the
+VLIB buffer to `ip4-lookup` or `ip6-lookup`. `uet tx fib table <table-id>`
+overrides the default IPv4 and IPv6 table 0; separate table IDs can be selected
+with `ip4-table` and `ip6-table`. The default is installed by `uet enable` when
+no explicit selection has already been made. No output interface is accepted
+or stored by the plugin. FIB lookup, multipath selection, adjacency rewrite,
+neighbor resolution, interface output and the device path remain VPP
+responsibilities.
+
+For UET-over-UDP, UE Specification 1.0.3 section 3.5.10.1 requires
+`udp.checksum` to be zero on send and ignored on receive, for both IPv4 and
+IPv6 encapsulation. The TX worker therefore overwrites that field with zero
+and does not request UDP checksum offload. The IPv4 header checksum remains
+the packet producer's responsibility (and is updated by the normal VPP IPv4
+forwarding path when routing changes the header); IPv6 has no IP header
+checksum.
+
+## Threading and process model
+
+The VPP main thread owns configuration, SVM lifecycle, protocol registration,
+and node state changes. It uses the VPP worker barrier when changing state.
+Each worker owns its rings, buffer ownership, TX completion state, RX release
+state, counters, and eventually its UET PDC/timer state. There is no mutex in
+the datapath and no SPSC ring is shared between workers.
+
+Each client process owns one named SSVM segment containing one independent
+SPSC channel per VPP worker. VPP may host several such application segments at
+the same time and polls every active TX channel on its owning worker. One
+`libuet_vpp_client` object maps that segment and the common VPP buffer pool
+once; datapath calls select a channel index. Each channel has one progress
+owner, while different channels can be used concurrently without an internal
+datapath mutex. All worker channels currently use the same physical VPP buffer
+pool and must be on the same NUMA node.
+
+`libuet_vpp_client_open()` takes a non-blocking exclusive lock on the segment's
+SHM object before SSVM attaches. A second opener, whether it is another process
+or a second open in the same process, receives `-EBUSY` and cannot overwrite
+the active channel owner. The lock and the shared owner PID are released by a
+clean close. The kernel releases the lock if the process exits, but the owner
+PID deliberately remains set: a later open returns `-EOWNERDEAD`, because
+rings and VPP-buffer ownership may have been left in an indeterminate state.
+Delete and recreate the SVM segment before attaching a replacement client
+after such a crash.
+VPP refuses to delete a segment whose owner process is still alive.
+
+Each client registers its endpoints through the segment's low-rate control
+rings. The RX lookup key is the local IP version/address, absolute versus
+relative addressing mode, JobID for relative addressing, PIDonFEP, and Resource
+Index. VPP rejects a key already owned by another process. The provider removes
+the key when the endpoint closes; deleting a segment also removes every key
+owned by that segment, including after a crashed client. The endpoint-control
+API is part of `libuet_vpp_client`; policy for connecting a transport or an
+application framework to that API is intentionally outside this plugin PR.
+
+For an initial RUD/ROD SYN, RUDI request, or UUD request, VPP reads the standard
+SES destination fields and performs the endpoint lookup. Established PDC
+traffic carries the process namespace in the high ten PDCID bits; RUDI
+responses carry it in the high ten `pkt_id` bits. These are opaque wire
+identifiers, so VPP does not keep per-packet or per-flow steering state. With
+only one ready process, the original fast path is retained: no UET parsing is
+performed and the RX ring producer is published once per VPP frame.
+
+PDC and RUDI identifier translation is confined to the VPP NIC shim, after the
+traditional transport has serialized TX and before it parses RX. The shim
+refreshes CRC32C after changing a cleartext identifier. The UET PDS and RUDI
+implementations contain no VPP-specific namespace logic.
+
+When several processes are ready, a malformed packet, a packet type without a
+supported destination identifier, or a security-encapsulated packet that hides
+those identifiers is dropped as ambiguous and increments `rx-ambiguous`; VPP
+never guesses a destination segment. Extending demux to encrypted multi-process
+traffic requires a visible steering identifier or moving security/transport
+termination into VPP.
+
+VPP Session Layer and VCL are intentionally absent. The external application
+communicates through SSVM metadata plus shared VPP physmem. The main thread is
+sufficient for serialized control only because configuration callbacks run on
+that thread and use worker barriers; it is not used to serialize datapath
+access.
+
+## Shared ABI 4.2
+
+The ABI is defined in [`uet/svm_abi.h`](uet/svm_abi.h). Structures use fixed
+width fields and offsets from a mapping base; process pointers never cross the
+boundary. A major version mismatch is rejected. New trailing fields require a
+minor version bump.
+
+ABI 4.2 contains the production SPSC dataplane plus a low-rate endpoint control
+channel:
+
+- lockless TX and TX-completion rings;
+- a lockless RX descriptor ring and RX-release ring;
+- a VPP physmem file descriptor passed over a Unix `SOCK_SEQPACKET` socket;
+- a provider-ready handshake counted across all workers, which makes DMA
+  unmapping safe;
+- an exclusive owner PID, backed by a lifetime SHM lock rather than a datapath
+  mutex;
+- one request/completion SPSC pair per application segment for endpoint add and
+  delete operations; and
+- a nonzero 10-bit process namespace assigned by VPP; and
+- an application mode flag that lets RX demultiplex both real PDS identifiers
+  and the endpoint overlay used by the stop-and-go implementation.
+
+The client library serializes endpoint control operations with one mutex. This
+does not affect TX, RX, completion, or release rings. VPP worker 0 consumes the
+control requests and updates a shared bihash; all workers perform lockless RX
+lookups. Namespaces are not reused during a VPP lifetime, preventing delayed
+packets from being redirected to a newly created process. Consequently, the
+current ABI permits 1023 segment creations before VPP must be restarted.
+
+The VPP NIC shim declares the selected PDS implementation before mapping DMA.
+Real PDS continues to use namespaced PDC and RUDI identifiers. SNG keeps its
+existing endpoint overlay unchanged; VPP resolves standard requests and ACKs
+against the registered endpoint key. `show uet` reports the mode for each
+application segment.
+
+The experimental `svm_msg_q` request path, payload verifier and fixed SSVM
+payload pool present in ABI 2.x have been removed. SSVM remains responsible
+for creating and mapping the channel set; packet data stays in shared VPP
+physmem, while SSVM carries only descriptors and the endpoint control channel.
+
+The TX pool starts with one VLIB buffer per shared slot. The client
+acquires a slot, writes the IP packet directly into its mapped VLIB data area,
+and publishes the descriptor. The worker transfers that buffer to the normal
+VPP graph, allocates a replacement VLIB buffer for the shared slot, updates the
+slot descriptor, and only then publishes the completion. The client therefore
+reuses the slot through its replacement while VPP exclusively owns the
+submitted buffer. Buffer lifetime does not depend on an output interface or on
+calling a device TX node from the plugin. A successful TX completion means that
+the replacement slot is available and the submitted buffer has been accepted
+by the VPP graph; it is deliberately not a physical-NIC-transmission
+completion.
+
+For RX, VPP publishes the full IP packet as up to eight scatter/gather segments
+pointing into the mapped VPP buffer pool. It retains the VLIB buffer chain
+until the client publishes a release. The release carries an opaque token;
+the worker resolves it through a private table before freeing the chain, so an
+external value is never treated directly as a VLIB buffer index. Outstanding
+RX ownership is bounded by the configured ring depth. The client library also
+tracks the exact token-to-RX-ID association and rejects stale, forged, or
+duplicate releases before publishing them.
+
+### DMA mapping trust boundary
+
+The Unix-socket filesystem permissions are the first authorization boundary.
+Before passing the physmem file descriptor, the plugin also reads the
+kernel-supplied `SO_PEERCRED` identity and requires the peer PID to match
+exactly one exclusive owner PID among the ready SSVM segments. The client must therefore
+attach its SSVM segment before requesting the DMA mapping. A process that
+merely knows the socket path receives `-EACCES` without an `SCM_RIGHTS`
+descriptor; accepted and rejected attempts are visible in `show uet`.
+
+An authorized client is still a trusted dataplane process. RX queues can
+allocate from VPP's default NUMA buffer pool, and the current VPP device API
+does not let this out-of-tree plugin select a private pool for those queues.
+Preserving zero-copy RX can consequently require exporting the backing file
+for that complete pool. This is not an isolation boundary for mutually
+untrusted tenants. Restricting the mapping requires VPP support for assigning
+a dedicated RX buffer pool, followed by moving both UET TX slots and the
+selected RX queues to that pool.
+
+The zero-copy boundaries are therefore:
+
+| Boundary | Current state |
+| --- | --- |
+| Shared ring descriptors | No copy |
+| VPP RX buffer to external client | No packet-data copy in the validated device setup |
+| Client DMA TX slot to VPP graph | Ownership of the same VLIB buffer is transferred without a packet-data copy |
+| Arbitrary application allocation to TX slot | Requires a copy unless the application obtains/uses the shared DMA arena |
+
+The client still uses VPP's SSVM attach API and must be built against a
+compatible VPP SDK. The packet-channel layout itself is defined by
+`uet/svm_abi.h` and checked as ABI 4.2 when a client opens a channel set. The
+plugin also declares the required `VPP_BUILD_VER`, so VPP rejects an
+incompatible binary at load time.
+
+## Device-driver independence
+
+The plugin consumes packets from the normal VPP IP graph and submits TX back
+to the normal IP lookup nodes. Interface creation and queue assignment remain
+standard VPP configuration and are intentionally absent from the plugin. The
+companion validation branch records the native-driver setup used for the
+published measurements.
+
+## VPP operations
+
+The plugin is disabled by default. Enable the binary explicitly in the VPP
+startup configuration, then enable its dataplane after the interfaces and FIB
+are configured:
+
+```text
+plugins {
+  plugin default { disable }
+  plugin uet_plugin.so { enable }
+}
+
+uet enable
+uet rx placement entropy-handoff
+uet svm create name uet
+```
+
+Create a different segment name for each client process. When several
+segments exist, deletion names the target explicitly:
+
+```text
+uet svm create name uet-app-a
+uet svm create name uet-app-b
+uet svm delete name uet-app-a
+```
+
+The default queue depth is 256. Each application segment reserves
+`worker-count * queue-depth` VPP buffers for its TX DMA slots, in addition to
+the buffers needed by the normal VPP graph. Size `buffers-per-numa` for the
+sum of all application segments before selecting a larger queue depth.
+
+This uses IPv4 and IPv6 table 0. Add `uet tx fib ...` before or after `uet
+enable` only to select other tables. The RX placement command is optional;
+`current-worker` is the default.
+
+The following native VPP facilities expose the useful operational state:
+
+```text
+show uet
+show errors
+show log
+set logging class uet level debug
+trace add uet-input 20
+trace add uet4-udp-input 20
+show trace
+clear uet counters
+```
+
+`show uet` gives aggregate, per-application, and per-worker channel state,
+including application namespaces and endpoint registration/collision counts.
+Standard node errors
+count malformed external TX requests, completion-ring saturation, invalid RX
+releases, absent or ambiguous clients, RX-ring saturation, malformed VLIB
+chains, and worker handoff queue saturation. Packet traces identify direction, worker, native-IP
+versus UDP encapsulation, IP version, packet length, request/RX identifier, and
+delivery/drop disposition. Lifecycle events use the `uet` VPP log class;
+detailed mapping-export messages are emitted only at debug level.
+
+The binary API mirrors the controls with `uet_enable_disable`,
+`uet_svm_create`, `uet_svm_delete`, `uet_tx_fib_set`, and
+`uet_clear_counters`.
+`uet_worker_dump` streams one `uet_worker_details` record per worker, including
+attachment/readiness state, queue occupancy, and the principal TX/RX counters.
+These APIs are management-plane snapshots; the packet datapath remains on the
+per-worker lockless SPSC rings.
+
+## Build
+
+```sh
+cmake -S vpp-plugin -B build/vpp-plugin \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH=/opt/vpp \
+  -DVPP_DIR=/opt/vpp/lib/x86_64-linux-gnu/cmake/vpp
+cmake --build build/vpp-plugin
+```
+
+Single-configuration generators default to `Release` when no build type is
+specified. Use an explicit `Debug` or `RelWithDebInfo` build when required;
+throughput results must use `Release`.
+
+Native package generation is optional and requires a Git checkout plus the
+packaging tools. Enable it with `-DUET_VPP_ENABLE_PACKAGING=ON`.
+
+## Tests
+
+The basic topology and SVM ownership tests are:
+
+```sh
+vpp-plugin/tests/smoke-one-worker.sh /opt/vpp build/vpp-plugin 2 3
+vpp-plugin/tests/smoke-multiworker.sh /opt/vpp build/vpp-plugin 2 3,4,5,6
+vpp-plugin/tests/reject-invalid-worker-count.sh /opt/vpp build/vpp-plugin 2
+vpp-plugin/tests/smoke-svm.sh /opt/vpp build/vpp-plugin 2 3
+```
+
+`smoke-multiworker.sh` has been validated with 1, 2, 4, and 8 workers. It opens
+two concurrent client processes, each with its own multi-worker segment, and
+verifies independent request and completion progress plus routed TX buffer
+replacement on every worker. It also verifies safe ambiguous-packet rejection,
+cross-process endpoint-collision detection, cleanup after an owner crash, and
+exact delivery to the respective SVM segment for RUD SYN and established
+traffic, ACK, PDC and RUDI NACK, CTRL, RUDI request/response, and UUD request
+packets. It also exercises the stop-and-go request and ACK endpoint overlay.
+
+`smoke-svm.sh` also connects an unattached process to the DMA socket and
+verifies that it receives `-EACCES` and no file descriptor before exercising
+the authorized client path. It selects distinct IPv4 and IPv6 table IDs through
+the binary API, then cycles IPv4/IPv6 native-UET and UDP packets through the TX
+slots without configuring an output interface or device. Its negative phase
+checks client-side ownership enforcement, rejected and atomic TX submissions,
+malformed-packet completions, DMA-slot exhaustion, and a completion ring filled
+to its configured depth. A packet-generator stream supplies real UET-over-UDP
+RX descriptors so the client can reject forged IDs, forged tokens, duplicate
+and stale releases without publishing them. The default queue depth of 257
+exercises modulo-based SPSC indexing; set `UET_SVM_QUEUE_DEPTH=256` to exercise
+the power-of-two mask path. The test also verifies that a concurrent attach is
+rejected, that a clean close releases ownership, and that a crashed owner is
+reported as `-EOWNERDEAD` until the SVM segment is recreated.
+
+## Companion hardware validation and performance
+
+Hardware-specific functional tests and performance tools are maintained on the
+companion
+[`feature/vpp-uet-benchmarks`](https://github.com/jtollet/uet-ref-prov/tree/feature/vpp-uet-benchmarks)
+branch. They are intentionally not proposed for merge in this RFC.
+
+That branch records the test topology and provides:
+
+- IPv4/IPv6 native-UET and UET-over-UDP local-delivery checks, including
+  matching transit traffic and non-UET UDP ports;
+- routed TX checks, including normalization of the UET UDP checksum to zero;
+- interoperability with the traditional raw-socket UET implementation
+  in both role directions;
+- VPP multicore functional and performance scaling.
+
+The reference measurements used Release builds, explicitly pinned application
+and VPP worker cores, and back-to-back test ports. The exact device and driver
+configuration is recorded only on the companion validation branch. Performance
+results are intentionally not part of this RFC: they must distinguish
+client-to-VPP graph completion from lossless physical transmission and be
+revalidated whenever buffer ownership or routing changes. The companion branch
+records the exact commands, limitations, and device restoration procedures.

--- a/vpp-plugin/client/CMakeLists.txt
+++ b/vpp-plugin/client/CMakeLists.txt
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+
+find_library(UET_CLIENT_SVM_LIBRARY NAMES svm)
+find_library(UET_CLIENT_VPPINFRA_LIBRARY NAMES vppinfra)
+
+if(NOT UET_CLIENT_SVM_LIBRARY OR NOT UET_CLIENT_VPPINFRA_LIBRARY)
+  message(FATAL_ERROR "libsvm and libvppinfra are required for libuet_vpp_client")
+endif()
+
+add_library(uet_vpp_client SHARED uet_vpp_client.c)
+target_include_directories(uet_vpp_client PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(uet_vpp_client PRIVATE
+  ${UET_CLIENT_SVM_LIBRARY}
+  ${UET_CLIENT_VPPINFRA_LIBRARY}
+  pthread
+  rt
+  m
+  dl
+)
+set_target_properties(uet_vpp_client PROPERTIES
+  VERSION ${PROJECT_VERSION}
+  SOVERSION 1
+)
+
+install(TARGETS uet_vpp_client
+  LIBRARY DESTINATION lib
+  COMPONENT vpp-plugin-uet
+)
+install(FILES uet_vpp_client.h
+  DESTINATION include
+  COMPONENT vpp-plugin-uet-dev
+)

--- a/vpp-plugin/client/uet_vpp_client.c
+++ b/vpp-plugin/client/uet_vpp_client.c
@@ -1,0 +1,1163 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/file.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <svm/ssvm.h>
+#include <vppinfra/mem.h>
+
+#include <uet/dma_abi.h>
+#include <uet/svm_abi.h>
+
+#include "uet_vpp_client.h"
+
+_Static_assert(UET_VPP_CLIENT_NAMESPACE_BITS == UET_VPP_SVM_CLIENT_NAMESPACE_BITS,
+	       "client and SVM namespace widths differ");
+_Static_assert(UET_VPP_CLIENT_PDC_LOCAL_BITS == UET_VPP_SVM_PDC_LOCAL_BITS,
+	       "client and SVM PDC widths differ");
+_Static_assert(UET_VPP_CLIENT_RUDI_LOCAL_BITS == UET_VPP_SVM_RUDI_LOCAL_BITS,
+	       "client and SVM RUDI widths differ");
+
+#define UET_VPP_CLIENT_HEAP_SIZE       (64U << 20)
+#define UET_VPP_CLIENT_ACK_SPINS       1000000U
+#define UET_VPP_CLIENT_ATTACH_ATTEMPTS 5
+
+typedef enum
+{
+  UET_VPP_SLOT_FREE = 0,
+  UET_VPP_SLOT_RESERVED,
+  UET_VPP_SLOT_INFLIGHT,
+} uet_vpp_slot_state_t;
+
+typedef struct
+{
+  uet_vpp_svm_worker_channel_t *shared;
+  uet_vpp_svm_dma_slot_t *dma_slots;
+  uet_vpp_svm_spsc_ring_t *tx_ring;
+  uet_vpp_svm_tx_desc_t *tx_descs;
+  uet_vpp_svm_spsc_ring_t *tx_completion_ring;
+  uet_vpp_svm_tx_completion_t *tx_completion_entries;
+  uet_vpp_svm_spsc_ring_t *rx_ring;
+  uet_vpp_svm_rx_desc_t *rx_descs;
+  uet_vpp_svm_spsc_ring_t *rx_release_ring;
+  uet_vpp_svm_rx_release_t *rx_release_entries;
+  uint8_t *dma_slot_states;
+  uint64_t *dma_slot_request_ids;
+  uint64_t *rx_token_ids;
+  uint32_t dma_next_slot;
+  uint32_t dma_inflight;
+  uint32_t rx_inflight;
+} __attribute__ ((aligned (UET_VPP_SVM_SHARED_ALIGNMENT))) uet_vpp_client_channel_t;
+
+struct uet_vpp_client
+{
+  ssvm_private_t segment;
+  uet_vpp_svm_shared_header_t *header;
+  uet_vpp_svm_worker_channel_t *shared_channels;
+  uet_vpp_svm_spsc_ring_t *control_request_ring;
+  uet_vpp_svm_control_request_t *control_requests;
+  uet_vpp_svm_spsc_ring_t *control_completion_ring;
+  uet_vpp_svm_control_completion_t *control_completions;
+  uet_vpp_client_channel_t *channels;
+  uint32_t channel_count;
+  void *dma_map;
+  uint32_t owner_pid;
+  int dma_fd;
+  int owner_fd;
+  int owner_claimed;
+  pthread_mutex_t control_mutex;
+  int control_mutex_initialized;
+  uint64_t next_control_request_id;
+};
+
+static pthread_once_t uet_vpp_heap_once = PTHREAD_ONCE_INIT;
+static int uet_vpp_heap_error = -ENOMEM;
+
+static int
+uet_vpp_client_wait_dma_ack (uet_vpp_client_t *client, int expected)
+{
+  uint32_t expected_count = expected ? client->header->worker_count : 0;
+
+  for (uint32_t i = 0; i < UET_VPP_CLIENT_ACK_SPINS; i++)
+    {
+      uint32_t count = __atomic_load_n (&client->header->server_dma_ready_count, __ATOMIC_ACQUIRE);
+
+      if (count == expected_count)
+	return 0;
+      if (count > client->header->worker_count)
+	return -EPROTO;
+      if (!__atomic_load_n (&client->segment.sh->ready, __ATOMIC_ACQUIRE))
+	return -ECONNRESET;
+      sched_yield ();
+    }
+  return -ETIMEDOUT;
+}
+
+static void
+uet_vpp_heap_init (void)
+{
+  /* Applications embedding another VPP client library may already have a
+   * VPP heap.  Reuse it instead of trying to initialize a second main heap.
+   */
+  if (clib_mem_get_heap () || clib_mem_init (0, UET_VPP_CLIENT_HEAP_SIZE))
+    uet_vpp_heap_error = 0;
+}
+
+static int
+uet_vpp_range_is_valid (uint64_t offset, uint64_t length, uint64_t size)
+{
+  return offset <= size && length <= size - offset;
+}
+
+static int
+uet_vpp_header_is_compatible (const uet_vpp_svm_shared_header_t *header, uint64_t header_offset,
+			      uint64_t mapped_size)
+{
+  if (header->magic != UET_VPP_SVM_ABI_MAGIC || header->abi_major != UET_VPP_SVM_ABI_MAJOR ||
+      header->abi_minor < UET_VPP_SVM_ABI_MINOR || header->header_size < sizeof (*header) ||
+      (header->capabilities & UET_VPP_SVM_REQUIRED_CAPABILITIES) !=
+	UET_VPP_SVM_REQUIRED_CAPABILITIES ||
+      header->queue_depth < UET_VPP_SVM_MIN_QUEUE_DEPTH ||
+      header->queue_depth > UET_VPP_SVM_MAX_QUEUE_DEPTH || header->segment_size > mapped_size ||
+      !uet_vpp_range_is_valid (header_offset, header->header_size, header->segment_size))
+    return 0;
+
+  if (!header->worker_count ||
+      header->worker_channel_desc_size != sizeof (uet_vpp_svm_worker_channel_t) ||
+      header->worker_count > UINT32_MAX / header->queue_depth ||
+      !uet_vpp_range_is_valid (header->worker_channel_table_offset,
+			       (uint64_t) header->worker_count * header->worker_channel_desc_size,
+			       header->segment_size) ||
+      header->dma_buffer_data_size == 0 || header->dma_map_size == 0)
+    return 0;
+
+  if (!header->client_namespace || header->client_namespace > UET_VPP_SVM_CLIENT_NAMESPACE_MAX ||
+      header->control_ring_size < UET_VPP_SVM_MIN_QUEUE_DEPTH ||
+      header->control_ring_size > UET_VPP_SVM_MAX_QUEUE_DEPTH ||
+      !uet_vpp_range_is_valid (header->control_request_ring_offset,
+			       sizeof (uet_vpp_svm_spsc_ring_t) +
+				 (uint64_t) header->control_ring_size *
+				   sizeof (uet_vpp_svm_control_request_t),
+			       header->segment_size) ||
+      !uet_vpp_range_is_valid (header->control_completion_ring_offset,
+			       sizeof (uet_vpp_svm_spsc_ring_t) +
+				 (uint64_t) header->control_ring_size *
+				   sizeof (uet_vpp_svm_control_completion_t),
+			       header->segment_size))
+    return 0;
+
+  if (header->tx_desc_size != sizeof (uet_vpp_svm_tx_desc_t) ||
+      header->tx_completion_size != sizeof (uet_vpp_svm_tx_completion_t) ||
+      header->rx_desc_size != sizeof (uet_vpp_svm_rx_desc_t) ||
+      header->rx_release_size != sizeof (uet_vpp_svm_rx_release_t))
+    return 0;
+
+  return 1;
+}
+
+static int
+uet_vpp_channel_is_compatible (const uet_vpp_svm_shared_header_t *header,
+			       const uet_vpp_svm_worker_channel_t *channel, uint32_t channel_index)
+{
+  if (channel->worker_index != channel_index || channel->dma_slot_count != header->queue_depth ||
+      channel->tx_ring_size != header->queue_depth ||
+      channel->rx_ring_size != header->queue_depth ||
+      !uet_vpp_range_is_valid (channel->dma_slot_table_offset,
+			       (uint64_t) channel->dma_slot_count * sizeof (uet_vpp_svm_dma_slot_t),
+			       header->segment_size) ||
+      !uet_vpp_range_is_valid (channel->tx_ring_offset,
+			       sizeof (uet_vpp_svm_spsc_ring_t) +
+				 (uint64_t) channel->tx_ring_size * header->tx_desc_size,
+			       header->segment_size) ||
+      !uet_vpp_range_is_valid (channel->tx_completion_ring_offset,
+			       sizeof (uet_vpp_svm_spsc_ring_t) +
+				 (uint64_t) channel->tx_ring_size * header->tx_completion_size,
+			       header->segment_size) ||
+      !uet_vpp_range_is_valid (channel->rx_ring_offset,
+			       sizeof (uet_vpp_svm_spsc_ring_t) +
+				 (uint64_t) channel->rx_ring_size * header->rx_desc_size,
+			       header->segment_size) ||
+      !uet_vpp_range_is_valid (channel->rx_release_ring_offset,
+			       sizeof (uet_vpp_svm_spsc_ring_t) +
+				 (uint64_t) channel->rx_ring_size * header->rx_release_size,
+			       header->segment_size))
+    return 0;
+
+  return 1;
+}
+
+static uet_vpp_client_channel_t *
+uet_vpp_client_channel (uet_vpp_client_t *client, uint32_t channel_index)
+{
+  if (!client || channel_index >= client->channel_count)
+    return 0;
+  return client->channels + channel_index;
+}
+
+static int
+uet_vpp_ring_is_compatible (const uet_vpp_svm_spsc_ring_t *ring, uint32_t expected_size)
+{
+  uint32_t expected_mask = (expected_size & (expected_size - 1)) == 0 ? expected_size - 1 : 0;
+  uint32_t producer = __atomic_load_n (&ring->producer, __ATOMIC_ACQUIRE);
+  uint32_t consumer = __atomic_load_n (&ring->consumer, __ATOMIC_ACQUIRE);
+
+  return ring->size == expected_size && ring->mask == expected_mask &&
+	 producer - consumer <= expected_size;
+}
+
+static int
+uet_vpp_client_is_drained (uet_vpp_client_t *client, int require_release_drain)
+{
+  for (uint32_t i = 0; i < client->channel_count; i++)
+    {
+      uet_vpp_client_channel_t *channel = client->channels + i;
+      const uet_vpp_svm_spsc_ring_t *rings[] = {
+	channel->tx_ring,
+	channel->tx_completion_ring,
+	channel->rx_ring,
+	channel->rx_release_ring,
+      };
+      uint32_t ring_count = require_release_drain ? 4 : 3;
+
+      if (channel->dma_inflight || channel->rx_inflight)
+	return 0;
+      for (uint32_t ring_index = 0; ring_index < ring_count; ring_index++)
+	{
+	  const uet_vpp_svm_spsc_ring_t *ring = rings[ring_index];
+	  uint32_t consumer = __atomic_load_n (&ring->consumer, __ATOMIC_RELAXED);
+	  uint32_t producer = __atomic_load_n (&ring->producer, __ATOMIC_ACQUIRE);
+	  uint32_t pending = producer - consumer;
+
+	  if (pending > ring->size)
+	    return -EPROTO;
+	  if (pending)
+	    return 0;
+	}
+    }
+  if (client->control_request_ring && client->control_completion_ring)
+    {
+      const uet_vpp_svm_spsc_ring_t *rings[] = {
+	client->control_request_ring,
+	client->control_completion_ring,
+      };
+
+      for (uint32_t i = 0; i < 2; i++)
+	{
+	  uint32_t consumer = __atomic_load_n (&rings[i]->consumer, __ATOMIC_RELAXED);
+	  uint32_t producer = __atomic_load_n (&rings[i]->producer, __ATOMIC_ACQUIRE);
+	  uint32_t pending = producer - consumer;
+
+	  if (pending > rings[i]->size)
+	    return -EPROTO;
+	  if (pending)
+	    return 0;
+	}
+    }
+  return 1;
+}
+
+static int
+uet_vpp_client_lock_segment (uet_vpp_client_t *client, const char *segment_name)
+{
+  int fd = -1;
+
+  for (uint32_t attempt = 0; attempt < UET_VPP_CLIENT_ATTACH_ATTEMPTS; attempt++)
+    {
+      fd = shm_open (segment_name, O_RDWR, 0);
+      if (fd >= 0)
+	break;
+      if (errno != ENOENT)
+	return -errno;
+      sleep (1);
+    }
+  if (fd < 0)
+    return -ECONNREFUSED;
+
+  if (flock (fd, LOCK_EX | LOCK_NB) < 0)
+    {
+      int rv = errno == EACCES || errno == EAGAIN ? -EBUSY : -errno;
+
+      close (fd);
+      return rv;
+    }
+
+  client->owner_fd = fd;
+  return 0;
+}
+
+static int
+uet_vpp_client_claim (uet_vpp_client_t *client)
+{
+  uint32_t expected = 0;
+
+  client->owner_pid = (uint32_t) getpid ();
+  if (!client->owner_pid)
+    return -EINVAL;
+  /*
+   * Holding the SHM lock excludes a live supported client.  A nonzero value
+   * therefore belongs to a client that exited without safely draining its
+   * rings; only deleting and recreating the channel may clear that state.
+   */
+  if (!__atomic_compare_exchange_n (&client->header->owner_pid, &expected, client->owner_pid, 0,
+				    __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+    return -EOWNERDEAD;
+
+  client->owner_claimed = 1;
+  __atomic_store_n (&client->segment.sh->client_pid, client->owner_pid, __ATOMIC_RELEASE);
+  return 0;
+}
+
+static void
+uet_vpp_client_channel_states_free (uet_vpp_client_t *client)
+{
+  if (!client || !client->channels)
+    return;
+
+  for (uint32_t i = 0; i < client->channel_count; i++)
+    {
+      free (client->channels[i].dma_slot_request_ids);
+      free (client->channels[i].dma_slot_states);
+      free (client->channels[i].rx_token_ids);
+      client->channels[i].dma_slot_request_ids = 0;
+      client->channels[i].dma_slot_states = 0;
+      client->channels[i].rx_token_ids = 0;
+    }
+}
+
+static void
+uet_vpp_client_channels_free (uet_vpp_client_t *client)
+{
+  uet_vpp_client_channel_states_free (client);
+  if (!client || !client->channels)
+    return;
+  free (client->channels);
+  client->channels = 0;
+}
+
+static void
+uet_vpp_client_unmap (uet_vpp_client_t *client)
+{
+  if (client->owner_claimed && client->header)
+    {
+      uint32_t expected = client->owner_pid;
+
+      __atomic_compare_exchange_n (&client->header->owner_pid, &expected, 0, 0, __ATOMIC_RELEASE,
+				   __ATOMIC_RELAXED);
+      client->owner_claimed = 0;
+    }
+  if (client->segment.sh)
+    {
+      uint32_t expected = client->owner_pid;
+
+      __atomic_compare_exchange_n (&client->segment.sh->client_pid, &expected, 0, 0,
+				   __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+      munmap (client->segment.sh, client->segment.ssvm_size);
+    }
+  if (client->owner_fd >= 0)
+    close (client->owner_fd);
+  vec_free (client->segment.name);
+}
+
+int
+uet_vpp_client_open (uet_vpp_client_t **client_out, const char *segment_name,
+		     uet_vpp_client_info_t *info)
+{
+  uet_vpp_client_t *client;
+  uint64_t header_offset;
+  int rv;
+
+  if (!client_out || !segment_name || !segment_name[0])
+    return -EINVAL;
+  *client_out = 0;
+
+  if (pthread_once (&uet_vpp_heap_once, uet_vpp_heap_init) != 0 || uet_vpp_heap_error)
+    return -ENOMEM;
+
+  client = calloc (1, sizeof (*client));
+  if (!client)
+    return -ENOMEM;
+  client->dma_fd = -1;
+  client->owner_fd = -1;
+
+  client->segment.name = format (0, "%s%c", segment_name, 0);
+  client->segment.my_pid = getpid ();
+  client->segment.attach_timeout = 5;
+  rv = uet_vpp_client_lock_segment (client, segment_name);
+  if (rv)
+    {
+      vec_free (client->segment.name);
+      free (client);
+      return rv;
+    }
+  if (ssvm_client_init (&client->segment, SSVM_SEGMENT_SHM) != 0)
+    {
+      uet_vpp_client_unmap (client);
+      free (client);
+      return -ECONNREFUSED;
+    }
+
+  header_offset = (uintptr_t) client->segment.sh->opaque[0];
+  if (client->segment.ssvm_size < sizeof (*client->segment.sh) ||
+      header_offset < sizeof (*client->segment.sh) ||
+      header_offset % UET_VPP_SVM_SHARED_ALIGNMENT != 0 ||
+      !uet_vpp_range_is_valid (header_offset, sizeof (*client->header), client->segment.ssvm_size))
+    {
+      uet_vpp_client_unmap (client);
+      free (client);
+      return -EPROTO;
+    }
+  client->header = (uet_vpp_svm_shared_header_t *) ((uint8_t *) client->segment.sh + header_offset);
+  if (!uet_vpp_header_is_compatible (client->header, header_offset, client->segment.ssvm_size))
+    {
+      uet_vpp_client_unmap (client);
+      free (client);
+      return -EPROTO;
+    }
+
+  rv = uet_vpp_client_claim (client);
+  if (rv)
+    {
+      uet_vpp_client_unmap (client);
+      free (client);
+      return rv;
+    }
+
+  client->channel_count = client->header->worker_count;
+  client->shared_channels =
+    (uet_vpp_svm_worker_channel_t *) ((uint8_t *) client->segment.sh +
+				      client->header->worker_channel_table_offset);
+  client->control_request_ring =
+    (uet_vpp_svm_spsc_ring_t *) ((uint8_t *) client->segment.sh +
+				 client->header->control_request_ring_offset);
+  client->control_requests = (uet_vpp_svm_control_request_t *) (client->control_request_ring + 1);
+  client->control_completion_ring =
+    (uet_vpp_svm_spsc_ring_t *) ((uint8_t *) client->segment.sh +
+				 client->header->control_completion_ring_offset);
+  client->control_completions =
+    (uet_vpp_svm_control_completion_t *) (client->control_completion_ring + 1);
+  if (!uet_vpp_ring_is_compatible (client->control_request_ring,
+				   client->header->control_ring_size) ||
+      !uet_vpp_ring_is_compatible (client->control_completion_ring,
+				   client->header->control_ring_size))
+    goto incompatible;
+  rv = posix_memalign ((void **) &client->channels, UET_VPP_SVM_SHARED_ALIGNMENT,
+		       client->channel_count * sizeof (*client->channels));
+  if (rv)
+    {
+      uet_vpp_client_unmap (client);
+      free (client);
+      return rv == ENOMEM ? -ENOMEM : -EINVAL;
+    }
+  memset (client->channels, 0, client->channel_count * sizeof (*client->channels));
+
+  for (uint32_t i = 0; i < client->channel_count; i++)
+    {
+      uet_vpp_svm_worker_channel_t *shared = client->shared_channels + i;
+      uet_vpp_client_channel_t *channel = client->channels + i;
+
+      if (!uet_vpp_channel_is_compatible (client->header, shared, i))
+	goto incompatible;
+      channel->shared = shared;
+      channel->dma_slots =
+	(uet_vpp_svm_dma_slot_t *) ((uint8_t *) client->segment.sh + shared->dma_slot_table_offset);
+      channel->tx_ring =
+	(uet_vpp_svm_spsc_ring_t *) ((uint8_t *) client->segment.sh + shared->tx_ring_offset);
+      channel->tx_descs = (uet_vpp_svm_tx_desc_t *) (channel->tx_ring + 1);
+      channel->tx_completion_ring = (uet_vpp_svm_spsc_ring_t *) ((uint8_t *) client->segment.sh +
+								 shared->tx_completion_ring_offset);
+      channel->tx_completion_entries =
+	(uet_vpp_svm_tx_completion_t *) (channel->tx_completion_ring + 1);
+      channel->rx_ring =
+	(uet_vpp_svm_spsc_ring_t *) ((uint8_t *) client->segment.sh + shared->rx_ring_offset);
+      channel->rx_descs = (uet_vpp_svm_rx_desc_t *) (channel->rx_ring + 1);
+      channel->rx_release_ring = (uet_vpp_svm_spsc_ring_t *) ((uint8_t *) client->segment.sh +
+							      shared->rx_release_ring_offset);
+      channel->rx_release_entries = (uet_vpp_svm_rx_release_t *) (channel->rx_release_ring + 1);
+
+      if (!uet_vpp_ring_is_compatible (channel->tx_ring, shared->tx_ring_size) ||
+	  !uet_vpp_ring_is_compatible (channel->tx_completion_ring, shared->tx_ring_size) ||
+	  !uet_vpp_ring_is_compatible (channel->rx_ring, shared->rx_ring_size) ||
+	  !uet_vpp_ring_is_compatible (channel->rx_release_ring, shared->rx_ring_size))
+	goto incompatible;
+    }
+  rv = pthread_mutex_init (&client->control_mutex, 0);
+  if (rv)
+    goto incompatible;
+  client->control_mutex_initialized = 1;
+  client->next_control_request_id = 1;
+  if (info)
+    {
+      info->abi_major = client->header->abi_major;
+      info->abi_minor = client->header->abi_minor;
+      info->channel_count = client->channel_count;
+      info->client_namespace = client->header->client_namespace;
+      info->queue_depth = client->header->queue_depth;
+      info->dma_slot_count = client->header->queue_depth;
+      info->dma_buffer_data_size = client->header->dma_buffer_data_size;
+      info->dma_map_size = client->header->dma_map_size;
+      info->tx_ring_size = client->header->queue_depth;
+      info->rx_ring_size = client->header->queue_depth;
+      info->generation = client->header->generation;
+    }
+
+  *client_out = client;
+  return 0;
+
+incompatible:
+  if (client->control_mutex_initialized)
+    pthread_mutex_destroy (&client->control_mutex);
+  uet_vpp_client_channels_free (client);
+  uet_vpp_client_unmap (client);
+  free (client);
+  return -EPROTO;
+}
+
+int
+uet_vpp_client_close (uet_vpp_client_t *client)
+{
+  int drained, rv;
+
+  if (!client)
+    return -EINVAL;
+  drained = uet_vpp_client_is_drained (client, 0);
+  if (drained <= 0)
+    return drained ? drained : -EBUSY;
+
+  if (client->dma_map)
+    {
+      __atomic_fetch_and (&client->header->client_flags, ~UET_VPP_SVM_CLIENT_F_DMA_READY,
+			  __ATOMIC_RELEASE);
+      rv = uet_vpp_client_wait_dma_ack (client, 0);
+
+      drained = rv ? 0 : uet_vpp_client_is_drained (client, 1);
+      if (!rv && drained < 0)
+	rv = drained;
+      else if (!rv && !drained)
+	rv = -EBUSY;
+      if (rv)
+	{
+	  __atomic_fetch_or (&client->header->client_flags, UET_VPP_SVM_CLIENT_F_DMA_READY,
+			     __ATOMIC_RELEASE);
+	  {
+	    int ack_rv = uet_vpp_client_wait_dma_ack (client, 1);
+
+	    if (ack_rv)
+	      return ack_rv;
+	  }
+	  return rv;
+	}
+    }
+
+  if (client->dma_map)
+    munmap (client->dma_map, client->header->dma_map_size);
+  if (client->dma_fd >= 0)
+    close (client->dma_fd);
+  if (client->control_mutex_initialized)
+    pthread_mutex_destroy (&client->control_mutex);
+  uet_vpp_client_channels_free (client);
+  uet_vpp_client_unmap (client);
+  free (client);
+  return 0;
+}
+
+int
+uet_vpp_client_set_pds_sng (uet_vpp_client_t *client, int enabled)
+{
+  if (!client)
+    return -EINVAL;
+  if (client->dma_map)
+    return -EBUSY;
+  if (enabled)
+    __atomic_fetch_or (&client->header->client_flags, UET_VPP_SVM_CLIENT_F_PDS_SNG,
+		       __ATOMIC_RELEASE);
+  else
+    __atomic_fetch_and (&client->header->client_flags, ~UET_VPP_SVM_CLIENT_F_PDS_SNG,
+			__ATOMIC_RELEASE);
+  return 0;
+}
+
+int
+uet_vpp_client_map_dma (uet_vpp_client_t *client, const char *socket_path)
+{
+  struct sockaddr_un address = { .sun_family = AF_UNIX };
+  uet_vpp_dma_reply_t reply;
+  char control[256] = { 0 };
+  struct iovec iov = { .iov_base = &reply, .iov_len = sizeof (reply) };
+  struct msghdr message = {
+    .msg_iov = &iov,
+    .msg_iovlen = 1,
+    .msg_control = control,
+    .msg_controllen = sizeof (control),
+  };
+  struct cmsghdr *cmsg;
+  ssize_t received;
+  int invalid_control = 0;
+  int socket_fd, received_fd = -1;
+
+  if (!client || !socket_path || !socket_path[0])
+    return -EINVAL;
+  if (client->dma_map)
+    return -EALREADY;
+  if (strlen (socket_path) >= sizeof (address.sun_path))
+    return -ENAMETOOLONG;
+
+  socket_fd = socket (AF_UNIX, SOCK_SEQPACKET | SOCK_CLOEXEC, 0);
+  if (socket_fd < 0)
+    return -errno;
+  memcpy (address.sun_path, socket_path, strlen (socket_path) + 1);
+  if (connect (socket_fd, (struct sockaddr *) &address, sizeof (address)) != 0)
+    {
+      int error = -errno;
+
+      close (socket_fd);
+      return error;
+    }
+
+  received = recvmsg (socket_fd, &message, MSG_CMSG_CLOEXEC);
+  if (received != sizeof (reply) || (message.msg_flags & (MSG_TRUNC | MSG_CTRUNC)))
+    {
+      int error = received < 0 ? -errno : -EPROTO;
+
+      close (socket_fd);
+      return error;
+    }
+
+  for (cmsg = CMSG_FIRSTHDR (&message); cmsg; cmsg = CMSG_NXTHDR (&message, cmsg))
+    if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS)
+      {
+	if (received_fd >= 0 || cmsg->cmsg_len != CMSG_LEN (sizeof (received_fd)))
+	  invalid_control = 1;
+	else
+	  memcpy (&received_fd, CMSG_DATA (cmsg), sizeof (received_fd));
+      }
+  close (socket_fd);
+
+  if (reply.magic != UET_VPP_DMA_ABI_MAGIC || reply.version != UET_VPP_DMA_ABI_VERSION ||
+      reply.status != 0 || invalid_control || received_fd < 0 ||
+      reply.generation != client->header->generation ||
+      reply.map_size != client->header->dma_map_size ||
+      reply.slot_count != client->channel_count * client->header->queue_depth ||
+      reply.buffer_data_size != client->header->dma_buffer_data_size ||
+      reply.buffer_pool_index != client->header->dma_buffer_pool_index)
+    {
+      if (received_fd >= 0)
+	close (received_fd);
+      return reply.status ? reply.status : -EPROTO;
+    }
+
+  client->dma_map = mmap (0, reply.map_size, PROT_READ | PROT_WRITE, MAP_SHARED, received_fd, 0);
+  if (client->dma_map == MAP_FAILED)
+    {
+      int error = -errno;
+
+      client->dma_map = 0;
+      close (received_fd);
+      return error;
+    }
+
+  for (uint32_t channel_index = 0; channel_index < client->channel_count; channel_index++)
+    {
+      uet_vpp_client_channel_t *channel = client->channels + channel_index;
+
+      for (uint32_t slot = 0; slot < channel->shared->dma_slot_count; slot++)
+	if (channel->dma_slots[slot].capacity == 0 ||
+	    channel->dma_slots[slot].capacity > client->header->dma_buffer_data_size ||
+	    channel->dma_slots[slot].data_offset > reply.map_size ||
+	    channel->dma_slots[slot].capacity >
+	      reply.map_size - channel->dma_slots[slot].data_offset)
+	  goto invalid_dma_slot;
+
+      channel->dma_slot_states =
+	calloc (channel->shared->dma_slot_count, sizeof (*channel->dma_slot_states));
+      channel->dma_slot_request_ids =
+	calloc (channel->shared->dma_slot_count, sizeof (*channel->dma_slot_request_ids));
+      channel->rx_token_ids =
+	calloc (channel->shared->rx_ring_size, sizeof (*channel->rx_token_ids));
+      if (!channel->dma_slot_states || !channel->dma_slot_request_ids || !channel->rx_token_ids)
+	{
+	  uet_vpp_client_channel_states_free (client);
+	  munmap (client->dma_map, reply.map_size);
+	  client->dma_map = 0;
+	  close (received_fd);
+	  return -ENOMEM;
+	}
+    }
+
+  client->dma_fd = received_fd;
+  __atomic_fetch_or (&client->header->client_flags, UET_VPP_SVM_CLIENT_F_DMA_READY,
+		     __ATOMIC_RELEASE);
+  {
+    int rv = uet_vpp_client_wait_dma_ack (client, 1);
+
+    if (rv)
+      {
+	int rollback_rv;
+
+	__atomic_fetch_and (&client->header->client_flags, ~UET_VPP_SVM_CLIENT_F_DMA_READY,
+			    __ATOMIC_RELEASE);
+	rollback_rv = uet_vpp_client_wait_dma_ack (client, 0);
+	if (rollback_rv)
+	  return rollback_rv;
+	uet_vpp_client_channel_states_free (client);
+	munmap (client->dma_map, reply.map_size);
+	client->dma_map = 0;
+	close (client->dma_fd);
+	client->dma_fd = -1;
+	return rv;
+      }
+  }
+  return 0;
+
+invalid_dma_slot:
+  uet_vpp_client_channel_states_free (client);
+  munmap (client->dma_map, reply.map_size);
+  client->dma_map = 0;
+  close (received_fd);
+  return -EPROTO;
+}
+
+static int
+uet_vpp_client_endpoint_control (uet_vpp_client_t *client, uint16_t operation,
+				 const uet_vpp_client_endpoint_t *endpoint)
+{
+  uet_vpp_svm_spsc_ring_t *request_ring, *completion_ring;
+  uet_vpp_svm_control_request_t *request;
+  uint32_t request_producer, request_consumer, completion_consumer;
+  uint64_t request_id;
+  int lock_rv, rv = -ETIMEDOUT;
+
+  if (!client || !endpoint || (endpoint->ip_version != 4 && endpoint->ip_version != 6) ||
+      endpoint->absolute > 1 || endpoint->pid_on_fep > 0x0fff ||
+      endpoint->resource_index > 0x0fff || endpoint->job_id > 0x00ffffff)
+    return -EINVAL;
+  if (!client->dma_map)
+    return -ENXIO;
+
+  lock_rv = pthread_mutex_lock (&client->control_mutex);
+  if (lock_rv)
+    return -lock_rv;
+
+  request_ring = client->control_request_ring;
+  completion_ring = client->control_completion_ring;
+  request_producer = __atomic_load_n (&request_ring->producer, __ATOMIC_RELAXED);
+  request_consumer = __atomic_load_n (&request_ring->consumer, __ATOMIC_ACQUIRE);
+  completion_consumer = __atomic_load_n (&completion_ring->consumer, __ATOMIC_RELAXED);
+  if (request_producer - request_consumer >= request_ring->size)
+    {
+      rv = -EAGAIN;
+      goto unlock;
+    }
+
+  request_id = client->next_control_request_id++;
+  if (!request_id)
+    request_id = client->next_control_request_id++;
+  request = client->control_requests + (request_ring->mask ? request_producer & request_ring->mask :
+							     request_producer % request_ring->size);
+  memset (request, 0, sizeof (*request));
+  request->request_id = request_id;
+  request->operation = operation;
+  request->endpoint.ip_version = endpoint->ip_version;
+  request->endpoint.absolute = endpoint->absolute;
+  request->endpoint.pid_on_fep = endpoint->pid_on_fep;
+  request->endpoint.resource_index = endpoint->resource_index;
+  request->endpoint.job_id = endpoint->absolute ? 0 : endpoint->job_id;
+  memcpy (request->endpoint.ip_address, endpoint->ip_address,
+	  sizeof (request->endpoint.ip_address));
+  __atomic_store_n (&request_ring->producer, request_producer + 1, __ATOMIC_RELEASE);
+
+  for (uint32_t spin = 0; spin < UET_VPP_CLIENT_ACK_SPINS; spin++)
+    {
+      uint32_t completion_producer = __atomic_load_n (&completion_ring->producer, __ATOMIC_ACQUIRE);
+      uint32_t available = completion_producer - completion_consumer;
+
+      if (available > completion_ring->size)
+	{
+	  rv = -EPROTO;
+	  break;
+	}
+      if (available)
+	{
+	  uet_vpp_svm_control_completion_t *completion =
+	    client->control_completions + (completion_ring->mask ?
+					     completion_consumer & completion_ring->mask :
+					     completion_consumer % completion_ring->size);
+
+	  if (completion->request_id != request_id || completion->reserved0 ||
+	      completion->reserved1[0] || completion->reserved1[1])
+	    rv = -EPROTO;
+	  else
+	    rv = completion->status;
+	  __atomic_store_n (&completion_ring->consumer, completion_consumer + 1, __ATOMIC_RELEASE);
+	  break;
+	}
+      if (!__atomic_load_n (&client->segment.sh->ready, __ATOMIC_ACQUIRE))
+	{
+	  rv = -ECONNRESET;
+	  break;
+	}
+      sched_yield ();
+    }
+
+unlock:
+  pthread_mutex_unlock (&client->control_mutex);
+  return rv;
+}
+
+int
+uet_vpp_client_endpoint_add (uet_vpp_client_t *client, const uet_vpp_client_endpoint_t *endpoint)
+{
+  return uet_vpp_client_endpoint_control (client, UET_VPP_SVM_CONTROL_ENDPOINT_ADD, endpoint);
+}
+
+int
+uet_vpp_client_endpoint_del (uet_vpp_client_t *client, const uet_vpp_client_endpoint_t *endpoint)
+{
+  return uet_vpp_client_endpoint_control (client, UET_VPP_SVM_CONTROL_ENDPOINT_DEL, endpoint);
+}
+
+int
+uet_vpp_client_acquire_dma (uet_vpp_client_t *client, uint32_t channel_index, uint32_t *dma_slot,
+			    void **data, size_t *capacity)
+{
+  uet_vpp_client_channel_t *channel = uet_vpp_client_channel (client, channel_index);
+  uint32_t i;
+
+  if (!channel || !dma_slot || !data || !capacity)
+    return -EINVAL;
+  if (!client->dma_map)
+    return -ENXIO;
+
+  for (i = 0; i < channel->shared->dma_slot_count; i++)
+    {
+      uint32_t slot = (channel->dma_next_slot + i) % channel->shared->dma_slot_count;
+
+      if (channel->dma_slot_states[slot] != UET_VPP_SLOT_FREE)
+	continue;
+
+      channel->dma_slot_states[slot] = UET_VPP_SLOT_RESERVED;
+      channel->dma_next_slot = (slot + 1) % channel->shared->dma_slot_count;
+      *dma_slot = slot;
+      *data = (uint8_t *) client->dma_map + channel->dma_slots[slot].data_offset;
+      *capacity = channel->dma_slots[slot].capacity;
+      return 0;
+    }
+
+  return -EAGAIN;
+}
+
+int
+uet_vpp_client_release_dma (uet_vpp_client_t *client, uint32_t channel_index, uint32_t dma_slot)
+{
+  uet_vpp_client_channel_t *channel = uet_vpp_client_channel (client, channel_index);
+
+  if (!channel || dma_slot >= channel->shared->dma_slot_count)
+    return -EINVAL;
+  if (!client->dma_map)
+    return -ENXIO;
+  if (channel->dma_slot_states[dma_slot] != UET_VPP_SLOT_RESERVED)
+    return -EPERM;
+
+  channel->dma_slot_states[dma_slot] = UET_VPP_SLOT_FREE;
+  return 0;
+}
+
+int
+uet_vpp_client_submit_ip_batch (uet_vpp_client_t *client, uint32_t channel_index,
+				const uet_vpp_client_tx_request_t *requests, size_t request_count)
+{
+  uet_vpp_client_channel_t *channel = uet_vpp_client_channel (client, channel_index);
+  uet_vpp_svm_spsc_ring_t *ring;
+  uint32_t producer, consumer, i;
+
+  if (!channel || !requests || request_count == 0 || request_count > UINT32_MAX)
+    return -EINVAL;
+  if (!client->dma_map)
+    return -ENXIO;
+  ring = channel->tx_ring;
+  producer = __atomic_load_n (&ring->producer, __ATOMIC_RELAXED);
+  consumer = __atomic_load_n (&ring->consumer, __ATOMIC_ACQUIRE);
+  if (producer - consumer > ring->size)
+    return -EPROTO;
+  if (request_count > ring->size - (producer - consumer))
+    return -EAGAIN;
+
+  for (i = 0; i < request_count; i++)
+    {
+      uint32_t slot = requests[i].dma_slot;
+
+      if (slot >= channel->shared->dma_slot_count)
+	return -EINVAL;
+      if (channel->dma_slot_states[slot] != UET_VPP_SLOT_RESERVED)
+	return -EPERM;
+      if (requests[i].packet_length < 20 ||
+	  requests[i].packet_length > channel->dma_slots[slot].capacity)
+	return -EMSGSIZE;
+    }
+
+  for (i = 0; i < request_count; i++)
+    {
+      const uet_vpp_client_tx_request_t *request = requests + i;
+      uint32_t slot = request->dma_slot;
+      uint32_t index = ring->mask ? (producer + i) & ring->mask : (producer + i) % ring->size;
+      uet_vpp_svm_tx_desc_t *desc = channel->tx_descs + index;
+
+      if (channel->dma_slot_states[slot] != UET_VPP_SLOT_RESERVED)
+	{
+	  while (i)
+	    {
+	      slot = requests[--i].dma_slot;
+	      channel->dma_slot_request_ids[slot] = 0;
+	      channel->dma_slot_states[slot] = UET_VPP_SLOT_RESERVED;
+	    }
+	  return -EINVAL;
+	}
+      desc->dma_slot = slot;
+      desc->packet_length = request->packet_length;
+      desc->request_id = request->request_id;
+      desc->user_context = request->user_context;
+      desc->reserved = 0;
+      channel->dma_slot_request_ids[slot] = request->request_id;
+      channel->dma_slot_states[slot] = UET_VPP_SLOT_INFLIGHT;
+    }
+  channel->dma_inflight += request_count;
+  __atomic_store_n (&ring->producer, producer + (uint32_t) request_count, __ATOMIC_RELEASE);
+  return 0;
+}
+
+int
+uet_vpp_client_submit_ip (uet_vpp_client_t *client, uint32_t channel_index, uint32_t dma_slot,
+			  uint32_t packet_length, uint64_t request_id, uint64_t user_context)
+{
+  uet_vpp_client_tx_request_t request = {
+    .dma_slot = dma_slot,
+    .packet_length = packet_length,
+    .request_id = request_id,
+    .user_context = user_context,
+  };
+
+  return uet_vpp_client_submit_ip_batch (client, channel_index, &request, 1);
+}
+
+int
+uet_vpp_client_poll_batch (uet_vpp_client_t *client, uint32_t channel_index,
+			   uet_vpp_client_completion_t *completions, size_t completion_capacity)
+{
+  uet_vpp_client_channel_t *channel = uet_vpp_client_channel (client, channel_index);
+  uet_vpp_svm_spsc_ring_t *ring;
+  uint32_t producer, consumer, available, i;
+
+  if (!channel || !completions || completion_capacity == 0 || completion_capacity > INT32_MAX)
+    return -EINVAL;
+
+  ring = channel->tx_completion_ring;
+  consumer = __atomic_load_n (&ring->consumer, __ATOMIC_RELAXED);
+  producer = __atomic_load_n (&ring->producer, __ATOMIC_ACQUIRE);
+  available = producer - consumer;
+  if (available > ring->size)
+    return -EPROTO;
+  available = available < completion_capacity ? available : completion_capacity;
+
+  for (i = 0; i < available; i++)
+    {
+      uint32_t index = ring->mask ? (consumer + i) & ring->mask : (consumer + i) % ring->size;
+      const uet_vpp_svm_tx_completion_t *wire = channel->tx_completion_entries + index;
+      uint32_t slot = wire->dma_slot;
+
+      if (wire->reserved || !client->dma_map || slot >= channel->shared->dma_slot_count ||
+	  channel->dma_slot_states[slot] != UET_VPP_SLOT_INFLIGHT ||
+	  channel->dma_slot_request_ids[slot] != wire->request_id)
+	return -EPROTO;
+    }
+
+  for (i = 0; i < available; i++)
+    {
+      uint32_t index = ring->mask ? (consumer + i) & ring->mask : (consumer + i) % ring->size;
+      const uet_vpp_svm_tx_completion_t *wire = channel->tx_completion_entries + index;
+      uet_vpp_client_completion_t *completion = completions + i;
+      uint32_t slot = wire->dma_slot;
+
+      completion->status = wire->status;
+      completion->completed_length = wire->completed_length;
+      completion->dma_slot = slot;
+      completion->request_id = wire->request_id;
+      completion->user_context = wire->user_context;
+      channel->dma_slot_request_ids[slot] = 0;
+      channel->dma_slot_states[slot] = UET_VPP_SLOT_FREE;
+    }
+  if (available)
+    {
+      channel->dma_inflight -= available;
+      __atomic_store_n (&ring->consumer, consumer + available, __ATOMIC_RELEASE);
+      return available;
+    }
+  return 0;
+}
+
+int
+uet_vpp_client_poll (uet_vpp_client_t *client, uint32_t channel_index,
+		     uet_vpp_client_completion_t *completion)
+{
+  return uet_vpp_client_poll_batch (client, channel_index, completion, 1);
+}
+
+static int
+uet_vpp_client_rx_decode (uet_vpp_client_t *client, uet_vpp_client_channel_t *channel,
+			  const uet_vpp_svm_rx_desc_t *desc, uet_vpp_client_rx_t *rx)
+{
+  uint64_t total = 0;
+
+  if (!desc->rx_id || desc->reserved || desc->release_token >= channel->rx_ring->size ||
+      !desc->segment_count || desc->segment_count > UET_VPP_SVM_MAX_RX_SEGS ||
+      !desc->packet_length ||
+      !((desc->flags & UET_VPP_SVM_RX_F_IP4) ^ (desc->flags & UET_VPP_SVM_RX_F_IP6)) ||
+      desc->flags & ~(UET_VPP_SVM_RX_F_IP4 | UET_VPP_SVM_RX_F_IP6 | UET_VPP_SVM_RX_F_UDP))
+    return -EPROTO;
+
+  memset (rx, 0, sizeof (*rx));
+  for (uint32_t i = 0; i < desc->segment_count; i++)
+    {
+      const uet_vpp_svm_rx_segment_t *segment = desc->segments + i;
+
+      if (!segment->length || segment->reserved ||
+	  segment->data_offset > client->header->dma_map_size ||
+	  segment->length > client->header->dma_map_size - segment->data_offset)
+	return -EPROTO;
+      rx->iov[i].base = (uint8_t *) client->dma_map + segment->data_offset;
+      rx->iov[i].length = segment->length;
+      total += segment->length;
+    }
+  if (total != desc->packet_length)
+    return -EPROTO;
+
+  rx->rx_id = desc->rx_id;
+  rx->release_token = desc->release_token;
+  rx->packet_length = desc->packet_length;
+  rx->rx_sw_if_index = desc->rx_sw_if_index;
+  rx->flags = desc->flags;
+  rx->iov_count = desc->segment_count;
+  return 0;
+}
+
+int
+uet_vpp_client_poll_rx_batch (uet_vpp_client_t *client, uint32_t channel_index,
+			      uet_vpp_client_rx_t *rx, size_t rx_capacity)
+{
+  uet_vpp_client_channel_t *channel = uet_vpp_client_channel (client, channel_index);
+  uet_vpp_svm_spsc_ring_t *ring;
+  uint32_t producer, consumer, available;
+
+  if (!channel || !rx || !rx_capacity || rx_capacity > UINT32_MAX)
+    return -EINVAL;
+  if (!client->dma_map)
+    return -ENXIO;
+
+  ring = channel->rx_ring;
+  consumer = __atomic_load_n (&ring->consumer, __ATOMIC_RELAXED);
+  producer = __atomic_load_n (&ring->producer, __ATOMIC_ACQUIRE);
+  available = producer - consumer;
+  if (available > ring->size)
+    return -EPROTO;
+  if (available > rx_capacity)
+    available = rx_capacity;
+
+  for (uint32_t i = 0; i < available; i++)
+    {
+      uint32_t counter = consumer + i;
+      uint32_t index = ring->mask ? counter & ring->mask : counter % ring->size;
+      int rv = uet_vpp_client_rx_decode (client, channel, channel->rx_descs + index, rx + i);
+
+      if (rv)
+	return rv;
+    }
+  for (uint32_t i = 0; i < available; i++)
+    {
+      uint32_t token = rx[i].release_token;
+
+      if (channel->rx_token_ids[token])
+	{
+	  while (i)
+	    channel->rx_token_ids[rx[--i].release_token] = 0;
+	  return -EPROTO;
+	}
+      channel->rx_token_ids[token] = rx[i].rx_id;
+    }
+  if (available)
+    {
+      channel->rx_inflight += available;
+      __atomic_store_n (&ring->consumer, consumer + available, __ATOMIC_RELEASE);
+    }
+  return available;
+}
+
+int
+uet_vpp_client_poll_rx (uet_vpp_client_t *client, uint32_t channel_index, uet_vpp_client_rx_t *rx)
+{
+  return uet_vpp_client_poll_rx_batch (client, channel_index, rx, 1);
+}
+
+int
+uet_vpp_client_release_rx_batch (uet_vpp_client_t *client, uint32_t channel_index,
+				 const uet_vpp_client_rx_t *rx, size_t rx_count)
+{
+  uet_vpp_client_channel_t *channel = uet_vpp_client_channel (client, channel_index);
+  uet_vpp_svm_spsc_ring_t *ring;
+  uint32_t producer, consumer;
+
+  if (!channel || !rx || !rx_count || rx_count > UINT32_MAX || rx_count > channel->rx_inflight)
+    return -EINVAL;
+
+  ring = channel->rx_release_ring;
+  producer = __atomic_load_n (&ring->producer, __ATOMIC_RELAXED);
+  consumer = __atomic_load_n (&ring->consumer, __ATOMIC_ACQUIRE);
+  if (producer - consumer > ring->size)
+    return -EPROTO;
+  if (rx_count > ring->size - (producer - consumer))
+    return -EAGAIN;
+
+  for (uint32_t i = 0; i < rx_count; i++)
+    if (!rx[i].rx_id || rx[i].release_token >= channel->shared->rx_ring_size ||
+	channel->rx_token_ids[rx[i].release_token] != rx[i].rx_id)
+      return -EINVAL;
+
+  for (uint32_t i = 0; i < rx_count; i++)
+    {
+      uint32_t counter = producer + i;
+      uint32_t index = ring->mask ? counter & ring->mask : counter % ring->size;
+      uet_vpp_svm_rx_release_t *release = channel->rx_release_entries + index;
+      uint32_t token = rx[i].release_token;
+
+      if (channel->rx_token_ids[token] != rx[i].rx_id)
+	{
+	  while (i)
+	    {
+	      i--;
+	      channel->rx_token_ids[rx[i].release_token] = rx[i].rx_id;
+	    }
+	  return -EINVAL;
+	}
+
+      release->rx_id = rx[i].rx_id;
+      release->release_token = token;
+      release->reserved = 0;
+      channel->rx_token_ids[token] = 0;
+    }
+  channel->rx_inflight -= rx_count;
+  __atomic_store_n (&ring->producer, producer + (uint32_t) rx_count, __ATOMIC_RELEASE);
+  return 0;
+}
+
+int
+uet_vpp_client_release_rx (uet_vpp_client_t *client, uint32_t channel_index,
+			   const uet_vpp_client_rx_t *rx)
+{
+  return uet_vpp_client_release_rx_batch (client, channel_index, rx, 1);
+}

--- a/vpp-plugin/client/uet_vpp_client.h
+++ b/vpp-plugin/client/uet_vpp_client.h
@@ -1,0 +1,157 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef included_uet_vpp_client_h
+#define included_uet_vpp_client_h
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  typedef struct uet_vpp_client uet_vpp_client_t;
+
+#define UET_VPP_CLIENT_NAMESPACE_BITS 10
+#define UET_VPP_CLIENT_NAMESPACE_MAX  ((1U << UET_VPP_CLIENT_NAMESPACE_BITS) - 1)
+#define UET_VPP_CLIENT_PDC_LOCAL_BITS  6
+#define UET_VPP_CLIENT_PDC_LOCAL_MASK  ((1U << UET_VPP_CLIENT_PDC_LOCAL_BITS) - 1)
+#define UET_VPP_CLIENT_RUDI_LOCAL_BITS (32 - UET_VPP_CLIENT_NAMESPACE_BITS)
+#define UET_VPP_CLIENT_RUDI_LOCAL_MASK ((1U << UET_VPP_CLIENT_RUDI_LOCAL_BITS) - 1)
+
+  typedef enum
+  {
+    UET_VPP_CLIENT_STATUS_OK = 0,
+    UET_VPP_CLIENT_STATUS_INVALID_PACKET = -1,
+    UET_VPP_CLIENT_STATUS_TX_NOT_CONFIGURED = -2,
+    UET_VPP_CLIENT_STATUS_SLOT_BUSY = -3,
+    UET_VPP_CLIENT_STATUS_NO_BUFFERS = -4,
+  } uet_vpp_client_status_t;
+
+  typedef struct
+  {
+    uint16_t abi_major;
+    uint16_t abi_minor;
+    uint32_t channel_count;
+    uint32_t client_namespace;
+    uint32_t queue_depth;
+    /* Slot and ring depths below are per channel. */
+    uint32_t dma_slot_count;
+    uint32_t dma_buffer_data_size;
+    uint64_t dma_map_size;
+    uint32_t tx_ring_size;
+    uint32_t rx_ring_size;
+    uint64_t generation;
+  } uet_vpp_client_info_t;
+
+#define UET_VPP_CLIENT_MAX_RX_IOV 8
+
+  typedef enum
+  {
+    UET_VPP_CLIENT_RX_F_IP4 = 1U << 0,
+    UET_VPP_CLIENT_RX_F_IP6 = 1U << 1,
+    UET_VPP_CLIENT_RX_F_UDP = 1U << 2,
+  } uet_vpp_client_rx_flags_t;
+
+  typedef struct
+  {
+    const void *base;
+    size_t length;
+  } uet_vpp_client_rx_iov_t;
+
+  typedef struct
+  {
+    uint64_t rx_id;
+    uint32_t release_token;
+    uint32_t packet_length;
+    uint32_t rx_sw_if_index;
+    uint16_t flags;
+    uint16_t iov_count;
+    uet_vpp_client_rx_iov_t iov[UET_VPP_CLIENT_MAX_RX_IOV];
+  } uet_vpp_client_rx_t;
+
+  typedef struct
+  {
+    uint32_t dma_slot;
+    uint32_t packet_length;
+    uint64_t request_id;
+    uint64_t user_context;
+  } uet_vpp_client_tx_request_t;
+
+  typedef struct
+  {
+    uint8_t ip_version;
+    uint8_t absolute;
+    uint16_t pid_on_fep;
+    uint16_t resource_index;
+    uint32_t job_id;
+    uint8_t ip_address[16];
+  } uet_vpp_client_endpoint_t;
+
+  /*
+   * A successful TX completion means that VPP owns the submitted buffer and
+   * dma_slot now refers to its replacement. It is not a physical device TX
+   * completion.
+   */
+  typedef struct
+  {
+    int32_t status;
+    uint32_t completed_length;
+    uint32_t dma_slot;
+    uint64_t request_id;
+    uint64_t user_context;
+  } uet_vpp_client_completion_t;
+
+  /*
+   * One client object owns one application segment containing one lockless
+   * SPSC channel per VPP worker.  Lifecycle calls must not overlap datapath
+   * calls.  A channel has one progress owner and must not be called
+   * concurrently; different channel indices may be used concurrently.
+   * Endpoint add/delete operations are serialized internally on their
+   * low-rate control ring and may run concurrently with datapath operations.
+   *
+   * Functions return 0 on success or a negative errno value, except poll(),
+   * which returns 1 when a completion was consumed, 0 when the CQ is empty, or
+   * a negative errno value.
+   */
+  int uet_vpp_client_open (uet_vpp_client_t **client, const char *segment_name,
+			   uet_vpp_client_info_t *info);
+  int uet_vpp_client_close (uet_vpp_client_t *client);
+  int uet_vpp_client_set_pds_sng (uet_vpp_client_t *client, int enabled);
+  int uet_vpp_client_map_dma (uet_vpp_client_t *client, const char *socket_path);
+  int uet_vpp_client_endpoint_add (uet_vpp_client_t *client,
+				   const uet_vpp_client_endpoint_t *endpoint);
+  int uet_vpp_client_endpoint_del (uet_vpp_client_t *client,
+				   const uet_vpp_client_endpoint_t *endpoint);
+
+  int uet_vpp_client_acquire_dma (uet_vpp_client_t *client, uint32_t channel_index,
+				  uint32_t *dma_slot, void **data, size_t *capacity);
+  int uet_vpp_client_release_dma (uet_vpp_client_t *client, uint32_t channel_index,
+				  uint32_t dma_slot);
+  int uet_vpp_client_submit_ip (uet_vpp_client_t *client, uint32_t channel_index, uint32_t dma_slot,
+				uint32_t packet_length, uint64_t request_id, uint64_t user_context);
+  int uet_vpp_client_submit_ip_batch (uet_vpp_client_t *client, uint32_t channel_index,
+				      const uet_vpp_client_tx_request_t *requests,
+				      size_t request_count);
+  int uet_vpp_client_poll (uet_vpp_client_t *client, uint32_t channel_index,
+			   uet_vpp_client_completion_t *completion);
+  int uet_vpp_client_poll_batch (uet_vpp_client_t *client, uint32_t channel_index,
+				 uet_vpp_client_completion_t *completions,
+				 size_t completion_capacity);
+  int uet_vpp_client_poll_rx (uet_vpp_client_t *client, uint32_t channel_index,
+			      uet_vpp_client_rx_t *rx);
+  int uet_vpp_client_poll_rx_batch (uet_vpp_client_t *client, uint32_t channel_index,
+				    uet_vpp_client_rx_t *rx, size_t rx_capacity);
+
+  /* A polled RX must be released exactly once with its unchanged ID and token. */
+  int uet_vpp_client_release_rx (uet_vpp_client_t *client, uint32_t channel_index,
+				 const uet_vpp_client_rx_t *rx);
+  int uet_vpp_client_release_rx_batch (uet_vpp_client_t *client, uint32_t channel_index,
+				       const uet_vpp_client_rx_t *rx, size_t rx_count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* included_uet_vpp_client_h */

--- a/vpp-plugin/tests/reject-invalid-worker-count.sh
+++ b/vpp-plugin/tests/reject-invalid-worker-count.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "usage: $0 <vpp-prefix> <plugin-build-dir> [main-core]" >&2
+  exit 2
+fi
+
+vpp_prefix=$1
+plugin_build_dir=$2
+main_core=${3:-2}
+
+vpp_bin="$vpp_prefix/bin/vpp"
+vppctl_bin="$vpp_prefix/bin/vppctl"
+plugin_dir="$plugin_build_dir/lib/vpp_plugins"
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+vpp_pid=
+
+cleanup()
+{
+  if [[ -n "$vpp_pid" ]] && kill -0 "$vpp_pid" 2>/dev/null; then
+    kill "$vpp_pid"
+    wait "$vpp_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+for required in "$vpp_bin" "$vppctl_bin" "$plugin_dir/uet_plugin.so"; do
+  if [[ ! -e "$required" ]]; then
+    echo "missing required file: $required" >&2
+    exit 1
+  fi
+done
+
+run_rejection_case()
+{
+  local label=$1
+  local worker_stanza=$2
+  local runtime_dir config_file stdout_file api_prefix output state
+
+  runtime_dir=$(mktemp -d "/tmp/uet-vpp-${label}.XXXXXX")
+  config_file="$runtime_dir/startup.conf"
+  stdout_file="$runtime_dir/stdout.log"
+  api_prefix="uet-${label}-$$"
+
+  sed \
+    -e "s|@RUNTIME_DIR@|$runtime_dir|g" \
+    -e "s|@API_PREFIX@|$api_prefix|g" \
+    -e "s|@PLUGIN_DIR@|$plugin_dir|g" \
+    -e "s|@MAIN_CORE@|$main_core|g" \
+    -e "s|@WORKER_STANZA@|$worker_stanza|g" \
+    -e "s|@BUFFERS_PER_NUMA@|${UET_BUFFERS_PER_NUMA:-32768}|g" \
+    "$script_dir/startup-worker-contract.conf.in" >"$config_file"
+
+  "$vpp_bin" -c "$config_file" >"$stdout_file" 2>&1 &
+  vpp_pid=$!
+
+  for _ in $(seq 1 100); do
+    [[ -S "$runtime_dir/cli.sock" ]] && break
+    if ! kill -0 "$vpp_pid" 2>/dev/null; then
+      echo "VPP exited before creating its CLI socket ($label case)" >&2
+      cat "$stdout_file" >&2
+      exit 1
+    fi
+    sleep 0.05
+  done
+
+  if [[ ! -S "$runtime_dir/cli.sock" ]]; then
+    echo "timed out waiting for VPP CLI socket ($label case)" >&2
+    cat "$stdout_file" >&2
+    exit 1
+  fi
+
+  output=$("$vppctl_bin" -s "$runtime_dir/cli.sock" uet enable 2>&1 || true)
+  output=$(tr -d '\r' <<<"$output")
+  printf '%s: %s\n' "$label" "$output"
+  grep -Fq "requires at least one VPP worker" <<<"$output"
+
+  state=$("$vppctl_bin" -s "$runtime_dir/cli.sock" show uet | tr -d '\r')
+  grep -q '^state disabled$' <<<"$state"
+
+  kill "$vpp_pid"
+  wait "$vpp_pid" 2>/dev/null || true
+  vpp_pid=
+}
+
+run_rejection_case zero-workers ""
+
+echo "UET zero-worker rejection test passed"

--- a/vpp-plugin/tests/smoke-multiworker.sh
+++ b/vpp-plugin/tests/smoke-multiworker.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 4 ]]; then
+  echo "usage: $0 <vpp-prefix> <plugin-build-dir> [main-core] [worker-core-list]" >&2
+  exit 2
+fi
+
+vpp_prefix=$1
+plugin_build_dir=$2
+main_core=${3:-2}
+worker_cores=${4:-3,4}
+IFS=, read -r -a worker_core_array <<<"$worker_cores"
+worker_count=${#worker_core_array[@]}
+if (( worker_count < 1 )); then
+  echo "at least one worker core is required" >&2
+  exit 2
+fi
+
+vpp_bin="$vpp_prefix/bin/vpp"
+vppctl_bin="$vpp_prefix/bin/vppctl"
+plugin_dir="$plugin_build_dir/lib/vpp_plugins"
+tx_client_bin="$plugin_build_dir/bin/uet_vpp_tx_smoke"
+owner_probe_bin="$plugin_build_dir/bin/uet_vpp_owner_probe"
+endpoint_smoke_bin="$plugin_build_dir/bin/uet_vpp_endpoint_smoke"
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+runtime_dir=$(mktemp -d /tmp/uet-vpp-multiworker.XXXXXX)
+config_file="$runtime_dir/startup.conf"
+stdout_file="$runtime_dir/stdout.log"
+api_prefix="uet-multiworker-$$"
+segment_name_a="uet-multiworker-a-$$"
+segment_name_b="uet-multiworker-b-$$"
+tx_packet_count=${UET_TX_SMOKE_PACKETS:-1024}
+vpp_pid=
+tx_pid_a=
+tx_pid_b=
+hold_pid_a=
+hold_pid_b=
+endpoint_pid_a=
+endpoint_pid_b=
+collision_holder_pid=
+
+cleanup()
+{
+  for client_pid in "$collision_holder_pid" "$endpoint_pid_a" "$endpoint_pid_b" \
+    "$hold_pid_a" "$hold_pid_b" "$tx_pid_a" "$tx_pid_b"; do
+    if [[ -n "$client_pid" ]] && kill -0 "$client_pid" 2>/dev/null; then
+      kill "$client_pid"
+      wait "$client_pid" 2>/dev/null || true
+    fi
+  done
+  if [[ -n "$vpp_pid" ]] && kill -0 "$vpp_pid" 2>/dev/null; then
+    kill "$vpp_pid"
+    wait "$vpp_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+for required in "$vpp_bin" "$vppctl_bin" "$plugin_dir/uet_plugin.so" \
+  "$tx_client_bin" "$owner_probe_bin" "$endpoint_smoke_bin" \
+  "$plugin_build_dir/lib/libuet_vpp_client.so"; do
+  if [[ ! -e "$required" ]]; then
+    echo "missing required file: $required" >&2
+    exit 1
+  fi
+done
+
+sed \
+  -e "s|@RUNTIME_DIR@|$runtime_dir|g" \
+  -e "s|@API_PREFIX@|$api_prefix|g" \
+  -e "s|@PLUGIN_DIR@|$plugin_dir|g" \
+  -e "s|@MAIN_CORE@|$main_core|g" \
+  -e "s|@WORKER_STANZA@|corelist-workers $worker_cores|g" \
+  -e "s|@BUFFERS_PER_NUMA@|${UET_BUFFERS_PER_NUMA:-32768}|g" \
+  "$script_dir/startup-worker-contract.conf.in" >"$config_file"
+
+"$vpp_bin" -c "$config_file" >"$stdout_file" 2>&1 &
+vpp_pid=$!
+for _ in $(seq 1 100); do
+  [[ -S "$runtime_dir/cli.sock" ]] && break
+  if ! kill -0 "$vpp_pid" 2>/dev/null; then
+    cat "$stdout_file" >&2
+    exit 1
+  fi
+  sleep 0.05
+done
+if [[ ! -S "$runtime_dir/cli.sock" ]]; then
+  echo "timed out waiting for VPP CLI socket" >&2
+  exit 1
+fi
+
+cli=("$vppctl_bin" -s "$runtime_dir/cli.sock")
+"${cli[@]}" uet enable
+grep -q '^rx-placement current-worker$' <<<"$("${cli[@]}" show uet | tr -d '\r')"
+"${cli[@]}" uet rx placement entropy-handoff
+grep -q '^rx-placement entropy-handoff$' <<<"$("${cli[@]}" show uet | tr -d '\r')"
+"${cli[@]}" uet rx placement current-worker
+"${cli[@]}" uet svm create name "$segment_name_a" queue-size 256
+"${cli[@]}" uet svm create name "$segment_name_b" queue-size 256
+
+library_path="$plugin_build_dir/lib:$vpp_prefix/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+env LD_LIBRARY_PATH="$library_path" \
+  "$tx_client_bin" "$segment_name_a" "$tx_packet_count" "$runtime_dir/uet-dma.sock" \
+  >"$runtime_dir/tx-client-a.log" 2>&1 &
+tx_pid_a=$!
+env LD_LIBRARY_PATH="$library_path" \
+  "$tx_client_bin" "$segment_name_b" "$tx_packet_count" "$runtime_dir/uet-dma.sock" \
+  >"$runtime_dir/tx-client-b.log" 2>&1 &
+tx_pid_b=$!
+if ! wait "$tx_pid_a"; then
+  tx_pid_a=
+  cat "$runtime_dir/tx-client-a.log" >&2
+  exit 1
+fi
+tx_pid_a=
+if ! wait "$tx_pid_b"; then
+  tx_pid_b=
+  cat "$runtime_dir/tx-client-b.log" >&2
+  exit 1
+fi
+tx_pid_b=
+cat "$runtime_dir/tx-client-a.log"
+cat "$runtime_dir/tx-client-b.log"
+
+status=$("${cli[@]}" show uet | tr -d '\r')
+printf '%s\n' "$status"
+grep -q "^workers $worker_count$" <<<"$status"
+grep -q '^svm-segments 2$' <<<"$status"
+grep -q "^application-0-segment $segment_name_a$" <<<"$status"
+grep -q "^application-1-segment $segment_name_b$" <<<"$status"
+grep -q "^application-0-channels $worker_count$" <<<"$status"
+grep -q "^application-1-channels $worker_count$" <<<"$status"
+grep -q "^tx-requests $((2 * worker_count * tx_packet_count))$" <<<"$status"
+grep -q '^invalid-requests 0$' <<<"$status"
+grep -q "^tx-packets $((2 * worker_count * tx_packet_count))$" <<<"$status"
+grep -q "^tx-completions $((2 * worker_count * tx_packet_count))$" <<<"$status"
+grep -q '^dma-authorized-clients 2$' <<<"$status"
+grep -q '^dma-rejected-clients 0$' <<<"$status"
+for ((worker = 0; worker < worker_count; worker++)); do
+  grep -q "^worker-$worker-channel attached$" <<<"$status"
+  grep -q "^worker-$worker-tx-requests $((2 * tx_packet_count))$" <<<"$status"
+  grep -q "^worker-$worker-tx-packets $((2 * tx_packet_count))$" <<<"$status"
+done
+
+"${cli[@]}" uet svm delete name "$segment_name_a"
+status=$("${cli[@]}" show uet | tr -d '\r')
+grep -q '^svm-segments 1$' <<<"$status"
+grep -q "^svm-segment $segment_name_b$" <<<"$status"
+"${cli[@]}" uet svm create name "$segment_name_a" queue-size 256
+
+"${cli[@]}" loopback create
+"${cli[@]}" set interface state loop0 up
+"${cli[@]}" set interface ip address loop0 198.18.0.1/24
+"${cli[@]}" "packet-generator new {
+  name uet-ambiguous-rx
+  limit 1
+  worker 0
+  node ip4-input
+  interface loop0
+  size 64-64
+  data {
+    UDP: 198.18.0.2 -> 198.18.0.1
+    UDP: 10000 -> 49150
+    incrementing 36
+  }
+}"
+
+LD_LIBRARY_PATH="$library_path" "$owner_probe_bin" "$segment_name_a" hold-dma \
+  "$runtime_dir/uet-dma.sock" >"$runtime_dir/hold-a.log" 2>&1 &
+hold_pid_a=$!
+LD_LIBRARY_PATH="$library_path" "$owner_probe_bin" "$segment_name_b" hold-dma \
+  "$runtime_dir/uet-dma.sock" >"$runtime_dir/hold-b.log" 2>&1 &
+hold_pid_b=$!
+for _ in $(seq 1 100); do
+  status=$("${cli[@]}" show uet | tr -d '\r')
+  if grep -q '^application-0-provider-ready yes$' <<<"$status" &&
+    grep -q '^application-1-provider-ready yes$' <<<"$status"; then
+    break
+  fi
+  sleep 0.01
+done
+grep -q '^application-0-provider-ready yes$' <<<"$status"
+grep -q '^application-1-provider-ready yes$' <<<"$status"
+"${cli[@]}" packet-generator enable-stream uet-ambiguous-rx
+for _ in $(seq 1 100); do
+  status=$("${cli[@]}" show uet | tr -d '\r')
+  grep -q '^rx-ambiguous 1$' <<<"$status" && break
+  sleep 0.01
+done
+grep -q '^rx-ambiguous 1$' <<<"$status"
+grep -q '^rx-delivered 0$' <<<"$status"
+
+kill "$hold_pid_a" "$hold_pid_b"
+wait "$hold_pid_a" 2>/dev/null || true
+wait "$hold_pid_b" 2>/dev/null || true
+hold_pid_a=
+hold_pid_b=
+
+"${cli[@]}" uet svm delete name "$segment_name_a"
+"${cli[@]}" uet svm delete name "$segment_name_b"
+"${cli[@]}" uet svm create name "$segment_name_a" queue-size 256
+"${cli[@]}" uet svm create name "$segment_name_b" queue-size 256
+
+LD_LIBRARY_PATH="$library_path" "$endpoint_smoke_bin" "$segment_name_a" \
+  "$runtime_dir/uet-dma.sock" hold 777 >"$runtime_dir/collision-holder.log" 2>&1 &
+collision_holder_pid=$!
+for _ in $(seq 1 500); do
+  grep -q '^endpoint control ready: pid 777$' "$runtime_dir/collision-holder.log" 2>/dev/null && break
+  sleep 0.01
+done
+grep -q '^endpoint control ready: pid 777$' "$runtime_dir/collision-holder.log"
+LD_LIBRARY_PATH="$library_path" "$endpoint_smoke_bin" "$segment_name_b" \
+  "$runtime_dir/uet-dma.sock" expect-collision 777
+status=$("${cli[@]}" show uet | tr -d '\r')
+grep -q '^endpoint-registrations 1$' <<<"$status"
+grep -q '^endpoint-collisions 1$' <<<"$status"
+kill -KILL "$collision_holder_pid"
+wait "$collision_holder_pid" 2>/dev/null || true
+collision_holder_pid=
+"${cli[@]}" uet svm delete name "$segment_name_a"
+"${cli[@]}" uet svm create name "$segment_name_a" queue-size 256
+LD_LIBRARY_PATH="$library_path" "$endpoint_smoke_bin" "$segment_name_b" \
+  "$runtime_dir/uet-dma.sock" control 777
+"${cli[@]}" show uet | tr -d '\r' | grep -q '^endpoint-registrations 0$'
+
+"${cli[@]}" clear uet counters
+LD_LIBRARY_PATH="$library_path" "$endpoint_smoke_bin" "$segment_name_a" \
+  "$runtime_dir/uet-dma.sock" >"$runtime_dir/endpoint-a.log" 2>&1 &
+endpoint_pid_a=$!
+LD_LIBRARY_PATH="$library_path" "$endpoint_smoke_bin" "$segment_name_b" \
+  "$runtime_dir/uet-dma.sock" >"$runtime_dir/endpoint-b.log" 2>&1 &
+endpoint_pid_b=$!
+for _ in $(seq 1 500); do
+  if grep -q '^endpoint ready: namespace ' "$runtime_dir/endpoint-a.log" 2>/dev/null &&
+    grep -q '^endpoint ready: namespace ' "$runtime_dir/endpoint-b.log" 2>/dev/null; then
+    break
+  fi
+  sleep 0.01
+done
+grep -q '^endpoint ready: namespace ' "$runtime_dir/endpoint-a.log"
+grep -q '^endpoint ready: namespace ' "$runtime_dir/endpoint-b.log"
+namespace_a=$(awk '/^endpoint ready: namespace / { print $4; exit }' "$runtime_dir/endpoint-a.log")
+namespace_b=$(awk '/^endpoint ready: namespace / { print $4; exit }' "$runtime_dir/endpoint-b.log")
+printf -v pid_a_hex '%04x' "$namespace_a"
+printf -v pid_b_hex '%04x' "$namespace_b"
+printf -v pdc_a_hex '%04x' "$(((namespace_a << 6) | 1))"
+printf -v pdc_b_hex '%04x' "$(((namespace_b << 6) | 1))"
+printf -v pkt_a_hex '%08x' "$(((namespace_a << 22) | 1))"
+printf -v pkt_b_hex '%08x' "$(((namespace_b << 22) | 1))"
+printf -v sng_pid_a_hex '%04x' "$namespace_a"
+printf -v sng_pid_b_hex '%04x' "$namespace_b"
+
+inject_endpoint_packet()
+{
+  local name=$1
+  local udp_source=$2
+  local packet_size=$3
+  local payload=$4
+
+  "${cli[@]}" "packet-generator new {
+    name $name
+    limit 1
+    worker 0
+    node ip4-input
+    interface loop0
+    size $packet_size-$packet_size
+    data {
+      UDP: 198.18.0.2 -> 198.18.0.1
+      UDP: $udp_source -> 49150
+      hex 0x$payload
+    }
+  }"
+  "${cli[@]}" packet-generator enable-stream "$name"
+}
+
+inject_endpoint_routes()
+{
+  local label=$1
+  local pid_hex=$2
+  local pdc_hex=$3
+  local pkt_hex=$4
+  local port_base=$5
+  local sng_pid_hex=$6
+  local ses="0008000100000000${pid_hex}000f"
+
+  inject_endpoint_packet "uet-$label-rud-syn" "$((port_base + 0))" 52 \
+    "11840000000000a100010000${ses}"
+  inject_endpoint_packet "uet-$label-rud-established" "$((port_base + 1))" 40 \
+    "10000000000000a20001${pdc_hex}"
+  inject_endpoint_packet "uet-$label-ack" "$((port_base + 2))" 40 \
+    "38000000000000a30001${pdc_hex}"
+  inject_endpoint_packet "uet-$label-nack-pdc" "$((port_base + 3))" 44 \
+    "50000100000000a40001${pdc_hex}00000000"
+  inject_endpoint_packet "uet-$label-control" "$((port_base + 4))" 44 \
+    "58800000000000a50001${pdc_hex}00000000"
+  inject_endpoint_packet "uet-$label-rudi-request" "$((port_base + 5))" 48 \
+    "21800000000000a6${ses}"
+  inject_endpoint_packet "uet-$label-rudi-response" "$((port_base + 6))" 36 \
+    "28000000${pkt_hex}"
+  inject_endpoint_packet "uet-$label-nack-rudi" "$((port_base + 7))" 44 \
+    "50080100${pkt_hex}0000000000000000"
+  inject_endpoint_packet "uet-$label-uud-request" "$((port_base + 8))" 44 \
+    "31800000${ses}"
+  inject_endpoint_packet "uet-$label-sng-request" "$((port_base + 9))" 52 \
+    "11880000000000a70000000f${ses}"
+  inject_endpoint_packet "uet-$label-sng-ack" "$((port_base + 10))" 48 \
+    "3a000000000000a8${sng_pid_hex}000f0000000100000000"
+}
+
+inject_endpoint_routes endpoint-a "$pid_a_hex" "$pdc_a_hex" "$pkt_a_hex" 10000 \
+  "$sng_pid_a_hex"
+inject_endpoint_routes endpoint-b "$pid_b_hex" "$pdc_b_hex" "$pkt_b_hex" 10016 \
+  "$sng_pid_b_hex"
+if ! wait "$endpoint_pid_a"; then
+  endpoint_pid_a=
+  cat "$runtime_dir/endpoint-a.log" >&2
+  exit 1
+fi
+endpoint_pid_a=
+if ! wait "$endpoint_pid_b"; then
+  endpoint_pid_b=
+  cat "$runtime_dir/endpoint-b.log" >&2
+  exit 1
+fi
+endpoint_pid_b=
+grep -q "^endpoint RX namespace $namespace_a passed$" "$runtime_dir/endpoint-a.log"
+grep -q "^endpoint RX namespace $namespace_b passed$" "$runtime_dir/endpoint-b.log"
+status=$("${cli[@]}" show uet | tr -d '\r')
+grep -q '^rx-delivered 22$' <<<"$status"
+grep -q '^rx-ambiguous 0$' <<<"$status"
+grep -q '^rx-releases 22$' <<<"$status"
+grep -q '^endpoint-registrations 0$' <<<"$status"
+
+"${cli[@]}" uet svm delete name "$segment_name_a"
+"${cli[@]}" uet svm delete name "$segment_name_b"
+echo "UET two-process, $worker_count-worker endpoint demux smoke test passed; logs: $runtime_dir"

--- a/vpp-plugin/tests/smoke-one-worker.sh
+++ b/vpp-plugin/tests/smoke-one-worker.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 4 ]]; then
+  echo "usage: $0 <vpp-prefix> <plugin-build-dir> [main-core] [worker-core]" >&2
+  exit 2
+fi
+
+vpp_prefix=$1
+plugin_build_dir=$2
+main_core=${3:-2}
+worker_core=${4:-3}
+
+vpp_bin="$vpp_prefix/bin/vpp"
+vppctl_bin="$vpp_prefix/bin/vppctl"
+vat2_bin="$vpp_prefix/bin/vat2"
+plugin_dir="$plugin_build_dir/lib/vpp_plugins"
+vat2_plugin_dir="$plugin_build_dir/lib/vat2_plugins"
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+runtime_dir=$(mktemp -d /tmp/uet-vpp-smoke.XXXXXX)
+config_file="$runtime_dir/startup.conf"
+stdout_file="$runtime_dir/stdout.log"
+api_prefix="uet-thread-$$"
+vpp_pid=
+
+cleanup()
+{
+  if [[ -n "$vpp_pid" ]] && kill -0 "$vpp_pid" 2>/dev/null; then
+    kill "$vpp_pid"
+    wait "$vpp_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+for required in "$vpp_bin" "$vppctl_bin" "$vat2_bin" \
+  "$plugin_dir/uet_plugin.so" "$vat2_plugin_dir/uet_test_plugin_uet_plugin.so"; do
+  if [[ ! -e "$required" ]]; then
+    echo "missing required file: $required" >&2
+    exit 1
+  fi
+done
+
+sed \
+  -e "s|@RUNTIME_DIR@|$runtime_dir|g" \
+  -e "s|@API_PREFIX@|$api_prefix|g" \
+  -e "s|@PLUGIN_DIR@|$plugin_dir|g" \
+  -e "s|@MAIN_CORE@|$main_core|g" \
+  -e "s|@WORKER_CORE@|$worker_core|g" \
+  "$script_dir/startup-one-worker.conf.in" >"$config_file"
+
+"$vpp_bin" -c "$config_file" >"$stdout_file" 2>&1 &
+vpp_pid=$!
+
+for _ in $(seq 1 100); do
+  [[ -S "$runtime_dir/cli.sock" ]] && break
+  if ! kill -0 "$vpp_pid" 2>/dev/null; then
+    echo "VPP exited before creating its CLI socket" >&2
+    cat "$stdout_file" >&2
+    exit 1
+  fi
+  sleep 0.05
+done
+
+if [[ ! -S "$runtime_dir/cli.sock" ]]; then
+  echo "timed out waiting for VPP CLI socket" >&2
+  cat "$stdout_file" >&2
+  exit 1
+fi
+
+cli=("$vppctl_bin" -s "$runtime_dir/cli.sock")
+
+unexpected_output=$("${cli[@]}" uet enable unexpected 2>&1 || true)
+grep -Eq '(unexpected|unknown) input' <<<"$unexpected_output"
+unexpected_output=$("${cli[@]}" show uet unexpected 2>&1 || true)
+grep -Eq '(unexpected|unknown) input' <<<"$unexpected_output"
+unexpected_output=$("${cli[@]}" uet svm delete unexpected 2>&1 || true)
+grep -Eq '(unexpected|unknown) input' <<<"$unexpected_output"
+
+"${cli[@]}" show version
+"${cli[@]}" show threads
+"${cli[@]}" show plugins | grep -F uet_plugin.so
+"${cli[@]}" uet enable
+sleep 0.2
+status=$("${cli[@]}" show uet | tr -d '\r')
+printf '%s\n' "$status"
+
+grep -q '^state enabled$' <<<"$status"
+grep -q '^owner-worker .* (1)$' <<<"$status"
+grep -q '^tx-ip4-table 0$' <<<"$status"
+grep -q '^tx-ip6-table 0$' <<<"$status"
+poll_calls=$(awk '/^poll-calls / { print $2 }' <<<"$status")
+if [[ -z "$poll_calls" || "$poll_calls" -eq 0 ]]; then
+  echo "UET worker did not poll" >&2
+  exit 1
+fi
+
+api_details=$("$vat2_bin" -s "$api_prefix" -p "$vat2_plugin_dir" \
+  uet_worker_dump '{}')
+printf '%s\n' "$api_details"
+grep -q '"worker_index"[[:space:]]*:[[:space:]]*0' <<<"$api_details"
+grep -q '"thread_index"[[:space:]]*:[[:space:]]*1' <<<"$api_details"
+grep -q '"enabled"[[:space:]]*:[[:space:]]*true' <<<"$api_details"
+grep -q '"tx_configured"[[:space:]]*:[[:space:]]*true' <<<"$api_details"
+grep -q '"tx_ip4_table_id"[[:space:]]*:[[:space:]]*0' <<<"$api_details"
+grep -q '"tx_ip6_table_id"[[:space:]]*:[[:space:]]*0' <<<"$api_details"
+
+log_output=$("${cli[@]}" show log | tr -d '\r')
+printf '%s\n' "$log_output"
+grep -q 'uet.*dataplane enabled with 1 workers' <<<"$log_output"
+
+"${cli[@]}" clear uet counters
+cleared_status=$("${cli[@]}" show uet | tr -d '\r')
+grep -q '^tx-requests 0$' <<<"$cleared_status"
+grep -q '^invalid-requests 0$' <<<"$cleared_status"
+
+"${cli[@]}" uet disable
+"${cli[@]}" show uet | tr -d '\r' | grep -q '^state disabled$'
+
+echo "UET one-worker smoke test passed; logs: $runtime_dir"

--- a/vpp-plugin/tests/smoke-svm.sh
+++ b/vpp-plugin/tests/smoke-svm.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 4 ]]; then
+  echo "usage: $0 <vpp-prefix> <plugin-build-dir> [main-core] [worker-core]" >&2
+  exit 2
+fi
+
+vpp_prefix=$1
+plugin_build_dir=$2
+main_core=${3:-2}
+worker_core=${4:-3}
+
+vpp_bin="$vpp_prefix/bin/vpp"
+vppctl_bin="$vpp_prefix/bin/vppctl"
+vat2_bin="$vpp_prefix/bin/vat2"
+plugin_dir="$plugin_build_dir/lib/vpp_plugins"
+vat2_plugin_dir="$plugin_build_dir/lib/vat2_plugins"
+tx_client_bin="$plugin_build_dir/bin/uet_vpp_tx_smoke"
+negative_client_bin="$plugin_build_dir/bin/uet_vpp_spsc_negative"
+owner_probe_bin="$plugin_build_dir/bin/uet_vpp_owner_probe"
+dma_auth_probe_bin="$plugin_build_dir/bin/uet_dma_auth_probe"
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+svm_abi_header="$script_dir/../uet/svm_abi.h"
+svm_abi_major=$(sed -n \
+  's/^#define UET_VPP_SVM_ABI_MAJOR[[:space:]][[:space:]]*//p' "$svm_abi_header")
+svm_abi_minor=$(sed -n \
+  's/^#define UET_VPP_SVM_ABI_MINOR[[:space:]][[:space:]]*//p' "$svm_abi_header")
+runtime_dir=$(mktemp -d /tmp/uet-vpp-svm.XXXXXX)
+config_file="$runtime_dir/startup.conf"
+stdout_file="$runtime_dir/stdout.log"
+api_prefix="uet-svm-$$"
+segment_name="uet-svm-$$"
+queue_depth=${UET_SVM_QUEUE_DEPTH:-257}
+tx_packet_count=4096
+rx_packet_count=4
+ip4_table_id=7
+ip6_table_id=8
+vpp_pid=
+negative_pid=
+owner_probe_pid=
+
+if [[ ! "$queue_depth" =~ ^[0-9]+$ ]] || (( queue_depth < 8 || queue_depth > 4096 )); then
+  echo "UET_SVM_QUEUE_DEPTH must be between 8 and 4096" >&2
+  exit 2
+fi
+
+cleanup()
+{
+  if [[ -n "$owner_probe_pid" ]] && kill -0 "$owner_probe_pid" 2>/dev/null; then
+    kill "$owner_probe_pid"
+    wait "$owner_probe_pid" 2>/dev/null || true
+  fi
+  if [[ -n "$negative_pid" ]] && kill -0 "$negative_pid" 2>/dev/null; then
+    kill "$negative_pid"
+    wait "$negative_pid" 2>/dev/null || true
+  fi
+  if [[ -n "$vpp_pid" ]] && kill -0 "$vpp_pid" 2>/dev/null; then
+    kill "$vpp_pid"
+    wait "$vpp_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+for required in \
+  "$vpp_bin" \
+  "$vppctl_bin" \
+  "$vat2_bin" \
+  "$plugin_dir/uet_plugin.so" \
+  "$vat2_plugin_dir/uet_test_plugin_uet_plugin.so" \
+  "$tx_client_bin" \
+  "$negative_client_bin" \
+  "$owner_probe_bin" \
+  "$dma_auth_probe_bin" \
+  "$plugin_build_dir/lib/libuet_vpp_client.so"; do
+  if [[ ! -e "$required" ]]; then
+    echo "missing required file: $required" >&2
+    exit 1
+  fi
+done
+
+sed \
+  -e "s|@RUNTIME_DIR@|$runtime_dir|g" \
+  -e "s|@API_PREFIX@|$api_prefix|g" \
+  -e "s|@PLUGIN_DIR@|$plugin_dir|g" \
+  -e "s|@MAIN_CORE@|$main_core|g" \
+  -e "s|@WORKER_CORE@|$worker_core|g" \
+  "$script_dir/startup-one-worker.conf.in" >"$config_file"
+
+"$vpp_bin" -c "$config_file" >"$stdout_file" 2>&1 &
+vpp_pid=$!
+
+for _ in $(seq 1 100); do
+  [[ -S "$runtime_dir/cli.sock" ]] && break
+  if ! kill -0 "$vpp_pid" 2>/dev/null; then
+    echo "VPP exited before creating its CLI socket" >&2
+    cat "$stdout_file" >&2
+    exit 1
+  fi
+  sleep 0.05
+done
+
+if [[ ! -S "$runtime_dir/cli.sock" ]]; then
+  echo "timed out waiting for VPP CLI socket" >&2
+  cat "$stdout_file" >&2
+  exit 1
+fi
+
+cli=("$vppctl_bin" -s "$runtime_dir/cli.sock")
+vat2=("$vat2_bin" -s "$api_prefix" -p "$vat2_plugin_dir")
+
+"${cli[@]}" uet enable
+create_reply=$("${vat2[@]}" uet_svm_create \
+  "{\"segment_name\":\"$segment_name\",\"queue_depth\":$queue_depth}")
+printf '%s\n' "$create_reply"
+grep -Eq '"retval":[[:space:]]*0' <<<"$create_reply"
+
+status=$("${cli[@]}" show uet | tr -d '\r')
+printf '%s\n' "$status"
+grep -q '^state enabled$' <<<"$status"
+grep -q '^owner-worker .* (1)$' <<<"$status"
+grep -q '^svm-state attached$' <<<"$status"
+grep -q "^svm-segment $segment_name$" <<<"$status"
+grep -q "^svm-abi ${svm_abi_major}\\.${svm_abi_minor}$" <<<"$status"
+grep -q "^svm-queue-depth $queue_depth$" <<<"$status"
+grep -q "^svm-dma-slot-count $queue_depth$" <<<"$status"
+grep -Eq '^svm-dma-buffer-data-size [1-9][0-9]*$' <<<"$status"
+grep -Eq '^svm-dma-map-size [1-9][0-9]*$' <<<"$status"
+grep -q "^svm-dma-socket $runtime_dir/uet-dma.sock$" <<<"$status"
+grep -q '^tx-ip4-table 0$' <<<"$status"
+grep -q '^tx-ip6-table 0$' <<<"$status"
+
+"${cli[@]}" loopback create
+"${cli[@]}" set interface state loop0 up
+"${cli[@]}" set interface ip address loop0 198.18.0.1/24
+"${cli[@]}" "packet-generator new {
+  name uet-rx
+  limit $rx_packet_count
+  worker 0
+  node ip4-input
+  interface loop0
+  size 64-64
+  data {
+    UDP: 198.18.0.2 -> 198.18.0.1
+    UDP: 10000 -> 49150
+    incrementing 36
+  }
+}"
+"${cli[@]}" "packet-generator new {
+  name uet-crash-rx
+  limit 1
+  worker 0
+  node ip4-input
+  interface loop0
+  size 64-64
+  data {
+    UDP: 198.18.0.2 -> 198.18.0.1
+    UDP: 10000 -> 49150
+    incrementing 36
+  }
+}"
+
+library_path="$plugin_build_dir/lib:$vpp_prefix/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+env LD_LIBRARY_PATH="$library_path" \
+  "$negative_client_bin" "$segment_name" "$runtime_dir/uet-dma.sock" "$rx_packet_count" \
+  >"$runtime_dir/negative-client.log" 2>&1 &
+negative_pid=$!
+for _ in $(seq 1 100); do
+  if "${cli[@]}" show uet | tr -d '\r' | grep -q '^provider-ready yes$'; then
+    break
+  fi
+  if ! kill -0 "$negative_pid" 2>/dev/null; then
+    cat "$runtime_dir/negative-client.log" >&2
+    exit 1
+  fi
+  sleep 0.01
+done
+if ! "${cli[@]}" show uet | tr -d '\r' | grep -q '^provider-ready yes$'; then
+  echo "negative client did not become ready" >&2
+  exit 1
+fi
+LD_LIBRARY_PATH="$library_path" "$owner_probe_bin" "$segment_name" expect-busy
+"${cli[@]}" show uet | tr -d '\r' | grep -q "^provider-owner-pid $negative_pid$"
+"${cli[@]}" packet-generator enable-stream uet-rx
+if ! wait "$negative_pid"; then
+  negative_pid=
+  cat "$runtime_dir/negative-client.log" >&2
+  exit 1
+fi
+negative_pid=
+negative_client_output=$(<"$runtime_dir/negative-client.log")
+printf '%s\n' "$negative_client_output"
+grep -q "UET SPSC negative smoke passed: ownership checks, $rx_packet_count RX packets, and $queue_depth-entry completion ring" \
+  <<<"$negative_client_output"
+
+status=$("${cli[@]}" show uet | tr -d '\r')
+printf '%s\n' "$status"
+grep -q "^tx-requests $((queue_depth + 1))$" <<<"$status"
+grep -q "^invalid-requests $((queue_depth + 1))$" <<<"$status"
+grep -q '^tx-packets 0$' <<<"$status"
+grep -q "^tx-completions $((queue_depth + 1))$" <<<"$status"
+grep -q "^rx-udp4-packets $rx_packet_count$" <<<"$status"
+grep -q "^rx-delivered $rx_packet_count$" <<<"$status"
+grep -q "^rx-releases $rx_packet_count$" <<<"$status"
+grep -q '^rx-invalid-releases 0$' <<<"$status"
+grep -q '^rx-outstanding 0$' <<<"$status"
+grep -q '^dma-authorized-clients 1$' <<<"$status"
+grep -q '^dma-rejected-clients 0$' <<<"$status"
+grep -q '^tx-pending 0$' <<<"$status"
+grep -q '^tx-completions-pending 0$' <<<"$status"
+grep -q '^provider-owner-pid 0$' <<<"$status"
+
+LD_LIBRARY_PATH="$library_path" "$owner_probe_bin" "$segment_name" expect-double-busy
+LD_LIBRARY_PATH="$library_path" "$owner_probe_bin" "$segment_name" expect-existing-heap
+LD_LIBRARY_PATH="$library_path" "$owner_probe_bin" "$segment_name" expect-success
+"${cli[@]}" show uet | tr -d '\r' | grep -q '^provider-owner-pid 0$'
+
+"${cli[@]}" clear uet counters
+
+"$dma_auth_probe_bin" "$runtime_dir/uet-dma.sock"
+
+"${cli[@]}" ip table add "$ip4_table_id"
+"${cli[@]}" ip6 table add "$ip6_table_id"
+fib_reply=$("${vat2[@]}" uet_tx_fib_set \
+  "{\"ip4_table_id\":$ip4_table_id,\"ip6_table_id\":$ip6_table_id}")
+printf '%s\n' "$fib_reply"
+grep -Eq '"retval":[[:space:]]*0' <<<"$fib_reply"
+
+tx_client_output=$(LD_LIBRARY_PATH="$plugin_build_dir/lib:$vpp_prefix/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+  "$tx_client_bin" "$segment_name" "$tx_packet_count" "$runtime_dir/uet-dma.sock")
+printf '%s\n' "$tx_client_output"
+grep -q "UET routed TX smoke passed: $tx_packet_count packets" <<<"$tx_client_output"
+
+status=$("${cli[@]}" show uet | tr -d '\r')
+printf '%s\n' "$status"
+grep -q "^tx-requests $tx_packet_count$" <<<"$status"
+grep -q '^invalid-requests 0$' <<<"$status"
+grep -q "^tx-ip4-table $ip4_table_id$" <<<"$status"
+grep -q "^tx-ip6-table $ip6_table_id$" <<<"$status"
+grep -q "^tx-packets $tx_packet_count$" <<<"$status"
+grep -q "^tx-completions $tx_packet_count$" <<<"$status"
+grep -q '^dma-authorized-clients 1$' <<<"$status"
+grep -q '^dma-rejected-clients 1$' <<<"$status"
+grep -q '^tx-pending 0$' <<<"$status"
+grep -q '^tx-completions-pending 0$' <<<"$status"
+
+env LD_LIBRARY_PATH="$library_path" \
+  "$owner_probe_bin" "$segment_name" hold-dma "$runtime_dir/uet-dma.sock" \
+  >"$runtime_dir/owner-probe.log" 2>&1 &
+owner_probe_pid=$!
+for _ in $(seq 1 100); do
+  grep -q '^owner ready:' "$runtime_dir/owner-probe.log" 2>/dev/null && break
+  if ! kill -0 "$owner_probe_pid" 2>/dev/null; then
+    cat "$runtime_dir/owner-probe.log" >&2
+    exit 1
+  fi
+  sleep 0.01
+done
+grep -q '^owner ready:' "$runtime_dir/owner-probe.log"
+"${cli[@]}" show uet | tr -d '\r' | grep -q "^provider-owner-pid $owner_probe_pid$"
+"${cli[@]}" packet-generator enable-stream uet-crash-rx
+for _ in $(seq 1 100); do
+  "${cli[@]}" show uet | tr -d '\r' | grep -q '^rx-outstanding 1$' && break
+  sleep 0.01
+done
+"${cli[@]}" show uet | tr -d '\r' | grep -q '^rx-outstanding 1$'
+busy_delete_reply=$("${vat2[@]}" uet_svm_delete "{\"segment_name\":\"$segment_name\"}")
+printf '%s\n' "$busy_delete_reply"
+grep -Eq '"retval":[[:space:]]*-[1-9][0-9]*' <<<"$busy_delete_reply"
+"${cli[@]}" show uet | tr -d '\r' | grep -q '^svm-state attached$'
+dead_owner_pid=$owner_probe_pid
+kill -KILL "$owner_probe_pid"
+wait "$owner_probe_pid" 2>/dev/null || true
+owner_probe_pid=
+LD_LIBRARY_PATH="$library_path" "$owner_probe_bin" "$segment_name" expect-owner-dead
+"${cli[@]}" show uet | tr -d '\r' | grep -q "^provider-owner-pid $dead_owner_pid$"
+
+delete_reply=$("${vat2[@]}" uet_svm_delete "{\"segment_name\":\"$segment_name\"}")
+printf '%s\n' "$delete_reply"
+grep -Eq '"retval":[[:space:]]*0' <<<"$delete_reply"
+"${cli[@]}" show uet | tr -d '\r' | grep -q '^svm-state detached$'
+
+create_reply=$("${vat2[@]}" uet_svm_create \
+  "{\"segment_name\":\"$segment_name\",\"queue_depth\":$queue_depth}")
+printf '%s\n' "$create_reply"
+grep -Eq '"retval":[[:space:]]*0' <<<"$create_reply"
+LD_LIBRARY_PATH="$library_path" "$owner_probe_bin" "$segment_name" expect-success
+"${cli[@]}" show uet | tr -d '\r' | grep -q '^provider-owner-pid 0$'
+delete_reply=$("${vat2[@]}" uet_svm_delete "{\"segment_name\":\"$segment_name\"}")
+printf '%s\n' "$delete_reply"
+grep -Eq '"retval":[[:space:]]*0' <<<"$delete_reply"
+"${cli[@]}" uet disable
+
+echo "UET SPSC channel smoke test passed; logs: $runtime_dir"

--- a/vpp-plugin/tests/startup-one-worker.conf.in
+++ b/vpp-plugin/tests/startup-one-worker.conf.in
@@ -1,0 +1,25 @@
+unix {
+  nodaemon
+  runtime-dir @RUNTIME_DIR@
+  cli-listen @RUNTIME_DIR@/cli.sock
+  log @RUNTIME_DIR@/vpp.log
+}
+
+api-segment {
+  prefix @API_PREFIX@
+}
+
+statseg {
+  socket-name @RUNTIME_DIR@/stats.sock
+}
+
+cpu {
+  main-core @MAIN_CORE@
+  corelist-workers @WORKER_CORE@
+}
+
+plugins {
+  path @PLUGIN_DIR@
+  plugin default { disable }
+  plugin uet_plugin.so { enable }
+}

--- a/vpp-plugin/tests/startup-worker-contract.conf.in
+++ b/vpp-plugin/tests/startup-worker-contract.conf.in
@@ -1,0 +1,29 @@
+unix {
+  nodaemon
+  runtime-dir @RUNTIME_DIR@
+  cli-listen @RUNTIME_DIR@/cli.sock
+  log @RUNTIME_DIR@/vpp.log
+}
+
+api-segment {
+  prefix @API_PREFIX@
+}
+
+statseg {
+  socket-name @RUNTIME_DIR@/stats.sock
+}
+
+cpu {
+  main-core @MAIN_CORE@
+  @WORKER_STANZA@
+}
+
+buffers {
+  buffers-per-numa @BUFFERS_PER_NUMA@
+}
+
+plugins {
+  path @PLUGIN_DIR@
+  plugin default { disable }
+  plugin uet_plugin.so { enable }
+}

--- a/vpp-plugin/tools/CMakeLists.txt
+++ b/vpp-plugin/tools/CMakeLists.txt
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+
+add_executable(uet_vpp_tx_smoke tx_smoke.c)
+target_link_libraries(uet_vpp_tx_smoke PRIVATE uet_vpp_client pthread)
+
+add_executable(uet_vpp_spsc_negative spsc_negative.c)
+target_link_libraries(uet_vpp_spsc_negative PRIVATE uet_vpp_client)
+
+add_executable(uet_vpp_owner_probe owner_probe.c)
+find_library(UET_TOOLS_VPPINFRA_LIBRARY NAMES vppinfra REQUIRED)
+target_link_libraries(uet_vpp_owner_probe PRIVATE
+  uet_vpp_client
+  ${UET_TOOLS_VPPINFRA_LIBRARY}
+)
+
+add_executable(uet_vpp_endpoint_smoke endpoint_smoke.c)
+target_link_libraries(uet_vpp_endpoint_smoke PRIVATE uet_vpp_client)
+
+add_executable(uet_dma_auth_probe dma_auth_probe.c)

--- a/vpp-plugin/tools/dma_auth_probe.c
+++ b/vpp-plugin/tools/dma_auth_probe.c
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <uet/dma_abi.h>
+
+int
+main (int argc, char **argv)
+{
+  struct sockaddr_un address = { .sun_family = AF_UNIX };
+  uet_vpp_dma_reply_t reply = { 0 };
+  char control[CMSG_SPACE (sizeof (int))] = { 0 };
+  struct iovec iov = { .iov_base = &reply, .iov_len = sizeof (reply) };
+  struct msghdr message = {
+    .msg_iov = &iov,
+    .msg_iovlen = 1,
+    .msg_control = control,
+    .msg_controllen = sizeof (control),
+  };
+  int socket_fd;
+  int received_fd = -1;
+  ssize_t received;
+
+  if (argc != 2 || !argv[1][0] || strlen (argv[1]) >= sizeof (address.sun_path))
+    {
+      fprintf (stderr, "usage: %s <dma-socket>\n", argv[0]);
+      return 2;
+    }
+
+  socket_fd = socket (AF_UNIX, SOCK_SEQPACKET | SOCK_CLOEXEC, 0);
+  if (socket_fd < 0)
+    {
+      perror ("socket");
+      return 1;
+    }
+  memcpy (address.sun_path, argv[1], strlen (argv[1]) + 1);
+  if (connect (socket_fd, (struct sockaddr *) &address, sizeof (address)) != 0)
+    {
+      perror ("connect");
+      close (socket_fd);
+      return 1;
+    }
+
+  received = recvmsg (socket_fd, &message, MSG_CMSG_CLOEXEC);
+  if (received != sizeof (reply) || (message.msg_flags & (MSG_TRUNC | MSG_CTRUNC)))
+    {
+      if (received < 0)
+	perror ("recvmsg");
+      else
+	fprintf (stderr, "invalid DMA reply length %zd\n", received);
+      close (socket_fd);
+      return 1;
+    }
+
+  for (struct cmsghdr *cmsg = CMSG_FIRSTHDR (&message); cmsg; cmsg = CMSG_NXTHDR (&message, cmsg))
+    if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS &&
+	cmsg->cmsg_len >= CMSG_LEN (sizeof (received_fd)))
+      {
+	memcpy (&received_fd, CMSG_DATA (cmsg), sizeof (received_fd));
+	break;
+      }
+  close (socket_fd);
+
+  if (received_fd >= 0)
+    close (received_fd);
+  if (reply.magic != UET_VPP_DMA_ABI_MAGIC || reply.version != UET_VPP_DMA_ABI_VERSION ||
+      reply.status != -EACCES || received_fd >= 0)
+    {
+      fprintf (stderr, "unauthorized DMA request returned status %d and fd %d\n", reply.status,
+	       received_fd);
+      return 1;
+    }
+
+  printf ("unauthorized DMA client rejected without a file descriptor\n");
+  return 0;
+}

--- a/vpp-plugin/tools/endpoint_smoke.c
+++ b/vpp-plugin/tools/endpoint_smoke.c
@@ -1,0 +1,395 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <uet_vpp_client.h>
+
+#define UET_ENDPOINT_SMOKE_RI	   15
+#define UET_ENDPOINT_SMOKE_PORT	   49150
+#define UET_ENDPOINT_SMOKE_WAIT_NS UINT64_C (5000000000)
+
+#define UET_ENDPOINT_SMOKE_PDS_TYPE_SHIFT 11
+#define UET_ENDPOINT_SMOKE_PDS_TYPE_MASK  0x1f
+#define UET_ENDPOINT_SMOKE_PDS_SYN	  0x04
+#define UET_ENDPOINT_SMOKE_PDS_NACK_RUDI  0x08
+#define UET_ENDPOINT_SMOKE_PDC_BITS	  6
+#define UET_ENDPOINT_SMOKE_RUDI_BITS	  22
+
+typedef enum
+{
+  UET_ENDPOINT_ROUTE_RUD_SYN = 1U << 0,
+  UET_ENDPOINT_ROUTE_RUD_ESTABLISHED = 1U << 1,
+  UET_ENDPOINT_ROUTE_ACK = 1U << 2,
+  UET_ENDPOINT_ROUTE_NACK_PDC = 1U << 3,
+  UET_ENDPOINT_ROUTE_CTRL = 1U << 4,
+  UET_ENDPOINT_ROUTE_RUDI_REQUEST = 1U << 5,
+  UET_ENDPOINT_ROUTE_RUDI_RESPONSE = 1U << 6,
+  UET_ENDPOINT_ROUTE_NACK_RUDI = 1U << 7,
+  UET_ENDPOINT_ROUTE_UUD_REQUEST = 1U << 8,
+  UET_ENDPOINT_ROUTE_SNG_REQUEST = 1U << 9,
+  UET_ENDPOINT_ROUTE_SNG_ACK = 1U << 10,
+} uet_endpoint_route_t;
+
+#define UET_ENDPOINT_ROUTE_ALL ((1U << 11) - 1)
+
+static int
+usage (const char *program)
+{
+  fprintf (stderr, "usage: %s <segment-name> <dma-socket>\n", program);
+  fprintf (stderr,
+	   "       %s <segment-name> <dma-socket> "
+	   "<hold|expect-collision|control> <pid-on-fep>\n",
+	   program);
+  return 2;
+}
+
+static uint64_t
+monotonic_ns (void)
+{
+  struct timespec now;
+
+  if (clock_gettime (CLOCK_MONOTONIC, &now))
+    return 0;
+  return (uint64_t) now.tv_sec * UINT64_C (1000000000) + now.tv_nsec;
+}
+
+static size_t
+copy_rx_prefix (const uet_vpp_client_rx_t *rx, uint8_t *dst, size_t capacity)
+{
+  size_t copied = 0;
+
+  for (uint16_t i = 0; i < rx->iov_count && copied < capacity; i++)
+    {
+      size_t length = rx->iov[i].length;
+
+      if (length > capacity - copied)
+	length = capacity - copied;
+      memcpy (dst + copied, rx->iov[i].base, length);
+      copied += length;
+    }
+  return copied;
+}
+
+static int
+validate_endpoint (const uint8_t *packet, size_t copied, size_t ses_offset, uint16_t expected_pid)
+{
+  uint16_t value;
+
+  if (copied < ses_offset + 12)
+    return -EPROTO;
+  memcpy (&value, packet + ses_offset + 8, sizeof (value));
+  if ((ntohs (value) & 0x0fff) != expected_pid)
+    return -EPROTO;
+  memcpy (&value, packet + ses_offset + 10, sizeof (value));
+  if ((ntohs (value) & 0x0fff) != UET_ENDPOINT_SMOKE_RI)
+    return -EPROTO;
+  return 0;
+}
+
+static int
+validate_pdc (const uint8_t *packet, size_t copied, size_t pds_offset, uint16_t expected_namespace)
+{
+  uint16_t value;
+
+  if (copied < pds_offset + 12)
+    return -EPROTO;
+  memcpy (&value, packet + pds_offset + 10, sizeof (value));
+  return (ntohs (value) >> UET_ENDPOINT_SMOKE_PDC_BITS) == expected_namespace ? 0 : -EPROTO;
+}
+
+static int
+validate_sng (const uint8_t *packet, size_t copied, size_t pds_offset, uint16_t expected_namespace,
+	      int ack)
+{
+  uint16_t pid, index;
+
+  if (copied < pds_offset + 12)
+    return -EPROTO;
+  memcpy (&pid, packet + pds_offset + 8, sizeof (pid));
+  memcpy (&index, packet + pds_offset + 10, sizeof (index));
+  pid = ntohs (pid);
+  index = ntohs (index);
+
+  if (pid != (ack ? expected_namespace : 0) || index != UET_ENDPOINT_SMOKE_RI)
+    return -EPROTO;
+  return 0;
+}
+
+static int
+validate_pkt_id (const uint8_t *packet, size_t copied, size_t pds_offset,
+		 uint16_t expected_namespace)
+{
+  uint32_t value;
+
+  if (copied < pds_offset + 8)
+    return -EPROTO;
+  memcpy (&value, packet + pds_offset + 4, sizeof (value));
+  return (ntohl (value) >> UET_ENDPOINT_SMOKE_RUDI_BITS) == expected_namespace ? 0 : -EPROTO;
+}
+
+static int
+validate_rx (const uet_vpp_client_rx_t *rx, uint16_t expected_namespace, uint32_t *route)
+{
+  uint8_t packet[96];
+  uint16_t prologue, value;
+  uint8_t flags, type;
+  size_t copied, ip_header_size, pds_offset;
+
+  if (!(rx->flags & UET_VPP_CLIENT_RX_F_IP4) || !(rx->flags & UET_VPP_CLIENT_RX_F_UDP) ||
+      (rx->flags & UET_VPP_CLIENT_RX_F_IP6))
+    return -EPROTO;
+  copied = copy_rx_prefix (rx, packet, sizeof (packet));
+  if (copied < 20 || (packet[0] >> 4) != 4)
+    return -EPROTO;
+  ip_header_size = (packet[0] & 0x0f) * 4;
+  pds_offset = ip_header_size + 8;
+  if (ip_header_size < 20 || copied < pds_offset + sizeof (prologue))
+    return -EPROTO;
+  memcpy (&value, packet + ip_header_size + 2, sizeof (value));
+  if (ntohs (value) != UET_ENDPOINT_SMOKE_PORT)
+    return -EPROTO;
+  memcpy (&prologue, packet + pds_offset, sizeof (prologue));
+  prologue = ntohs (prologue);
+  type = (prologue >> UET_ENDPOINT_SMOKE_PDS_TYPE_SHIFT) & UET_ENDPOINT_SMOKE_PDS_TYPE_MASK;
+  flags = prologue & 0x7f;
+
+  switch (type)
+    {
+    case 2:  /* RUD request */
+    case 3:  /* ROD request */
+    case 13: /* RUD request with CC */
+    case 14: /* ROD request with CC */
+      if (flags & UET_ENDPOINT_SMOKE_PDS_SYN)
+	{
+	  size_t ses_offset = pds_offset + 12 + ((type == 13 || type == 14) ? 4 : 0);
+
+	  *route = UET_ENDPOINT_ROUTE_RUD_SYN;
+	  return validate_endpoint (packet, copied, ses_offset, expected_namespace);
+	}
+      memcpy (&value, packet + pds_offset + 10, sizeof (value));
+      if (!(ntohs (value) >> UET_ENDPOINT_SMOKE_PDC_BITS))
+	{
+	  *route = UET_ENDPOINT_ROUTE_SNG_REQUEST;
+	  return validate_sng (packet, copied, pds_offset, expected_namespace, 0);
+	}
+      *route = UET_ENDPOINT_ROUTE_RUD_ESTABLISHED;
+      return validate_pdc (packet, copied, pds_offset, expected_namespace);
+    case 4: /* RUDI request */
+      *route = UET_ENDPOINT_ROUTE_RUDI_REQUEST;
+      return validate_endpoint (packet, copied, pds_offset + 8, expected_namespace);
+    case 5: /* RUDI response */
+      *route = UET_ENDPOINT_ROUTE_RUDI_RESPONSE;
+      return validate_pkt_id (packet, copied, pds_offset, expected_namespace);
+    case 6: /* UUD request */
+      *route = UET_ENDPOINT_ROUTE_UUD_REQUEST;
+      return validate_endpoint (packet, copied, pds_offset + 4, expected_namespace);
+    case 7: /* ACK */
+    case 8: /* ACK with CC */
+    case 9: /* ACK with CCX */
+      memcpy (&value, packet + pds_offset + 8, sizeof (value));
+      if (ntohs (value) == expected_namespace)
+	{
+	  *route = UET_ENDPOINT_ROUTE_SNG_ACK;
+	  return validate_sng (packet, copied, pds_offset, expected_namespace, 1);
+	}
+      *route = UET_ENDPOINT_ROUTE_ACK;
+      return validate_pdc (packet, copied, pds_offset, expected_namespace);
+    case 10: /* NACK */
+    case 12: /* NACK with CCX */
+      if (flags & UET_ENDPOINT_SMOKE_PDS_NACK_RUDI)
+	{
+	  *route = UET_ENDPOINT_ROUTE_NACK_RUDI;
+	  return validate_pkt_id (packet, copied, pds_offset, expected_namespace);
+	}
+      *route = UET_ENDPOINT_ROUTE_NACK_PDC;
+      return validate_pdc (packet, copied, pds_offset, expected_namespace);
+    case 11: /* PDC control */
+      *route = UET_ENDPOINT_ROUTE_CTRL;
+      return validate_pdc (packet, copied, pds_offset, expected_namespace);
+    default:
+      return -EPROTO;
+    }
+}
+
+int
+main (int argc, char **argv)
+{
+  uet_vpp_client_endpoint_t endpoint = {
+    .ip_version = 4,
+    .absolute = 0,
+    .resource_index = UET_ENDPOINT_SMOKE_RI,
+    .job_id = 0,
+  };
+  const struct timespec pause_time = {
+    .tv_nsec = 1000000,
+  };
+  uet_vpp_client_t *client = 0;
+  uet_vpp_client_info_t info = { 0 };
+  uet_vpp_client_rx_t rx;
+  uint64_t deadline;
+  uint32_t received_routes = 0;
+  uint32_t rx_channel = 0;
+  unsigned long requested_pid = 0;
+  enum
+  {
+    MODE_RECEIVE,
+    MODE_HOLD,
+    MODE_EXPECT_COLLISION,
+    MODE_CONTROL,
+  } mode = MODE_RECEIVE;
+  int endpoint_added = 0;
+  int rc, rv = 1;
+
+  if (argc == 5)
+    {
+      char *end = 0;
+
+      if (!strcmp (argv[3], "hold"))
+	mode = MODE_HOLD;
+      else if (!strcmp (argv[3], "expect-collision"))
+	mode = MODE_EXPECT_COLLISION;
+      else if (!strcmp (argv[3], "control"))
+	mode = MODE_CONTROL;
+      else
+	return usage (argv[0]);
+      errno = 0;
+      requested_pid = strtoul (argv[4], &end, 0);
+      if (errno || end == argv[4] || *end || requested_pid > 0x0fff)
+	return usage (argv[0]);
+    }
+  else if (argc != 3)
+    return usage (argv[0]);
+  rc = uet_vpp_client_open (&client, argv[1], &info);
+  if (rc)
+    {
+      fprintf (stderr, "uet_vpp_client_open failed: %d\n", rc);
+      return 1;
+    }
+  rc = uet_vpp_client_set_pds_sng (client, mode == MODE_RECEIVE);
+  if (rc)
+    {
+      fprintf (stderr, "uet_vpp_client_set_pds_sng failed: %d\n", rc);
+      goto done;
+    }
+  rc = uet_vpp_client_map_dma (client, argv[2]);
+  if (rc)
+    {
+      fprintf (stderr, "uet_vpp_client_map_dma failed: %d\n", rc);
+      goto done;
+    }
+  endpoint.pid_on_fep = mode == MODE_RECEIVE ? info.client_namespace : requested_pid;
+  if (inet_pton (AF_INET, "198.18.0.1", endpoint.ip_address) != 1)
+    goto done;
+  rc = uet_vpp_client_endpoint_add (client, &endpoint);
+  if (mode == MODE_EXPECT_COLLISION)
+    {
+      if (rc != -EADDRINUSE)
+	{
+	  fprintf (stderr, "endpoint add returned %d, expected %d\n", rc, -EADDRINUSE);
+	  if (!rc)
+	    endpoint_added = 1;
+	  goto done;
+	}
+      printf ("endpoint collision pid %u passed\n", endpoint.pid_on_fep);
+      rv = 0;
+      goto done;
+    }
+  if (rc)
+    {
+      fprintf (stderr, "endpoint add failed: %d\n", rc);
+      goto done;
+    }
+  endpoint_added = 1;
+  if (mode == MODE_CONTROL)
+    {
+      printf ("endpoint control pid %u passed\n", endpoint.pid_on_fep);
+      rv = 0;
+      goto done;
+    }
+  if (mode == MODE_HOLD)
+    {
+      printf ("endpoint control ready: pid %u\n", endpoint.pid_on_fep);
+      fflush (stdout);
+      for (;;)
+	pause ();
+    }
+  printf ("endpoint ready: namespace %u\n", info.client_namespace);
+  fflush (stdout);
+
+  deadline = monotonic_ns () + UET_ENDPOINT_SMOKE_WAIT_NS;
+  do
+    {
+      for (uint32_t channel = 0; channel < info.channel_count; channel++)
+	{
+	  rc = uet_vpp_client_poll_rx (client, channel, &rx);
+	  if (rc < 0)
+	    {
+	      fprintf (stderr, "RX poll failed on channel %u: %d\n", channel, rc);
+	      goto done;
+	    }
+	  if (rc == 1)
+	    {
+	      uint32_t route = 0;
+
+	      rx_channel = channel;
+	      rc = validate_rx (&rx, info.client_namespace, &route);
+	      if (rc)
+		{
+		  fprintf (stderr, "received packet did not match endpoint namespace %u\n",
+			   info.client_namespace);
+		  uet_vpp_client_release_rx (client, rx_channel, &rx);
+		  goto done;
+		}
+	      if (received_routes & route)
+		{
+		  fprintf (stderr, "received duplicate endpoint route 0x%x\n", route);
+		  uet_vpp_client_release_rx (client, rx_channel, &rx);
+		  goto done;
+		}
+	      rc = uet_vpp_client_release_rx (client, rx_channel, &rx);
+	      if (rc)
+		{
+		  fprintf (stderr, "RX release failed: %d\n", rc);
+		  goto done;
+		}
+	      received_routes |= route;
+	      if (received_routes == UET_ENDPOINT_ROUTE_ALL)
+		{
+		  rv = 0;
+		  goto done;
+		}
+	    }
+	}
+      nanosleep (&pause_time, 0);
+    }
+  while (monotonic_ns () < deadline);
+  fprintf (stderr, "timed out waiting for endpoint routes: received 0x%x, expected 0x%x\n",
+	   received_routes, UET_ENDPOINT_ROUTE_ALL);
+
+done:
+  if (endpoint_added)
+    {
+      rc = uet_vpp_client_endpoint_del (client, &endpoint);
+      if (rc)
+	{
+	  fprintf (stderr, "endpoint delete failed: %d\n", rc);
+	  rv = 1;
+	}
+    }
+  rc = uet_vpp_client_close (client);
+  if (rc)
+    {
+      fprintf (stderr, "uet_vpp_client_close failed: %d\n", rc);
+      rv = 1;
+    }
+  if (!rv && mode == MODE_RECEIVE)
+    printf ("endpoint RX namespace %u passed\n", info.client_namespace);
+  return rv;
+}

--- a/vpp-plugin/tools/owner_probe.c
+++ b/vpp-plugin/tools/owner_probe.c
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <vppinfra/mem.h>
+
+#include <uet_vpp_client.h>
+
+static int
+expected_result (const char *mode, int *hold)
+{
+  *hold = 0;
+  if (!strcmp (mode, "expect-success"))
+    return 0;
+  if (!strcmp (mode, "expect-existing-heap"))
+    return 0;
+  if (!strcmp (mode, "expect-busy"))
+    return -EBUSY;
+  if (!strcmp (mode, "expect-owner-dead"))
+    return -EOWNERDEAD;
+  if (!strcmp (mode, "expect-double-busy"))
+    return 0;
+  if (!strcmp (mode, "hold") || !strcmp (mode, "hold-dma"))
+    {
+      *hold = 1;
+      return 0;
+    }
+  return 1;
+}
+
+int
+main (int argc, char **argv)
+{
+  uet_vpp_client_t *client = 0;
+  int expected, hold, rc;
+
+  if ((argc != 3 && argc != 4) || (expected = expected_result (argv[2], &hold)) > 0 ||
+      (argc == 4 && strcmp (argv[2], "hold-dma")) || (argc == 3 && !strcmp (argv[2], "hold-dma")))
+    {
+      fprintf (stderr,
+	       "usage: %s <segment-name> "
+	       "<expect-success|expect-existing-heap|expect-busy|expect-owner-dead|"
+	       "expect-double-busy|hold|hold-dma> "
+	       "[dma-socket]\n",
+	       argv[0]);
+      return 2;
+    }
+
+  if (!strcmp (argv[2], "expect-existing-heap") && !clib_mem_init (0, 1U << 20))
+    {
+      fprintf (stderr, "failed to initialize the existing VPP heap\n");
+      return 1;
+    }
+
+  rc = uet_vpp_client_open (&client, argv[1], 0);
+  if (rc != expected)
+    {
+      fprintf (stderr, "uet_vpp_client_open returned %d, expected %d\n", rc, expected);
+      if (!rc)
+	uet_vpp_client_close (client);
+      return 1;
+    }
+  if (rc)
+    return 0;
+
+  if (!strcmp (argv[2], "expect-double-busy"))
+    {
+      uet_vpp_client_t *second = 0;
+
+      rc = uet_vpp_client_open (&second, argv[1], 0);
+      if (rc != -EBUSY)
+	{
+	  fprintf (stderr, "second uet_vpp_client_open returned %d, expected %d\n", rc, -EBUSY);
+	  if (!rc)
+	    uet_vpp_client_close (second);
+	  uet_vpp_client_close (client);
+	  return 1;
+	}
+    }
+
+  if (argc == 4)
+    {
+      rc = uet_vpp_client_map_dma (client, argv[3]);
+      if (rc)
+	{
+	  fprintf (stderr, "uet_vpp_client_map_dma failed: %d\n", rc);
+	  uet_vpp_client_close (client);
+	  return 1;
+	}
+    }
+
+  if (hold)
+    {
+      printf ("owner ready: pid %d\n", getpid ());
+      fflush (stdout);
+      for (;;)
+	pause ();
+    }
+
+  rc = uet_vpp_client_close (client);
+  if (rc)
+    {
+      fprintf (stderr, "uet_vpp_client_close failed: %d\n", rc);
+      return 1;
+    }
+  return 0;
+}

--- a/vpp-plugin/tools/spsc_negative.c
+++ b/vpp-plugin/tools/spsc_negative.c
@@ -1,0 +1,333 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <sched.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <uet_vpp_client.h>
+
+#define UET_SPSC_NEGATIVE_WAIT_NS    (500ULL * 1000 * 1000)
+#define UET_SPSC_NEGATIVE_TIMEOUT_NS (2ULL * 1000 * 1000 * 1000)
+
+static uint64_t
+monotonic_ns (void)
+{
+  struct timespec now;
+
+  if (clock_gettime (CLOCK_MONOTONIC, &now) != 0)
+    {
+      perror ("clock_gettime");
+      exit (1);
+    }
+  return (uint64_t) now.tv_sec * 1000000000ULL + (uint64_t) now.tv_nsec;
+}
+
+static int
+expect_result (const char *operation, int actual, int expected)
+{
+  if (actual == expected)
+    return 0;
+
+  fprintf (stderr, "%s returned %d, expected %d\n", operation, actual, expected);
+  return -1;
+}
+
+static int
+completion_check (const uet_vpp_client_completion_t *completion,
+		  const uet_vpp_client_tx_request_t *request)
+{
+  if (completion->status == UET_VPP_CLIENT_STATUS_INVALID_PACKET &&
+      completion->completed_length == 0 && completion->dma_slot == request->dma_slot &&
+      completion->request_id == request->request_id &&
+      completion->user_context == request->user_context)
+    return 0;
+
+  fprintf (stderr, "invalid negative completion for request %" PRIu64 "\n", request->request_id);
+  return -1;
+}
+
+static int
+rx_ownership_check (uet_vpp_client_t *client, uint32_t rx_count, uint32_t ring_size)
+{
+  uet_vpp_client_rx_t *received = calloc (rx_count, sizeof (*received));
+  uet_vpp_client_rx_t forged, duplicate[2];
+  uint64_t deadline = monotonic_ns () + UET_SPSC_NEGATIVE_TIMEOUT_NS;
+  uint32_t n_received = 0;
+  int rc = -ENOMEM;
+
+  if (!received)
+    {
+      perror ("calloc");
+      return -1;
+    }
+
+  while (n_received < rx_count && monotonic_ns () < deadline)
+    {
+      rc = uet_vpp_client_poll_rx_batch (client, 0, received + n_received, rx_count - n_received);
+      if (rc < 0)
+	break;
+      if (rc == 0)
+	sched_yield ();
+      else
+	n_received += rc;
+    }
+  if (n_received != rx_count)
+    {
+      fprintf (stderr, "RX poll returned %u packets, expected %u (last result %d)\n", n_received,
+	       rx_count, rc);
+      goto failed;
+    }
+  for (uint32_t i = 0; i < rx_count; i++)
+    if (!(received[i].flags & UET_VPP_CLIENT_RX_F_IP4) ||
+	!(received[i].flags & UET_VPP_CLIENT_RX_F_UDP) ||
+	(received[i].flags & UET_VPP_CLIENT_RX_F_IP6) || received[i].iov_count == 0 ||
+	received[i].packet_length < 20)
+      {
+	fprintf (stderr, "invalid RX metadata at index %u\n", i);
+	goto failed;
+      }
+
+  if (expect_result ("close with RX outstanding", uet_vpp_client_close (client), -EBUSY))
+    goto failed;
+
+  forged = received[0];
+  forged.rx_id ^= UINT64_C (1) << 63;
+  if (!forged.rx_id)
+    forged.rx_id = 1;
+  if (expect_result ("forged RX ID release", uet_vpp_client_release_rx (client, 0, &forged),
+		     -EINVAL))
+    goto failed;
+
+  forged = received[0];
+  forged.release_token = (forged.release_token + 1) % ring_size;
+  if (expect_result ("forged RX token release", uet_vpp_client_release_rx (client, 0, &forged),
+		     -EINVAL))
+    goto failed;
+
+  duplicate[0] = received[0];
+  duplicate[1] = received[0];
+  if (expect_result ("duplicate RX release batch",
+		     uet_vpp_client_release_rx_batch (client, 0, duplicate, 2), -EINVAL) ||
+      expect_result ("valid RX release batch",
+		     uet_vpp_client_release_rx_batch (client, 0, received, rx_count), 0) ||
+      expect_result ("stale RX release", uet_vpp_client_release_rx (client, 0, received), -EINVAL))
+    goto failed;
+
+  free (received);
+  return 0;
+
+failed:
+  free (received);
+  return -1;
+}
+
+int
+main (int argc, char **argv)
+{
+  uet_vpp_client_t *client = 0;
+  uet_vpp_client_info_t info;
+  uet_vpp_client_tx_request_t duplicate[2];
+  uet_vpp_client_tx_request_t *requests = 0;
+  uet_vpp_client_completion_t completion;
+  uet_vpp_client_completion_t *completions = 0;
+  uet_vpp_client_rx_t rx = { .rx_id = 1 };
+  struct timespec wait_time = {
+    .tv_sec = 0,
+    .tv_nsec = UET_SPSC_NEGATIVE_WAIT_NS,
+  };
+  uint32_t slot, unused_slot;
+  uint32_t rx_count;
+  uint64_t deadline;
+  char *end = 0;
+  unsigned long parsed_rx_count;
+  size_t capacity, unused_capacity;
+  void *data, *unused_data;
+  int rc, rv = 1;
+
+  if (argc != 4)
+    {
+      fprintf (stderr, "usage: %s <segment-name> <dma-socket> <rx-count>\n", argv[0]);
+      return 2;
+    }
+  errno = 0;
+  parsed_rx_count = strtoul (argv[3], &end, 10);
+  if (errno || !end || *end || parsed_rx_count < 2 || parsed_rx_count > UINT32_MAX)
+    {
+      fprintf (stderr, "invalid RX count: %s\n", argv[3]);
+      return 2;
+    }
+  rx_count = parsed_rx_count;
+
+  rc = uet_vpp_client_open (&client, argv[1], &info);
+  if (rc)
+    {
+      fprintf (stderr, "uet_vpp_client_open failed: %d\n", rc);
+      return 1;
+    }
+  if (info.queue_depth != info.dma_slot_count || info.queue_depth != info.tx_ring_size)
+    {
+      fprintf (stderr, "inconsistent SPSC and DMA depths\n");
+      goto done;
+    }
+  if (rx_count > info.rx_ring_size)
+    {
+      fprintf (stderr, "RX count %u exceeds ring size %u\n", rx_count, info.rx_ring_size);
+      goto done;
+    }
+  if (expect_result ("acquire before DMA map",
+		     uet_vpp_client_acquire_dma (client, 0, &slot, &data, &capacity), -ENXIO) ||
+      expect_result ("RX poll before DMA map", uet_vpp_client_poll_rx (client, 0, &rx), -ENXIO))
+    goto done;
+
+  rc = uet_vpp_client_map_dma (client, argv[2]);
+  if (rc)
+    {
+      fprintf (stderr, "uet_vpp_client_map_dma failed: %d\n", rc);
+      goto done;
+    }
+  if (expect_result ("duplicate DMA map", uet_vpp_client_map_dma (client, argv[2]), -EALREADY) ||
+      expect_result ("out-of-range release",
+		     uet_vpp_client_release_dma (client, 0, info.dma_slot_count), -EINVAL) ||
+      expect_result ("unowned submit", uet_vpp_client_submit_ip (client, 0, 0, 20, 1, 0), -EPERM) ||
+      expect_result ("unowned release", uet_vpp_client_release_dma (client, 0, 0), -EPERM) ||
+      expect_result ("unowned RX release", uet_vpp_client_release_rx (client, 0, &rx), -EINVAL))
+    goto done;
+
+  rc = uet_vpp_client_acquire_dma (client, 0, &slot, &data, &capacity);
+  if (rc)
+    {
+      fprintf (stderr, "DMA acquisition failed: %d\n", rc);
+      goto done;
+    }
+  if (expect_result ("undersized IP submit", uet_vpp_client_submit_ip (client, 0, slot, 19, 2, 0),
+		     -EMSGSIZE) ||
+      expect_result ("release after rejected submit", uet_vpp_client_release_dma (client, 0, slot),
+		     0))
+    goto done;
+
+  rc = uet_vpp_client_acquire_dma (client, 0, &slot, &data, &capacity);
+  if (rc || capacity < 20)
+    {
+      fprintf (stderr, "DMA acquisition for duplicate batch failed: %d\n", rc);
+      goto done;
+    }
+  memset (data, 0, 20);
+  duplicate[0] = (uet_vpp_client_tx_request_t){
+    .dma_slot = slot,
+    .packet_length = 20,
+    .request_id = 3,
+    .user_context = 0x33,
+  };
+  duplicate[1] = duplicate[0];
+  duplicate[1].request_id++;
+  if (expect_result ("duplicate-slot batch",
+		     uet_vpp_client_submit_ip_batch (client, 0, duplicate, 2), -EINVAL) ||
+      expect_result ("release after rejected batch", uet_vpp_client_release_dma (client, 0, slot),
+		     0))
+    goto done;
+
+  rc = uet_vpp_client_acquire_dma (client, 0, &slot, &data, &capacity);
+  if (rc || capacity < 20)
+    {
+      fprintf (stderr, "DMA acquisition for malformed packet failed: %d\n", rc);
+      goto done;
+    }
+  memset (data, 0, 20);
+  duplicate[0] = (uet_vpp_client_tx_request_t){
+    .dma_slot = slot,
+    .packet_length = 20,
+    .request_id = 5,
+    .user_context = 0x55,
+  };
+  if (expect_result ("malformed IP submit",
+		     uet_vpp_client_submit_ip_batch (client, 0, duplicate, 1), 0) ||
+      expect_result ("close with TX in flight", uet_vpp_client_close (client), -EBUSY) ||
+      expect_result ("release with TX in flight", uet_vpp_client_release_dma (client, 0, slot),
+		     -EPERM))
+    goto done;
+
+  deadline = monotonic_ns () + UET_SPSC_NEGATIVE_TIMEOUT_NS;
+  do
+    {
+      rc = uet_vpp_client_poll (client, 0, &completion);
+      if (rc == 0)
+	sched_yield ();
+    }
+  while (rc == 0 && monotonic_ns () < deadline);
+  if (rc != 1 || completion_check (&completion, duplicate))
+    goto done;
+  if (expect_result ("release after completion", uet_vpp_client_release_dma (client, 0, slot),
+		     -EPERM))
+    goto done;
+
+  requests = calloc (info.queue_depth, sizeof (*requests));
+  completions = calloc (info.queue_depth, sizeof (*completions));
+  if (!requests || !completions)
+    {
+      perror ("calloc");
+      goto done;
+    }
+  for (uint32_t i = 0; i < info.queue_depth; i++)
+    {
+      rc = uet_vpp_client_acquire_dma (client, 0, &slot, &data, &capacity);
+      if (rc || capacity < 20)
+	{
+	  fprintf (stderr, "DMA pool exhaustion setup failed at slot %u: %d\n", i, rc);
+	  goto done;
+	}
+      memset (data, 0, 20);
+      requests[i] = (uet_vpp_client_tx_request_t){
+	.dma_slot = slot,
+	.packet_length = 20,
+	.request_id = UINT64_C (0x100000000) + i,
+	.user_context = UINT64_C (0x200000000) + i,
+      };
+    }
+  if (expect_result (
+	"DMA slot exhaustion",
+	uet_vpp_client_acquire_dma (client, 0, &unused_slot, &unused_data, &unused_capacity),
+	-EAGAIN) ||
+      expect_result ("full-depth TX batch",
+		     uet_vpp_client_submit_ip_batch (client, 0, requests, info.queue_depth), 0) ||
+      expect_result ("close with full-depth TX batch", uet_vpp_client_close (client), -EBUSY))
+    goto done;
+
+  while (nanosleep (&wait_time, &wait_time) != 0 && errno == EINTR)
+    ;
+  rc = uet_vpp_client_poll_batch (client, 0, completions, info.queue_depth);
+  if (rc != (int) info.queue_depth)
+    {
+      fprintf (stderr, "completion ring returned %d entries, expected %u\n", rc, info.queue_depth);
+      goto done;
+    }
+  for (uint32_t i = 0; i < info.queue_depth; i++)
+    if (completion_check (completions + i, requests + i))
+      goto done;
+
+  if (rx_ownership_check (client, rx_count, info.rx_ring_size))
+    goto done;
+
+  rc = uet_vpp_client_close (client);
+  if (rc)
+    {
+      fprintf (stderr, "final client close failed: %d\n", rc);
+      goto done;
+    }
+  client = 0;
+  printf ("UET SPSC negative smoke passed: ownership checks, %u RX packets, and %u-entry "
+	  "completion ring\n",
+	  rx_count, info.queue_depth);
+  rv = 0;
+
+done:
+  free (completions);
+  free (requests);
+  if (client)
+    uet_vpp_client_close (client);
+  return rv;
+}

--- a/vpp-plugin/tools/tx_smoke.c
+++ b/vpp-plugin/tools/tx_smoke.c
@@ -1,0 +1,269 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <uet_vpp_client.h>
+
+#define UET_TX_SMOKE_IP_PROTOCOL 253
+#define UET_TX_SMOKE_UDP_PORT	 49150
+#define UET_TX_SMOKE_TIMEOUT_NS	 (2ULL * 1000 * 1000 * 1000)
+
+static uint64_t
+monotonic_ns (void)
+{
+  struct timespec ts;
+
+  if (clock_gettime (CLOCK_MONOTONIC, &ts) != 0)
+    {
+      perror ("clock_gettime");
+      exit (1);
+    }
+  return (uint64_t) ts.tv_sec * 1000000000ULL + (uint64_t) ts.tv_nsec;
+}
+
+static uint16_t
+ip4_checksum (const uint8_t *header, size_t length)
+{
+  uint32_t sum = 0;
+
+  for (size_t i = 0; i < length; i += 2)
+    sum += ((uint16_t) header[i] << 8) | header[i + 1];
+  while (sum >> 16)
+    sum = (sum & 0xffff) + (sum >> 16);
+  return htons ((uint16_t) ~sum);
+}
+
+static void
+store_u16 (void *destination, uint16_t value)
+{
+  memcpy (destination, &value, sizeof (value));
+}
+
+static void
+store_u32 (void *destination, uint32_t value)
+{
+  memcpy (destination, &value, sizeof (value));
+}
+
+static uint32_t
+packet_build (uint8_t *packet, size_t capacity, uint64_t request_id)
+{
+  static const uint8_t src4[4] = { 192, 0, 2, 1 };
+  static const uint8_t dst4[4] = { 198, 51, 100, 1 };
+  static const uint8_t src6[16] = { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
+  static const uint8_t dst6[16] = { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1 };
+  const int is_ip6 = request_id & 1;
+  const int is_udp = request_id & 2;
+  const uint32_t ip_header_length = is_ip6 ? 40 : 20;
+  const uint32_t l4_length = is_udp ? 12 : 4;
+  const uint32_t packet_length = ip_header_length + l4_length;
+  uint8_t *l4;
+
+  if (capacity < packet_length)
+    return 0;
+  memset (packet, 0, packet_length);
+
+  if (is_ip6)
+    {
+      packet[0] = 0x60;
+      store_u16 (packet + 4, htons (l4_length));
+      packet[6] = is_udp ? IPPROTO_UDP : UET_TX_SMOKE_IP_PROTOCOL;
+      packet[7] = 64;
+      memcpy (packet + 8, src6, sizeof (src6));
+      memcpy (packet + 24, dst6, sizeof (dst6));
+    }
+  else
+    {
+      packet[0] = 0x45;
+      store_u16 (packet + 2, htons (packet_length));
+      packet[8] = 64;
+      packet[9] = is_udp ? IPPROTO_UDP : UET_TX_SMOKE_IP_PROTOCOL;
+      memcpy (packet + 12, src4, sizeof (src4));
+      memcpy (packet + 16, dst4, sizeof (dst4));
+      store_u16 (packet + 10, ip4_checksum (packet, ip_header_length));
+    }
+
+  l4 = packet + ip_header_length;
+  if (is_udp)
+    {
+      store_u16 (l4, htons ((uint16_t) (10000 + request_id % 1000)));
+      store_u16 (l4 + 2, htons (UET_TX_SMOKE_UDP_PORT));
+      store_u16 (l4 + 4, htons (l4_length));
+      store_u16 (l4 + 6, htons (0x1234)); /* The plugin normalizes it to zero. */
+      store_u32 (l4 + 8, htonl ((uint32_t) request_id));
+    }
+  else
+    store_u32 (l4, htonl ((uint32_t) request_id));
+
+  return packet_length;
+}
+
+typedef struct
+{
+  uet_vpp_client_t *client;
+  uint64_t count;
+  uint32_t channel;
+  int result;
+} uet_tx_smoke_thread_t;
+
+static void *
+tx_channel_run (void *opaque)
+{
+  uet_tx_smoke_thread_t *thread = opaque;
+  uint64_t deadline = monotonic_ns () + UET_TX_SMOKE_TIMEOUT_NS;
+
+  thread->result = 1;
+  for (uint64_t sequence = 1; sequence <= thread->count; sequence++)
+    {
+      uet_vpp_client_completion_t completion;
+      uint64_t request_id = ((uint64_t) thread->channel << 56) | sequence;
+      uint32_t slot, packet_length;
+      size_t capacity;
+      void *packet;
+      int rc;
+
+      do
+	rc =
+	  uet_vpp_client_acquire_dma (thread->client, thread->channel, &slot, &packet, &capacity);
+      while (rc == -EAGAIN && monotonic_ns () < deadline);
+      if (rc || !(packet_length = packet_build (packet, capacity, request_id)))
+	{
+	  fprintf (stderr,
+		   "channel %u TX slot acquisition/build failed for request %" PRIu64 ": %d\n",
+		   thread->channel, request_id, rc);
+	  return 0;
+	}
+
+      rc = uet_vpp_client_submit_ip (thread->client, thread->channel, slot, packet_length,
+				     request_id, request_id ^ thread->count);
+      if (rc)
+	{
+	  fprintf (stderr, "channel %u TX submit failed for request %" PRIu64 ": %d\n",
+		   thread->channel, request_id, rc);
+	  uet_vpp_client_release_dma (thread->client, thread->channel, slot);
+	  return 0;
+	}
+
+      do
+	{
+	  rc = uet_vpp_client_poll (thread->client, thread->channel, &completion);
+	  if (rc == 0)
+	    usleep (50);
+	}
+      while (rc == 0 && monotonic_ns () < deadline);
+      if (rc != 1 || completion.status != UET_VPP_CLIENT_STATUS_OK ||
+	  completion.completed_length != packet_length || completion.dma_slot != slot ||
+	  completion.request_id != request_id ||
+	  completion.user_context != (request_id ^ thread->count))
+	{
+	  fprintf (stderr, "channel %u invalid TX completion for request %" PRIu64 "\n",
+		   thread->channel, request_id);
+	  return 0;
+	}
+      deadline = monotonic_ns () + UET_TX_SMOKE_TIMEOUT_NS;
+    }
+
+  thread->result = 0;
+  return 0;
+}
+
+int
+main (int argc, char **argv)
+{
+  uet_vpp_client_t *client = 0;
+  uet_vpp_client_info_t info;
+  uet_tx_smoke_thread_t *thread_contexts = 0;
+  pthread_t *threads = 0;
+  uint64_t count;
+  uint32_t threads_started = 0;
+  char *end = 0;
+  int rc, rv = 1;
+
+  if (argc != 4)
+    {
+      fprintf (stderr, "usage: %s <segment-name> <packet-count> <dma-socket>\n", argv[0]);
+      return 2;
+    }
+
+  errno = 0;
+  count = strtoull (argv[2], &end, 10);
+  if (errno || !end || *end || !count || count >= (UINT64_C (1) << 56))
+    {
+      fprintf (stderr, "invalid packet count: %s\n", argv[2]);
+      return 2;
+    }
+
+  rc = uet_vpp_client_open (&client, argv[1], &info);
+  if (rc)
+    {
+      fprintf (stderr, "uet_vpp_client_open failed: %d\n", rc);
+      return 1;
+    }
+  rc = uet_vpp_client_map_dma (client, argv[3]);
+  if (rc)
+    {
+      fprintf (stderr, "uet_vpp_client_map_dma failed: %d\n", rc);
+      goto done;
+    }
+
+  threads = calloc (info.channel_count, sizeof (*threads));
+  thread_contexts = calloc (info.channel_count, sizeof (*thread_contexts));
+  if (!threads || !thread_contexts)
+    {
+      perror ("calloc");
+      goto done;
+    }
+  for (uint32_t channel = 0; channel < info.channel_count; channel++)
+    {
+      thread_contexts[channel] = (uet_tx_smoke_thread_t){
+	.client = client,
+	.count = count,
+	.channel = channel,
+      };
+      rc = pthread_create (threads + channel, 0, tx_channel_run, thread_contexts + channel);
+      if (rc)
+	{
+	  fprintf (stderr, "pthread_create for channel %u failed: %s\n", channel, strerror (rc));
+	  break;
+	}
+      threads_started++;
+    }
+  for (uint32_t channel = 0; channel < threads_started; channel++)
+    {
+      int join_rc = pthread_join (threads[channel], 0);
+
+      if (join_rc && !rc)
+	rc = join_rc;
+    }
+  if (threads_started != info.channel_count || rc)
+    goto done;
+  for (uint32_t channel = 0; channel < info.channel_count; channel++)
+    if (thread_contexts[channel].result)
+      goto done;
+
+  printf ("UET routed TX smoke passed: %" PRIu64
+	  " packets on each of %u channels, IPv4/IPv6 native and UDP, %u replacement slots per "
+	  "channel\n",
+	  count, info.channel_count, info.dma_slot_count);
+  rv = 0;
+
+done:
+  free (thread_contexts);
+  free (threads);
+  rc = uet_vpp_client_close (client);
+  if (rc)
+    {
+      fprintf (stderr, "uet_vpp_client_close failed: %d\n", rc);
+      rv = 1;
+    }
+  return rv;
+}

--- a/vpp-plugin/uet/CMakeLists.txt
+++ b/vpp-plugin/uet/CMakeLists.txt
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+add_vpp_plugin(uet
+  SOURCES
+    dma_socket.c
+    node.c
+    uet.c
+
+  MULTIARCH_SOURCES
+    node.c
+
+  API_FILES
+    uet.api
+
+  INSTALL_HEADERS
+    dma_abi.h
+    svm_abi.h
+
+  COMPONENT
+    vpp-plugin-uet
+)
+
+install(FILES
+  dma_abi.h
+  svm_abi.h
+  DESTINATION include/uet
+  COMPONENT vpp-plugin-uet-dev
+)

--- a/vpp-plugin/uet/FEATURE.yaml
+++ b/vpp-plugin/uet/FEATURE.yaml
@@ -1,0 +1,11 @@
+---
+name: Ultra Ethernet host dataplane
+maintainer: Jerome Tollet <jtollet@cisco.com>
+features:
+  - IPv4 and IPv6 local delivery for native UET and UET over UDP
+  - Per-worker lockless external-process channels
+  - Native VPP routing and adjacency resolution on transmit
+  - Shared-memory zero-copy buffer exchange
+description: "Host dataplane between VPP and an external UET client"
+state: experimental
+properties: [API, CLI, MULTITHREAD, STATS]

--- a/vpp-plugin/uet/dma_abi.h
+++ b/vpp-plugin/uet/dma_abi.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef included_uet_vpp_dma_abi_h
+#define included_uet_vpp_dma_abi_h
+
+#include <stdint.h>
+
+#define UET_VPP_DMA_ABI_MAGIC	0x414d4455U
+#define UET_VPP_DMA_ABI_VERSION 2
+
+typedef struct
+{
+  uint32_t magic;
+  uint16_t version;
+  int16_t status;
+  uint64_t generation;
+  uint64_t map_size;
+  uint32_t slot_count;
+  uint32_t buffer_data_size;
+  uint16_t buffer_pool_index;
+  uint16_t reserved0;
+  uint32_t reserved1;
+} uet_vpp_dma_reply_t;
+
+#ifdef __cplusplus
+#define UET_VPP_DMA_STATIC_ASSERT static_assert
+#else
+#define UET_VPP_DMA_STATIC_ASSERT _Static_assert
+#endif
+
+UET_VPP_DMA_STATIC_ASSERT (sizeof (uet_vpp_dma_reply_t) == 40, "unexpected UET DMA reply size");
+
+#undef UET_VPP_DMA_STATIC_ASSERT
+
+#endif /* included_uet_vpp_dma_abi_h */

--- a/vpp-plugin/uet/dma_socket.c
+++ b/vpp-plugin/uet/dma_socket.c
@@ -1,0 +1,179 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <errno.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <uet/uet.h>
+
+#include <vlib/file.h>
+#include <vlib/physmem_funcs.h>
+#include <vlib/unix/unix.h>
+
+typedef struct
+{
+  pid_t pid;
+  uid_t uid;
+  gid_t gid;
+} uet_dma_peer_credentials_t;
+
+static int
+uet_dma_peer_authorize (clib_socket_t *socket, uet_dma_peer_credentials_t *credentials,
+			uet_client_t **authorized_client)
+{
+  uet_main_t *um = &uet_main;
+  uet_client_t *candidate;
+  socklen_t credentials_length = sizeof (*credentials);
+
+  *authorized_client = 0;
+  if (getsockopt (socket->fd, SOL_SOCKET, SO_PEERCRED, credentials, &credentials_length) < 0)
+    return -errno;
+  if (credentials_length != sizeof (*credentials) || credentials->pid <= 0)
+    return -EACCES;
+
+  pool_foreach (candidate, um->clients)
+    if (candidate->segment.sh && candidate->header &&
+	clib_atomic_load_acq_n (&candidate->segment.sh->ready) &&
+	clib_atomic_load_acq_n (&candidate->header->owner_pid) == credentials->pid)
+      {
+	if (*authorized_client)
+	  return -EEXIST;
+	*authorized_client = candidate;
+      }
+
+  if (*authorized_client)
+    return 0;
+
+  return -EACCES;
+}
+
+static clib_error_t *
+uet_dma_accept_ready (clib_file_t *uf)
+{
+  uet_main_t *um = &uet_main;
+  clib_socket_t client = { 0 };
+  uet_vpp_dma_reply_t reply = {
+    .magic = UET_VPP_DMA_ABI_MAGIC,
+    .version = UET_VPP_DMA_ABI_VERSION,
+    .status = -ENOENT,
+  };
+  clib_error_t *err;
+  clib_error_t *close_err;
+  uet_dma_peer_credentials_t credentials = { 0 };
+  uet_client_t *authorized_client = 0;
+  int authorization_status;
+  int fd = -1;
+
+  err = clib_socket_accept (um->dma_listener, &client);
+  if (err)
+    {
+      uet_log_warn ("failed to accept DMA client: %U", format_clib_error, err);
+      return err;
+    }
+
+  authorization_status = uet_dma_peer_authorize (&client, &credentials, &authorized_client);
+  if (authorization_status)
+    {
+      reply.status = authorization_status;
+      um->dma_rejected_clients++;
+      uet_log_warn ("rejected DMA client pid %d uid %u gid %u: no matching active SSVM channel",
+		    credentials.pid, credentials.uid, credentials.gid);
+    }
+  else if (authorized_client && um->dma_map_base)
+    {
+      vlib_buffer_pool_t *bp = vlib_get_buffer_pool (um->vlib_main, um->dma_buffer_pool_index);
+      vlib_physmem_map_t *pm = vlib_physmem_get_map (um->vlib_main, bp->physmem_map_index);
+
+      reply.status = 0;
+      reply.generation = authorized_client->generation;
+      reply.map_size = um->dma_map_size;
+      reply.slot_count = authorized_client->queue_depth * authorized_client->channel_count;
+      reply.buffer_data_size = um->dma_buffer_data_size;
+      reply.buffer_pool_index = um->dma_buffer_pool_index;
+      fd = pm->fd;
+      um->dma_authorized_clients++;
+    }
+  else
+    uet_log_warn ("DMA client connected before worker channels were ready");
+
+  err = clib_socket_sendmsg (&client, &reply, sizeof (reply), fd >= 0 ? &fd : 0, fd >= 0 ? 1 : 0);
+  if (err)
+    uet_log_warn ("failed to send DMA mapping metadata: %U", format_clib_error, err);
+  else if (fd >= 0)
+    uet_log_debug ("exported DMA map generation %llu, size %llu to pid %d uid %u for %s",
+		   reply.generation, reply.map_size, credentials.pid, credentials.uid,
+		   authorized_client->segment.name);
+  close_err = clib_socket_close (&client);
+  clib_socket_free (&client);
+  if (close_err)
+    {
+      if (!err)
+	err = close_err;
+      else
+	clib_error_free (close_err);
+    }
+  return err;
+}
+
+clib_error_t *
+uet_dma_listener_init (void)
+{
+  uet_main_t *um = &uet_main;
+  clib_file_t file = { 0 };
+  clib_socket_t *listener;
+  clib_error_t *err;
+
+  if (um->dma_listener)
+    return 0;
+
+  um->dma_socket_name = format (0, "%s/%s%c", vlib_unix_get_runtime_dir (), "uet-dma.sock", 0);
+  listener = clib_mem_alloc (sizeof (*listener));
+  clib_memset (listener, 0, sizeof (*listener));
+  listener->config = (char *) um->dma_socket_name;
+  listener->is_server = 1;
+  listener->allow_group_write = 1;
+  listener->is_seqpacket = 1;
+  listener->passcred = 1;
+
+  if ((err = clib_socket_init (listener)))
+    {
+      clib_socket_free (listener);
+      clib_mem_free (listener);
+      um->dma_socket_name = 0;
+      return err;
+    }
+
+  file.read_function = uet_dma_accept_ready;
+  file.file_descriptor = listener->fd;
+  /* The socket object owns the descriptor and unlinks the Unix socket on
+   * close.  Keep clib_file_del_by_index() from closing the descriptor first.
+   */
+  file.dont_close = 1;
+  file.description = format (0, "UET DMA listener %s", listener->config);
+  um->dma_listener_file_index = clib_file_add (&file_main, &file);
+  um->dma_listener = listener;
+  uet_log_notice ("listening for trusted DMA clients on %s", listener->config);
+  return 0;
+}
+
+void
+uet_dma_listener_delete (void)
+{
+  uet_main_t *um = &uet_main;
+  clib_error_t *err;
+
+  if (!um->dma_listener)
+    return;
+
+  clib_file_del_by_index (&file_main, um->dma_listener_file_index);
+  err = clib_socket_close (um->dma_listener);
+  if (err)
+    clib_error_free (err);
+  clib_socket_free (um->dma_listener);
+  clib_mem_free (um->dma_listener);
+  um->dma_listener = 0;
+  um->dma_listener_file_index = ~0;
+  um->dma_socket_name = 0;
+  uet_log_debug ("DMA listener deleted");
+}

--- a/vpp-plugin/uet/node.c
+++ b/vpp-plugin/uet/node.c
@@ -1,0 +1,1478 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <errno.h>
+
+#include <uet/uet.h>
+
+#include <vnet/udp/udp_packet.h>
+
+#define UET_SPSC_MAX_BATCH 64
+
+typedef enum
+{
+  UET_TX_NEXT_IP4_LOOKUP,
+  UET_TX_NEXT_IP6_LOOKUP,
+  UET_TX_N_NEXT,
+} uet_tx_next_t;
+
+#define foreach_uet_tx_error                                                                       \
+  _ (INVALID_REQUEST, "invalid external UET request")                                              \
+  _ (COMPLETION_RING_FULL, "UET completion ring full")                                             \
+  _ (INVALID_RX_RELEASE, "invalid external UET RX release")
+
+typedef enum
+{
+#define _(name, string) UET_TX_ERROR_##name,
+  foreach_uet_tx_error
+#undef _
+    UET_TX_N_ERROR,
+} uet_tx_error_t;
+
+#define foreach_uet_local_error                                                                    \
+  _ (NO_CLIENT, "UET packet dropped: no ready external client")                                    \
+  _ (AMBIGUOUS_CLIENT, "UET packet dropped: destination ambiguous across clients")                 \
+  _ (RING_FULL, "UET packet dropped: external RX ring full")                                       \
+  _ (BAD_CHAIN, "UET packet dropped: invalid VLIB buffer chain")                                   \
+  _ (HANDOFF_QUEUE_FULL, "UET packet dropped: worker handoff queue full")
+
+typedef enum
+{
+#define _(name, string) UET_LOCAL_ERROR_##name,
+  foreach_uet_local_error
+#undef _
+    UET_LOCAL_N_ERROR,
+} uet_local_error_t;
+
+typedef enum
+{
+  UET_TRACE_TX_ROUTED,
+  UET_TRACE_RX_DELIVERED,
+  UET_TRACE_RX_NO_CLIENT,
+  UET_TRACE_RX_AMBIGUOUS_CLIENT,
+  UET_TRACE_RX_RING_FULL,
+  UET_TRACE_RX_BAD_CHAIN,
+} uet_trace_disposition_t;
+
+typedef struct
+{
+  u64 id;
+  u32 packet_length;
+  u32 sw_if_index_or_table_id;
+  u32 thread_index;
+  u16 next_index;
+  u8 direction;
+  u8 ip_version;
+  u8 is_udp;
+  u8 disposition;
+  u8 segment_count;
+} uet_trace_t;
+
+typedef struct
+{
+  u32 remaining;
+  u8 initialized;
+} uet_trace_state_t;
+
+static_always_inline void
+uet_tx_error_count (vlib_main_t *vm, uet_tx_error_t error)
+{
+  vlib_error_count (vm, uet_input_node.index, error, 1);
+}
+
+static_always_inline int
+uet_trace_claim (vlib_main_t *vm, vlib_node_runtime_t *node, vlib_buffer_t *buffer, u32 next_index,
+		 uet_trace_state_t *state)
+{
+  if (PREDICT_FALSE (!state->initialized))
+    {
+      state->remaining = vlib_get_trace_count (vm, node);
+      state->initialized = 1;
+    }
+
+  if (state->remaining && vlib_trace_buffer (vm, node, next_index, buffer, 0 /* follow_chain */))
+    {
+      state->remaining--;
+      /* `clear trace` may remove the per-node state concurrently. */
+      if (PREDICT_TRUE (node->node_index < vec_len (vm->trace_main.nodes)))
+	vlib_set_trace_count (vm, node, state->remaining);
+      return 1;
+    }
+  return buffer->flags & VLIB_BUFFER_IS_TRACED;
+}
+
+static_always_inline void
+uet_trace_add (vlib_main_t *vm, vlib_node_runtime_t *node, vlib_buffer_t *buffer,
+	       uet_trace_state_t *state, u32 next_index, u64 id, u32 packet_length,
+	       u32 sw_if_index_or_table_id, u8 direction, u8 ip_version, u8 is_udp,
+	       uet_trace_disposition_t disposition, u8 segment_count)
+{
+  uet_trace_t *trace;
+
+  if (PREDICT_TRUE (!vm->trace_main.trace_enable))
+    return;
+  if (PREDICT_TRUE (!uet_trace_claim (vm, node, buffer, next_index, state)))
+    return;
+
+  trace = vlib_add_trace (vm, node, buffer, sizeof (*trace));
+  trace->id = id;
+  trace->packet_length = packet_length;
+  trace->sw_if_index_or_table_id = sw_if_index_or_table_id;
+  trace->thread_index = vm->thread_index;
+  trace->next_index = next_index;
+  trace->direction = direction;
+  trace->ip_version = ip_version;
+  trace->is_udp = is_udp;
+  trace->disposition = disposition;
+  trace->segment_count = segment_count;
+}
+
+static_always_inline int
+uet_tx_l4_prepare (u8 protocol, u8 *l4, u32 l4_length)
+{
+  if (protocol == UET_IP_PROTOCOL)
+    return l4_length >= 4; /* Native-IP entropy header. */
+
+  if (protocol == IP_PROTOCOL_UDP && l4_length >= sizeof (udp_header_t))
+    {
+      udp_header_t *udp = (udp_header_t *) l4;
+
+      if (clib_net_to_host_u16 (udp->dst_port) != UET_UDP_PORT ||
+	  clib_net_to_host_u16 (udp->length) != l4_length)
+	return 0;
+
+      /* UE Specification 1.0.3, section 3.5.10.1: udp.checksum MUST
+       * be zero on send.  Normalize provider input here and do not request
+       * UDP checksum offload. */
+      udp->checksum = 0;
+      return 1;
+    }
+
+  return 0;
+}
+
+/*
+ * Validate the provider-supplied IP packet and initialize exactly the
+ * metadata consumed by ip4-lookup/ip6-lookup.  VLIB_TX carries a FIB index
+ * override, not an output interface.  The lookup still selects the route,
+ * adjacency, interface and device path.
+ */
+static_always_inline int
+uet_tx_ip_prepare (vlib_buffer_t *buffer, u32 packet_length, u32 ip4_fib_index, u32 ip6_fib_index,
+		   u16 *next)
+{
+  u8 *packet = buffer->data;
+  u32 fib_index;
+  u8 version;
+
+  if (packet_length < sizeof (ip4_header_t))
+    return 0;
+  version = packet[0] >> 4;
+
+  if (version == 4)
+    {
+      const ip4_header_t *ip4 = (const ip4_header_t *) packet;
+      u32 header_length = ip4_header_bytes (ip4);
+
+      if (header_length < sizeof (*ip4) || header_length > packet_length ||
+	  clib_net_to_host_u16 (ip4->length) != packet_length ||
+	  !uet_tx_l4_prepare (ip4->protocol, packet + header_length, packet_length - header_length))
+	return 0;
+
+      buffer->flags |= VNET_BUFFER_F_IS_IP4 | VNET_BUFFER_F_L3_HDR_OFFSET_VALID;
+      fib_index = ip4_fib_index;
+      *next = UET_TX_NEXT_IP4_LOOKUP;
+    }
+  else if (version == 6)
+    {
+      const ip6_header_t *ip6 = (const ip6_header_t *) packet;
+
+      if (packet_length < sizeof (*ip6) ||
+	  (u32) clib_net_to_host_u16 (ip6->payload_length) + sizeof (*ip6) != packet_length ||
+	  !uet_tx_l4_prepare (ip6->protocol, packet + sizeof (*ip6), packet_length - sizeof (*ip6)))
+	return 0;
+
+      buffer->flags |= VNET_BUFFER_F_IS_IP6 | VNET_BUFFER_F_L3_HDR_OFFSET_VALID;
+      fib_index = ip6_fib_index;
+      *next = UET_TX_NEXT_IP6_LOOKUP;
+    }
+  else
+    return 0;
+
+  buffer->current_data = 0;
+  buffer->current_length = packet_length;
+  vnet_buffer (buffer)->l3_hdr_offset = 0;
+  vnet_buffer (buffer)->sw_if_index[VLIB_RX] = 0;
+  vnet_buffer (buffer)->sw_if_index[VLIB_TX] = fib_index;
+  return 1;
+}
+
+static_always_inline u32
+uet_spsc_index (const uet_vpp_svm_spsc_ring_t *ring, u32 counter)
+{
+  return ring->mask ? counter & ring->mask : counter % ring->size;
+}
+
+static_always_inline void
+uet_endpoint_bihash_key_init (const uet_vpp_svm_endpoint_key_t *endpoint, clib_bihash_kv_40_8_t *kv)
+{
+  clib_memset (kv, 0, sizeof (*kv));
+  clib_memcpy_fast (kv->key, endpoint, sizeof (*endpoint));
+}
+
+static_always_inline int
+uet_endpoint_update (uet_main_t *um, u32 client_namespace,
+		     const uet_vpp_svm_control_request_t *request)
+{
+  const uet_vpp_svm_endpoint_key_t *endpoint = &request->endpoint;
+  clib_bihash_kv_40_8_t kv, result;
+  u32 client_index;
+  int found;
+
+  if (!client_namespace || client_namespace > UET_VPP_SVM_CLIENT_NAMESPACE_MAX ||
+      !request->request_id || request->reserved0 || request->reserved1 || request->reserved2[0] ||
+      request->reserved2[1] || (endpoint->ip_version != 4 && endpoint->ip_version != 6) ||
+      endpoint->absolute > 1 || endpoint->pid_on_fep > 0x0fff ||
+      endpoint->resource_index > 0x0fff || endpoint->job_id > 0x00ffffff || endpoint->reserved0 ||
+      endpoint->reserved1 || (endpoint->absolute && endpoint->job_id))
+    return -EINVAL;
+  if (endpoint->ip_version == 4)
+    for (u32 i = 4; i < sizeof (endpoint->ip_address); i++)
+      if (endpoint->ip_address[i])
+	return -EINVAL;
+
+  client_index = um->client_by_namespace[client_namespace];
+  if (client_index == UET_INVALID_CLIENT_INDEX || pool_is_free_index (um->clients, client_index))
+    return -ENOENT;
+
+  uet_endpoint_bihash_key_init (endpoint, &kv);
+  found = clib_bihash_search_40_8 (&um->endpoint_hash, &kv, &result) == 0;
+  if (request->operation == UET_VPP_SVM_CONTROL_ENDPOINT_ADD)
+    {
+      if (found)
+	{
+	  if (result.value == client_namespace)
+	    return 0;
+	  um->endpoint_collisions++;
+	  return -EADDRINUSE;
+	}
+      kv.value = client_namespace;
+      if (clib_bihash_add_del_40_8 (&um->endpoint_hash, &kv, 1))
+	return -ENOMEM;
+      um->endpoint_registrations++;
+      return 0;
+    }
+  if (request->operation == UET_VPP_SVM_CONTROL_ENDPOINT_DEL)
+    {
+      if (!found)
+	return -ENOENT;
+      if (result.value != client_namespace)
+	return -EPERM;
+      kv.value = result.value;
+      if (clib_bihash_add_del_40_8 (&um->endpoint_hash, &kv, 0))
+	return -EIO;
+      ASSERT (um->endpoint_registrations > 0);
+      um->endpoint_registrations--;
+      return 0;
+    }
+  return -EINVAL;
+}
+
+static_always_inline void
+uet_control_process (uet_main_t *um, uet_worker_channel_t *channel)
+{
+  uet_vpp_svm_spsc_ring_t *request_ring = channel->control_request_ring;
+  uet_vpp_svm_spsc_ring_t *completion_ring = channel->control_completion_ring;
+  u32 request_consumer = clib_atomic_load_relax_n (&request_ring->consumer);
+  u32 request_producer = clib_atomic_load_acq_n (&request_ring->producer);
+  u32 completion_producer = clib_atomic_load_relax_n (&completion_ring->producer);
+  u32 completion_consumer = clib_atomic_load_acq_n (&completion_ring->consumer);
+  u32 available = request_producer - request_consumer;
+  u32 processed = 0;
+
+  if (PREDICT_FALSE (available > request_ring->size ||
+		     completion_producer - completion_consumer > completion_ring->size))
+    return;
+  available = clib_min (available, (u32) UET_SPSC_MAX_BATCH);
+  while (processed < available && completion_producer - completion_consumer < completion_ring->size)
+    {
+      const uet_vpp_svm_control_request_t *request =
+	channel->control_requests + uet_spsc_index (request_ring, request_consumer + processed);
+      uet_vpp_svm_control_completion_t completion = {
+	.request_id = request->request_id,
+	.status = uet_endpoint_update (um, channel->client_namespace, request),
+      };
+      u32 completion_index = uet_spsc_index (completion_ring, completion_producer);
+
+      clib_memcpy_fast (channel->control_completions + completion_index, &completion,
+			sizeof (completion));
+      completion_producer++;
+      processed++;
+    }
+  if (processed)
+    {
+      clib_atomic_store_rel_n (&completion_ring->producer, completion_producer);
+      clib_atomic_store_rel_n (&request_ring->consumer, request_consumer + processed);
+    }
+}
+
+static_always_inline void
+uet_rx_release_process (vlib_main_t *vm, uet_worker_t *uw, uet_worker_channel_t *channel)
+{
+  uet_vpp_svm_spsc_ring_t *ring = channel->rx_release_ring;
+  u32 consumer = clib_atomic_load_relax_n (&ring->consumer);
+  u32 producer = clib_atomic_load_acq_n (&ring->producer);
+  u32 available = producer - consumer;
+
+  if (PREDICT_FALSE (available > ring->size))
+    {
+      uw->rx_invalid_releases++;
+      uet_tx_error_count (vm, UET_TX_ERROR_INVALID_RX_RELEASE);
+      return;
+    }
+  available = clib_min (available, (u32) UET_SPSC_MAX_BATCH);
+
+  for (u32 i = 0; i < available; i++)
+    {
+      const uet_vpp_svm_rx_release_t *release =
+	channel->rx_release_entries + uet_spsc_index (ring, consumer + i);
+      u32 token = release->release_token;
+
+      if (release->reserved || !release->rx_id || token >= channel->dma_slot_count ||
+	  channel->rx_ids[token] != release->rx_id)
+	{
+	  uw->rx_invalid_releases++;
+	  uet_tx_error_count (vm, UET_TX_ERROR_INVALID_RX_RELEASE);
+	  continue;
+	}
+
+      vlib_buffer_free_one (vm, channel->rx_buffer_indices[token]);
+      channel->rx_ids[token] = 0;
+      channel->rx_buffer_indices[token] = ~0;
+      ASSERT (channel->rx_free_count < channel->dma_slot_count);
+      channel->rx_free_slots[channel->rx_free_count++] = token;
+      uw->rx_releases++;
+      ASSERT (channel->rx_outstanding > 0 && uw->rx_outstanding > 0);
+      channel->rx_outstanding--;
+      uw->rx_outstanding--;
+    }
+
+  if (available)
+    clib_atomic_store_rel_n (&ring->consumer, consumer + available);
+}
+
+static_always_inline int
+uet_rx_descriptor_build (vlib_main_t *vm, uet_main_t *um, vlib_buffer_t *buffer, u32 release_token,
+			 u8 is_ip4, u8 is_udp, uet_vpp_svm_rx_desc_t *desc)
+{
+  i16 l3_offset = vnet_buffer (buffer)->l3_hdr_offset;
+  u8 *start = buffer->data + l3_offset;
+  u8 *end = vlib_buffer_get_current (buffer) + buffer->current_length;
+  u32 packet_length, remaining;
+  vlib_buffer_t *segment_buffer = buffer;
+  u8 *segment_start = start;
+
+  if (start < buffer->data - VLIB_BUFFER_PRE_DATA_SIZE || start >= end)
+    return 0;
+
+  if (is_ip4)
+    {
+      const ip4_header_t *ip4 = (const ip4_header_t *) start;
+
+      if ((uword) (end - start) < sizeof (*ip4) || ip4->ip_version_and_header_length >> 4 != 4)
+	return 0;
+      packet_length = clib_net_to_host_u16 (ip4->length);
+    }
+  else
+    {
+      const ip6_header_t *ip6 = (const ip6_header_t *) start;
+
+      if ((uword) (end - start) < sizeof (*ip6) ||
+	  clib_net_to_host_u32 (ip6->ip_version_traffic_class_and_flow_label) >> 28 != 6)
+	return 0;
+      packet_length = sizeof (*ip6) + clib_net_to_host_u16 (ip6->payload_length);
+    }
+
+  if (!packet_length ||
+      packet_length > (u32) (end - start) + buffer->total_length_not_including_first_buffer)
+    return 0;
+
+  clib_memset (desc, 0, sizeof (*desc));
+  desc->release_token = release_token;
+  desc->packet_length = packet_length;
+  desc->rx_sw_if_index = vnet_buffer (buffer)->ip.rx_sw_if_index;
+  desc->flags = is_ip4 ? UET_VPP_SVM_RX_F_IP4 : UET_VPP_SVM_RX_F_IP6;
+  desc->flags |= is_udp ? UET_VPP_SVM_RX_F_UDP : 0;
+  remaining = packet_length;
+
+  while (remaining)
+    {
+      u32 length;
+      u64 data_offset;
+
+      if (desc->segment_count == UET_VPP_SVM_MAX_RX_SEGS)
+	return 0;
+      length = clib_min (remaining, (u32) ((u8 *) vlib_buffer_get_current (segment_buffer) +
+					   segment_buffer->current_length - segment_start));
+      if (!length || segment_start < um->dma_map_base ||
+	  (u64) (segment_start - um->dma_map_base) >= um->dma_map_size)
+	return 0;
+      data_offset = segment_start - um->dma_map_base;
+      if (length > um->dma_map_size - data_offset)
+	return 0;
+
+      desc->segments[desc->segment_count].data_offset = data_offset;
+      desc->segments[desc->segment_count].length = length;
+      desc->segment_count++;
+      remaining -= length;
+      if (!remaining)
+	break;
+      if (!(segment_buffer->flags & VLIB_BUFFER_NEXT_PRESENT))
+	return 0;
+      segment_buffer = vlib_get_buffer (vm, segment_buffer->next_buffer);
+      segment_start = vlib_buffer_get_current (segment_buffer);
+    }
+
+  return 1;
+}
+
+static_always_inline u32
+uet_rx_ip_packet_length (vlib_main_t *vm, vlib_buffer_t *buffer, u8 is_ip4)
+{
+  u8 *start = buffer->data + vnet_buffer (buffer)->l3_hdr_offset;
+  u8 *end = (u8 *) vlib_buffer_get_current (buffer) + buffer->current_length;
+  u32 length = 0;
+
+  if (start >= buffer->data - VLIB_BUFFER_PRE_DATA_SIZE && start < end)
+    {
+      if (is_ip4 && (uword) (end - start) >= sizeof (ip4_header_t))
+	length = clib_net_to_host_u16 (((ip4_header_t *) start)->length);
+      else if (!is_ip4 && (uword) (end - start) >= sizeof (ip6_header_t))
+	length =
+	  sizeof (ip6_header_t) + clib_net_to_host_u16 (((ip6_header_t *) start)->payload_length);
+      if (length <= (u32) (end - start) + buffer->total_length_not_including_first_buffer)
+	return length;
+    }
+  return vlib_buffer_length_in_chain (vm, buffer);
+}
+
+static_always_inline void
+uet_tx_completion_add (uet_worker_t *uw, uet_worker_channel_t *channel,
+		       const uet_vpp_svm_tx_completion_t *completion, u32 *producer)
+{
+  u32 index = uet_spsc_index (channel->tx_completion_ring, *producer);
+
+  clib_memcpy_fast (channel->tx_completion_entries + index, completion, sizeof (*completion));
+  (*producer)++;
+  uw->tx_completions++;
+}
+
+/*
+ * Transfer the populated slot buffer to the VPP graph and replenish the slot
+ * before publishing its completion.  The graph owns the old buffer normally;
+ * no output-interface or device-node knowledge is required to reclaim it.
+ */
+static_always_inline int
+uet_dma_slot_replace (vlib_main_t *vm, uet_main_t *um, uet_worker_channel_t *channel, u32 slot,
+		      u32 *tx_buffer_index)
+{
+  u32 replacement_index;
+  vlib_buffer_t *replacement;
+  u64 data_offset;
+
+  if (vlib_buffer_alloc_from_pool (vm, &replacement_index, 1, um->dma_buffer_pool_index) != 1)
+    return 0;
+
+  replacement = vlib_get_buffer (vm, replacement_index);
+  data_offset = (u8 *) replacement->data - um->dma_map_base;
+  if (PREDICT_FALSE (data_offset >= um->dma_map_size ||
+		     um->dma_buffer_data_size > um->dma_map_size - data_offset))
+    {
+      vlib_buffer_free_one (vm, replacement_index);
+      return 0;
+    }
+
+  *tx_buffer_index = channel->dma_buffer_indices[slot];
+  channel->dma_buffer_indices[slot] = replacement_index;
+  channel->dma_slots[slot].data_offset = data_offset;
+  channel->dma_slots[slot].capacity = um->dma_buffer_data_size;
+  return 1;
+}
+
+static_always_inline void
+uet_tx_process (vlib_main_t *vm, uet_worker_t *uw, uet_worker_channel_t *channel, u32 *tx_buffers,
+		u16 *tx_nexts, u64 *tx_trace_ids, u32 *n_tx)
+{
+  uet_main_t *um = &uet_main;
+  uet_vpp_svm_spsc_ring_t *tx_ring = channel->tx_ring;
+  uet_vpp_svm_spsc_ring_t *cq_ring = channel->tx_completion_ring;
+  u32 cq_producer = clib_atomic_load_relax_n (&cq_ring->producer);
+  u32 cq_initial_producer = cq_producer;
+  u32 cq_consumer = clib_atomic_load_acq_n (&cq_ring->consumer);
+  u32 tx_consumer, tx_producer, tx_available, n_processed = 0;
+
+  if (PREDICT_FALSE (cq_producer - cq_consumer > cq_ring->size))
+    {
+      uet_tx_error_count (vm, UET_TX_ERROR_COMPLETION_RING_FULL);
+      return;
+    }
+
+  tx_consumer = clib_atomic_load_relax_n (&tx_ring->consumer);
+  tx_producer = clib_atomic_load_acq_n (&tx_ring->producer);
+  tx_available = tx_producer - tx_consumer;
+  if (PREDICT_FALSE (tx_available > tx_ring->size))
+    {
+      uw->invalid_requests++;
+      uet_tx_error_count (vm, UET_TX_ERROR_INVALID_REQUEST);
+      tx_available = tx_ring->size;
+    }
+
+  while (n_processed < tx_available && *n_tx < UET_SPSC_MAX_BATCH)
+    {
+      u32 index = uet_spsc_index (tx_ring, tx_consumer + n_processed);
+      const uet_vpp_svm_tx_desc_t *desc = channel->tx_descs + index;
+      u32 slot = desc->dma_slot;
+      uet_vpp_svm_tx_completion_t completion = {
+	.dma_slot = UET_VPP_SVM_INVALID_DMA_SLOT,
+	.request_id = desc->request_id,
+	.user_context = desc->user_context,
+      };
+      u8 valid = 0;
+
+      if (cq_producer - cq_consumer >= cq_ring->size)
+	{
+	  uw->tx_completion_ring_full++;
+	  uet_tx_error_count (vm, UET_TX_ERROR_COMPLETION_RING_FULL);
+	  break;
+	}
+
+      if (slot < channel->dma_slot_count)
+	completion.dma_slot = slot;
+      if (!uw->tx_configured)
+	completion.status = UET_VPP_SVM_STATUS_TX_NOT_CONFIGURED;
+      else if (slot >= channel->dma_slot_count ||
+	       desc->packet_length > channel->dma_slots[slot].capacity || desc->reserved)
+	{
+	  completion.status = UET_VPP_SVM_STATUS_INVALID_PACKET;
+	  uw->invalid_requests++;
+	  uet_tx_error_count (vm, UET_TX_ERROR_INVALID_REQUEST);
+	}
+      else
+	{
+	  vlib_buffer_t *buffer = vlib_get_buffer (vm, channel->dma_buffer_indices[slot]);
+
+	  if (clib_atomic_load_acq_n (&buffer->ref_count) != 1)
+	    {
+	      completion.status = UET_VPP_SVM_STATUS_SLOT_BUSY;
+	      uw->invalid_requests++;
+	      uet_tx_error_count (vm, UET_TX_ERROR_INVALID_REQUEST);
+	    }
+	  else
+	    valid = 1;
+	}
+
+      if (!valid)
+	uet_tx_completion_add (uw, channel, &completion, &cq_producer);
+      else
+	{
+	  vlib_buffer_t *buffer = vlib_get_buffer (vm, channel->dma_buffer_indices[slot]);
+	  vlib_buffer_pool_t *pool = vlib_get_buffer_pool (vm, buffer->buffer_pool_index);
+
+	  vlib_buffer_copy_template (buffer, &pool->buffer_template);
+	  if (!uet_tx_ip_prepare (buffer, desc->packet_length, uw->tx_ip4_fib_index,
+				  uw->tx_ip6_fib_index, tx_nexts + *n_tx))
+	    {
+	      completion.status = UET_VPP_SVM_STATUS_INVALID_PACKET;
+	      uw->invalid_requests++;
+	      uet_tx_error_count (vm, UET_TX_ERROR_INVALID_REQUEST);
+	      uet_tx_completion_add (uw, channel, &completion, &cq_producer);
+	      goto next_request;
+	    }
+	  if (!uet_dma_slot_replace (vm, um, channel, slot, tx_buffers + *n_tx))
+	    break;
+
+	  completion.status = UET_VPP_SVM_STATUS_OK;
+	  completion.completed_length = desc->packet_length;
+	  uet_tx_completion_add (uw, channel, &completion, &cq_producer);
+	  tx_trace_ids[*n_tx] = desc->request_id;
+	  (*n_tx)++;
+	  uw->tx_packets++;
+	  uw->tx_bytes += desc->packet_length;
+	}
+
+    next_request:
+      uw->tx_requests++;
+      n_processed++;
+    }
+
+  if (cq_producer != cq_initial_producer)
+    clib_atomic_store_rel_n (&cq_ring->producer, cq_producer);
+  if (n_processed)
+    clib_atomic_store_rel_n (&tx_ring->consumer, tx_consumer + n_processed);
+}
+
+static __clib_noinline void
+uet_tx_trace_batch (vlib_main_t *vm, vlib_node_runtime_t *node, uet_worker_t *uw,
+		    const u32 *tx_buffers, const u16 *tx_nexts, const u64 *tx_trace_ids, u32 n_tx)
+{
+  uet_trace_state_t trace_state = { 0 };
+
+  for (u32 i = 0; i < n_tx; i++)
+    {
+      vlib_buffer_t *buffer = vlib_get_buffer (vm, tx_buffers[i]);
+      u8 ip_version = buffer->data[0] >> 4;
+      u8 is_udp = ip_version == 4 ? ((ip4_header_t *) buffer->data)->protocol == IP_PROTOCOL_UDP :
+				    ((ip6_header_t *) buffer->data)->protocol == IP_PROTOCOL_UDP;
+
+      uet_trace_add (vm, node, buffer, &trace_state, tx_nexts[i], tx_trace_ids[i],
+		     buffer->current_length,
+		     ip_version == 4 ? uw->tx_ip4_table_id : uw->tx_ip6_table_id, 0 /* TX */,
+		     ip_version, is_udp, UET_TRACE_TX_ROUTED, 1);
+    }
+}
+
+static_always_inline u32
+uet_svm_process (vlib_main_t *vm, vlib_node_runtime_t *node, uet_worker_t *uw,
+		 uet_worker_channel_t *channel)
+{
+  u32 tx_buffers[UET_SPSC_MAX_BATCH + 1];
+  u16 tx_nexts[UET_SPSC_MAX_BATCH + 1];
+  u64 tx_trace_ids[UET_SPSC_MAX_BATCH + 1];
+  u32 n_tx = 0;
+  u32 client_flags;
+
+  client_flags = clib_atomic_load_acq_n (&channel->svm_header->client_flags);
+  if (!!(client_flags & UET_VPP_SVM_CLIENT_F_DMA_READY) != channel->dma_ready_ack)
+    {
+      if (client_flags & UET_VPP_SVM_CLIENT_F_DMA_READY)
+	{
+	  u32 ready = clib_atomic_add_fetch (&channel->svm_header->server_dma_ready_count, 1);
+
+	  channel->dma_ready_ack = 1;
+	  if (ready == channel->svm_header->worker_count)
+	    clib_atomic_store_rel_n (&channel->svm_header->server_flags,
+				     UET_VPP_SVM_SERVER_F_DMA_READY_ACK);
+	}
+      else
+	{
+	  /* The client may have published its final RX releases immediately
+	   * before clearing DMA_READY. Consume them before acknowledging that
+	   * this worker no longer touches the old owner state.
+	   */
+	  for (u32 batch = 0;
+	       batch < (channel->dma_slot_count + UET_SPSC_MAX_BATCH - 1) / UET_SPSC_MAX_BATCH;
+	       batch++)
+	    {
+	      u32 consumer = clib_atomic_load_relax_n (&channel->rx_release_ring->consumer);
+	      u32 producer = clib_atomic_load_acq_n (&channel->rx_release_ring->producer);
+
+	      if (producer == consumer)
+		break;
+	      uet_rx_release_process (vm, uw, channel);
+	    }
+	  u32 ready = clib_atomic_sub_fetch (&channel->svm_header->server_dma_ready_count, 1);
+
+	  channel->dma_ready_ack = 0;
+	  if (!ready)
+	    clib_atomic_store_rel_n (&channel->svm_header->server_flags, 0);
+	}
+    }
+
+  if (!(client_flags & UET_VPP_SVM_CLIENT_F_DMA_READY))
+    return 0;
+
+  if (uw->thread_index == vlib_get_worker_thread_index (0))
+    uet_control_process (&uet_main, channel);
+  uet_rx_release_process (vm, uw, channel);
+  uet_tx_process (vm, uw, channel, tx_buffers, tx_nexts, tx_trace_ids, &n_tx);
+
+  if (n_tx)
+    {
+      if (PREDICT_FALSE (vm->trace_main.trace_enable))
+	uet_tx_trace_batch (vm, node, uw, tx_buffers, tx_nexts, tx_trace_ids, n_tx);
+      vlib_buffer_enqueue_to_next (vm, node, tx_buffers, tx_nexts, n_tx);
+    }
+
+  return n_tx;
+}
+
+VLIB_NODE_FN (uet_input_node)
+(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame)
+{
+  uet_main_t *um = &uet_main;
+  uet_worker_t *uw;
+  u32 n_tx = 0;
+
+  if (PREDICT_FALSE (!um->enabled || vm->thread_index == 0 ||
+		     vm->thread_index >= vec_len (um->workers)))
+    return 0;
+
+  uw = vec_elt_at_index (um->workers, vm->thread_index);
+  ASSERT (uw->thread_index == vm->thread_index);
+
+  uw->poll_calls++;
+
+  for (u32 client_index = 0; client_index < vec_len (uw->channels); client_index++)
+    {
+      uet_worker_channel_t *channel = uw->channels + client_index;
+
+      if (PREDICT_TRUE (channel->active))
+	n_tx += uet_svm_process (vm, node, uw, channel);
+    }
+
+  return n_tx;
+}
+
+typedef enum
+{
+  UET_LOCAL_NEXT_DROP,
+  UET_LOCAL_N_NEXT,
+} uet_local_next_t;
+
+#define UET_WIRE_PDS_TYPE_MASK	    0xf800
+#define UET_WIRE_PDS_TYPE_SHIFT	    11
+#define UET_WIRE_PDS_NEXT_MASK	    0x0780
+#define UET_WIRE_PDS_NEXT_SHIFT	    7
+#define UET_WIRE_PDS_FLAGS_MASK	    0x007f
+#define UET_WIRE_PDS_RUD_REQ	    2
+#define UET_WIRE_PDS_ROD_REQ	    3
+#define UET_WIRE_PDS_RUDI_REQ	    4
+#define UET_WIRE_PDS_RUDI_RESP	    5
+#define UET_WIRE_PDS_UUD_REQ	    6
+#define UET_WIRE_PDS_ACK	    7
+#define UET_WIRE_PDS_ACK_CC	    8
+#define UET_WIRE_PDS_ACK_CCX	    9
+#define UET_WIRE_PDS_NACK	    10
+#define UET_WIRE_PDS_CTRL	    11
+#define UET_WIRE_PDS_NACK_CCX	    12
+#define UET_WIRE_PDS_RUD_CC_REQ	    13
+#define UET_WIRE_PDS_ROD_CC_REQ	    14
+#define UET_WIRE_PDS_REQ_SYN	    0x04
+#define UET_WIRE_PDS_NACK_RUDI	    0x08
+#define UET_WIRE_SES_REQ_STD	    3
+#define UET_WIRE_SES_RSP	    4
+#define UET_WIRE_SES_RSP_DATA	    5
+#define UET_WIRE_SES_RSP_DATA_SMALL 6
+#define UET_WIRE_SES_RELATIVE	    0x08
+#define UET_WIRE_PDC_HEADER_SIZE    12
+#define UET_WIRE_NACK_HEADER_SIZE   16
+#define UET_WIRE_CTRL_HEADER_SIZE   16
+#define UET_WIRE_RUDI_HEADER_SIZE   8
+#define UET_WIRE_UUD_HEADER_SIZE    4
+#define UET_WIRE_SES_REQ_CMN_SIZE   12
+#define UET_WIRE_SES_RSP_CMN_SIZE   8
+
+static_always_inline int
+uet_rx_endpoint_key_namespace (uet_main_t *um, const uet_vpp_svm_endpoint_key_t *endpoint,
+			       u32 *client_namespace)
+{
+  clib_bihash_kv_40_8_t kv, result;
+
+  uet_endpoint_bihash_key_init (endpoint, &kv);
+  if (clib_bihash_search_40_8 (&um->endpoint_hash, &kv, &result))
+    return 0;
+  if (!result.value || result.value > UET_VPP_SVM_CLIENT_NAMESPACE_MAX)
+    return 0;
+  *client_namespace = result.value;
+  return 1;
+}
+
+static_always_inline int
+uet_rx_endpoint_namespace (uet_main_t *um, const u8 *ses, u32 available, const void *dst_address,
+			   u8 is_ip4, u32 *client_namespace)
+{
+  uet_vpp_svm_endpoint_key_t endpoint = {
+    .ip_version = is_ip4 ? 4 : 6,
+  };
+  u16 value16;
+  u32 value32;
+
+  if (available < UET_WIRE_SES_REQ_CMN_SIZE)
+    return 0;
+  endpoint.absolute = !(ses[1] & UET_WIRE_SES_RELATIVE);
+  clib_memcpy_fast (&value32, ses + 4, sizeof (value32));
+  endpoint.job_id = endpoint.absolute ? 0 : clib_net_to_host_u32 (value32) & 0x00ffffff;
+  clib_memcpy_fast (&value16, ses + 8, sizeof (value16));
+  endpoint.pid_on_fep = clib_net_to_host_u16 (value16) & 0x0fff;
+  clib_memcpy_fast (&value16, ses + 10, sizeof (value16));
+  endpoint.resource_index = clib_net_to_host_u16 (value16) & 0x0fff;
+  clib_memcpy_fast (endpoint.ip_address, dst_address, is_ip4 ? 4 : 16);
+  return uet_rx_endpoint_key_namespace (um, &endpoint, client_namespace);
+}
+
+static_always_inline int
+uet_rx_sng_ack_namespace (uet_main_t *um, const u8 *pds, u32 available, const void *dst_address,
+			  u8 is_ip4, u8 next_header, u32 *client_namespace)
+{
+  uet_vpp_svm_endpoint_key_t endpoint = {
+    .ip_version = is_ip4 ? 4 : 6,
+  };
+  const u8 *ses = pds + UET_WIRE_PDC_HEADER_SIZE;
+  u16 value16;
+  u32 value32;
+
+  if ((next_header != UET_WIRE_SES_RSP && next_header != UET_WIRE_SES_RSP_DATA &&
+       next_header != UET_WIRE_SES_RSP_DATA_SMALL) ||
+      available < UET_WIRE_PDC_HEADER_SIZE + UET_WIRE_SES_RSP_CMN_SIZE)
+    return 0;
+  clib_memcpy_fast (&value16, pds + 8, sizeof (value16));
+  endpoint.pid_on_fep = clib_net_to_host_u16 (value16) & 0x0fff;
+  clib_memcpy_fast (&value16, pds + 10, sizeof (value16));
+  endpoint.resource_index = clib_net_to_host_u16 (value16) & 0x0fff;
+  clib_memcpy_fast (&value32, ses + 4, sizeof (value32));
+  endpoint.job_id = clib_net_to_host_u32 (value32) & 0x00ffffff;
+  clib_memcpy_fast (endpoint.ip_address, dst_address, is_ip4 ? 4 : 16);
+
+  /* SES responses do not repeat the request's relative-addressing bit. */
+  if (uet_rx_endpoint_key_namespace (um, &endpoint, client_namespace))
+    return 1;
+  endpoint.absolute = 1;
+  endpoint.job_id = 0;
+  return uet_rx_endpoint_key_namespace (um, &endpoint, client_namespace);
+}
+
+static_always_inline int
+uet_rx_namespace_mode (uet_worker_t *uw, u32 client_namespace, u8 *sng)
+{
+  u32 client_index;
+  uet_worker_channel_t *channel;
+
+  if (!client_namespace || client_namespace > UET_VPP_SVM_CLIENT_NAMESPACE_MAX)
+    return 0;
+  client_index = uet_main.client_by_namespace[client_namespace];
+  if (client_index == UET_INVALID_CLIENT_INDEX || client_index >= vec_len (uw->channels))
+    return 0;
+  channel = uw->channels + client_index;
+  if (!channel->active)
+    return 0;
+  *sng =
+    !!(clib_atomic_load_acq_n (&channel->svm_header->client_flags) & UET_VPP_SVM_CLIENT_F_PDS_SNG);
+  return 1;
+}
+
+static_always_inline int
+uet_rx_namespace_uses_sng (uet_worker_t *uw, u32 client_namespace)
+{
+  u8 sng;
+
+  return uet_rx_namespace_mode (uw, client_namespace, &sng) && sng;
+}
+
+static_always_inline int
+uet_rx_packet_namespace (uet_worker_t *uw, vlib_buffer_t *buffer, u8 is_ip4, u8 is_udp,
+			 u32 *client_namespace)
+{
+  uet_main_t *um = &uet_main;
+  u8 *start = buffer->data + vnet_buffer (buffer)->l3_hdr_offset;
+  u8 *end = vlib_buffer_get_current (buffer) + buffer->current_length;
+  const void *dst_address;
+  u8 *pds;
+  u32 available, l4_offset;
+  u16 prologue, pdc_id;
+  u8 type, next_header, flags;
+
+  if (start < buffer->data - VLIB_BUFFER_PRE_DATA_SIZE || start >= end)
+    return 0;
+  available = end - start;
+  if (is_ip4)
+    {
+      ip4_header_t *ip4 = (ip4_header_t *) start;
+
+      if (available < sizeof (*ip4))
+	return 0;
+      l4_offset = ip4_header_bytes (ip4);
+      if (l4_offset < sizeof (*ip4) || l4_offset > available)
+	return 0;
+      dst_address = &ip4->dst_address;
+    }
+  else
+    {
+      ip6_header_t *ip6 = (ip6_header_t *) start;
+
+      if (available < sizeof (*ip6))
+	return 0;
+      l4_offset = sizeof (*ip6);
+      dst_address = &ip6->dst_address;
+    }
+  l4_offset += is_udp ? sizeof (udp_header_t) : 4;
+  if (l4_offset + sizeof (prologue) > available)
+    return 0;
+  pds = start + l4_offset;
+  available -= l4_offset;
+  clib_memcpy_fast (&prologue, pds, sizeof (prologue));
+  prologue = clib_net_to_host_u16 (prologue);
+  type = (prologue & UET_WIRE_PDS_TYPE_MASK) >> UET_WIRE_PDS_TYPE_SHIFT;
+  next_header = (prologue & UET_WIRE_PDS_NEXT_MASK) >> UET_WIRE_PDS_NEXT_SHIFT;
+  flags = prologue & UET_WIRE_PDS_FLAGS_MASK;
+
+  switch (type)
+    {
+    case UET_WIRE_PDS_RUD_REQ:
+    case UET_WIRE_PDS_ROD_REQ:
+    case UET_WIRE_PDS_RUD_CC_REQ:
+    case UET_WIRE_PDS_ROD_CC_REQ:
+      if (available < UET_WIRE_PDC_HEADER_SIZE)
+	return 0;
+      if (!(flags & UET_WIRE_PDS_REQ_SYN))
+	{
+	  u32 endpoint_namespace;
+
+	  /* SNG has no PDC setup and carries the destination endpoint in
+	   * every standard SES request. Real PDS retains the constant-time
+	   * namespaced-PDC path below.
+	   */
+	  if ((type == UET_WIRE_PDS_RUD_REQ || type == UET_WIRE_PDS_ROD_REQ) &&
+	      next_header == UET_WIRE_SES_REQ_STD &&
+	      uet_rx_endpoint_namespace (um, pds + UET_WIRE_PDC_HEADER_SIZE,
+					 available - UET_WIRE_PDC_HEADER_SIZE, dst_address, is_ip4,
+					 &endpoint_namespace) &&
+	      uet_rx_namespace_uses_sng (uw, endpoint_namespace))
+	    {
+	      *client_namespace = endpoint_namespace;
+	      return 1;
+	    }
+	  clib_memcpy_fast (&pdc_id, pds + 10, sizeof (pdc_id));
+	  *client_namespace = clib_net_to_host_u16 (pdc_id) >> UET_VPP_SVM_PDC_LOCAL_BITS;
+	  return *client_namespace != 0;
+	}
+      if (next_header != UET_WIRE_SES_REQ_STD)
+	return 0;
+      l4_offset = UET_WIRE_PDC_HEADER_SIZE +
+		  ((type == UET_WIRE_PDS_RUD_CC_REQ || type == UET_WIRE_PDS_ROD_CC_REQ) ? 4 : 0);
+      if (l4_offset > available)
+	return 0;
+      return uet_rx_endpoint_namespace (um, pds + l4_offset, available - l4_offset, dst_address,
+					is_ip4, client_namespace);
+    case UET_WIRE_PDS_ACK:
+      if (available < UET_WIRE_PDC_HEADER_SIZE)
+	return 0;
+      {
+	u32 pds_namespace, sng_namespace;
+	u8 pds_is_sng;
+
+	clib_memcpy_fast (&pdc_id, pds + 10, sizeof (pdc_id));
+	pds_namespace = clib_net_to_host_u16 (pdc_id) >> UET_VPP_SVM_PDC_LOCAL_BITS;
+
+	if (uet_rx_sng_ack_namespace (um, pds, available, dst_address, is_ip4, next_header,
+				      &sng_namespace) &&
+	    uet_rx_namespace_uses_sng (uw, sng_namespace))
+	  {
+	    /* A real-PDS ACK can coincidentally resemble the SNG overlay. Never
+	     * choose between two live applications arbitrarily.
+	     */
+	    if (pds_namespace != sng_namespace &&
+		uet_rx_namespace_mode (uw, pds_namespace, &pds_is_sng) && !pds_is_sng)
+	      return 0;
+	    *client_namespace = sng_namespace;
+	    return 1;
+	  }
+	*client_namespace = pds_namespace;
+      }
+      return *client_namespace != 0;
+    case UET_WIRE_PDS_ACK_CC:
+    case UET_WIRE_PDS_ACK_CCX:
+      if (available < UET_WIRE_PDC_HEADER_SIZE)
+	return 0;
+      clib_memcpy_fast (&pdc_id, pds + 10, sizeof (pdc_id));
+      *client_namespace = clib_net_to_host_u16 (pdc_id) >> UET_VPP_SVM_PDC_LOCAL_BITS;
+      return *client_namespace != 0;
+    case UET_WIRE_PDS_NACK:
+    case UET_WIRE_PDS_NACK_CCX:
+      if (available < UET_WIRE_NACK_HEADER_SIZE)
+	return 0;
+      if (flags & UET_WIRE_PDS_NACK_RUDI)
+	{
+	  u32 packet_id;
+
+	  clib_memcpy_fast (&packet_id, pds + 4, sizeof (packet_id));
+	  *client_namespace = clib_net_to_host_u32 (packet_id) >> UET_VPP_SVM_RUDI_LOCAL_BITS;
+	}
+      else
+	{
+	  clib_memcpy_fast (&pdc_id, pds + 10, sizeof (pdc_id));
+	  *client_namespace = clib_net_to_host_u16 (pdc_id) >> UET_VPP_SVM_PDC_LOCAL_BITS;
+	}
+      return *client_namespace != 0;
+    case UET_WIRE_PDS_CTRL:
+      if (available < UET_WIRE_CTRL_HEADER_SIZE || (flags & UET_WIRE_PDS_REQ_SYN))
+	return 0;
+      clib_memcpy_fast (&pdc_id, pds + 10, sizeof (pdc_id));
+      *client_namespace = clib_net_to_host_u16 (pdc_id) >> UET_VPP_SVM_PDC_LOCAL_BITS;
+      return *client_namespace != 0;
+    case UET_WIRE_PDS_RUDI_REQ:
+      if (available < UET_WIRE_RUDI_HEADER_SIZE || next_header != UET_WIRE_SES_REQ_STD)
+	return 0;
+      return uet_rx_endpoint_namespace (um, pds + UET_WIRE_RUDI_HEADER_SIZE,
+					available - UET_WIRE_RUDI_HEADER_SIZE, dst_address, is_ip4,
+					client_namespace);
+    case UET_WIRE_PDS_RUDI_RESP:
+      if (available < UET_WIRE_RUDI_HEADER_SIZE)
+	return 0;
+      {
+	u32 packet_id;
+
+	clib_memcpy_fast (&packet_id, pds + 4, sizeof (packet_id));
+	*client_namespace = clib_net_to_host_u32 (packet_id) >> UET_VPP_SVM_RUDI_LOCAL_BITS;
+	return *client_namespace != 0;
+      }
+    case UET_WIRE_PDS_UUD_REQ:
+      if (available < UET_WIRE_UUD_HEADER_SIZE || next_header != UET_WIRE_SES_REQ_STD)
+	return 0;
+      return uet_rx_endpoint_namespace (um, pds + UET_WIRE_UUD_HEADER_SIZE,
+					available - UET_WIRE_UUD_HEADER_SIZE, dst_address, is_ip4,
+					client_namespace);
+    default:
+      return 0;
+    }
+}
+
+static_always_inline uet_worker_channel_t *
+uet_rx_channels_prepare (vlib_main_t *vm, uet_worker_t *uw, u32 *ready_count)
+{
+  uet_worker_channel_t *selected = 0;
+
+  *ready_count = 0;
+  for (u32 client_index = 0; client_index < vec_len (uw->channels); client_index++)
+    {
+      uet_worker_channel_t *channel = uw->channels + client_index;
+
+      if (!channel->active)
+	continue;
+      uet_rx_release_process (vm, uw, channel);
+      if (!(clib_atomic_load_acq_n (&channel->svm_header->client_flags) &
+	    UET_VPP_SVM_CLIENT_F_DMA_READY))
+	continue;
+      selected = channel;
+      (*ready_count)++;
+    }
+  return selected;
+}
+
+static_always_inline uet_worker_channel_t *
+uet_rx_channel_select (uet_worker_t *uw, vlib_buffer_t *buffer, u8 is_ip4, u8 is_udp,
+		       u32 ready_count, uet_worker_channel_t *single_channel, u8 *ambiguous)
+{
+  uet_worker_channel_t *selected;
+  u32 client_namespace, client_index;
+
+  *ambiguous = 0;
+  if (ready_count <= 1)
+    return single_channel;
+
+  *ambiguous = 1;
+  if (!uet_rx_packet_namespace (uw, buffer, is_ip4, is_udp, &client_namespace) ||
+      client_namespace > UET_VPP_SVM_CLIENT_NAMESPACE_MAX)
+    return 0;
+  client_index = uet_main.client_by_namespace[client_namespace];
+  if (client_index == UET_INVALID_CLIENT_INDEX || client_index >= vec_len (uw->channels))
+    return 0;
+  selected = uw->channels + client_index;
+  if (!selected->active || !(clib_atomic_load_acq_n (&selected->svm_header->client_flags) &
+			     UET_VPP_SVM_CLIENT_F_DMA_READY))
+    return 0;
+  *ambiguous = 0;
+  return selected;
+}
+
+static_always_inline int
+uet_rx_publish (vlib_main_t *vm, vlib_node_runtime_t *node, uet_main_t *um, uet_worker_t *uw,
+		uet_worker_channel_t *channel, u32 buffer_index, vlib_buffer_t *buffer,
+		u32 *producer, u32 consumer, u8 is_ip4, u8 is_udp, uet_trace_state_t *trace_state)
+{
+  uet_vpp_svm_spsc_ring_t *ring = channel->rx_ring;
+  uet_vpp_svm_rx_desc_t descriptor;
+  u32 token;
+  u64 rx_id;
+
+  if (PREDICT_FALSE (*producer - consumer >= ring->size || !channel->rx_free_count))
+    {
+      uw->rx_ring_full++;
+      buffer->error = node->errors[UET_LOCAL_ERROR_RING_FULL];
+      uet_trace_add (vm, node, buffer, trace_state, UET_LOCAL_NEXT_DROP, 0,
+		     uet_rx_ip_packet_length (vm, buffer, is_ip4),
+		     vnet_buffer (buffer)->ip.rx_sw_if_index, 1 /* RX */, is_ip4 ? 4 : 6, is_udp,
+		     UET_TRACE_RX_RING_FULL, 0);
+      return 0;
+    }
+
+  token = channel->rx_free_slots[channel->rx_free_count - 1];
+  if (PREDICT_FALSE (!uet_rx_descriptor_build (vm, um, buffer, token, is_ip4, is_udp, &descriptor)))
+    {
+      uw->rx_bad_chain++;
+      buffer->error = node->errors[UET_LOCAL_ERROR_BAD_CHAIN];
+      uet_trace_add (vm, node, buffer, trace_state, UET_LOCAL_NEXT_DROP, 0,
+		     uet_rx_ip_packet_length (vm, buffer, is_ip4),
+		     vnet_buffer (buffer)->ip.rx_sw_if_index, 1 /* RX */, is_ip4 ? 4 : 6, is_udp,
+		     UET_TRACE_RX_BAD_CHAIN, 0);
+      return 0;
+    }
+
+  rx_id = channel->next_rx_id++;
+  if (PREDICT_FALSE (!rx_id))
+    rx_id = channel->next_rx_id++;
+  descriptor.rx_id = rx_id;
+  clib_memcpy_fast (channel->rx_descs + uet_spsc_index (ring, *producer), &descriptor,
+		    sizeof (descriptor));
+  channel->rx_free_count--;
+  channel->rx_ids[token] = rx_id;
+  channel->rx_buffer_indices[token] = buffer_index;
+  channel->rx_outstanding++;
+  uw->rx_outstanding++;
+  uw->rx_delivered++;
+  uet_trace_add (vm, node, buffer, trace_state, UET_LOCAL_NEXT_DROP, rx_id,
+		 descriptor.packet_length, descriptor.rx_sw_if_index, 1 /* RX */, is_ip4 ? 4 : 6,
+		 is_udp, UET_TRACE_RX_DELIVERED, descriptor.segment_count);
+  (*producer)++;
+  return 1;
+}
+
+static_always_inline uword
+uet_local_deliver (vlib_main_t *vm, vlib_node_runtime_t *node, u32 *from, u32 n_vectors, u8 is_ip4,
+		   u8 is_udp)
+{
+  uet_main_t *um = &uet_main;
+  uet_worker_t *uw = 0;
+  uet_worker_channel_t *single_channel = 0;
+  u32 drop_buffers[VLIB_FRAME_SIZE];
+  u32 n_drop = 0;
+  u32 ready_count = 0;
+  u64 bytes = 0;
+  uet_trace_state_t trace_state = { 0 };
+
+  if (PREDICT_TRUE (um->enabled && vm->thread_index > 0 &&
+		    vm->thread_index < vec_len (um->workers)))
+    {
+      uw = vec_elt_at_index (um->workers, vm->thread_index);
+      single_channel = uet_rx_channels_prepare (vm, uw, &ready_count);
+      for (u32 i = 0; i < n_vectors; i++)
+	bytes += uet_rx_ip_packet_length (vm, vlib_get_buffer (vm, from[i]), is_ip4);
+
+      if (is_udp && is_ip4)
+	{
+	  uw->rx_udp4_packets += n_vectors;
+	  uw->rx_udp4_bytes += bytes;
+	}
+      else if (is_udp)
+	{
+	  uw->rx_udp6_packets += n_vectors;
+	  uw->rx_udp6_bytes += bytes;
+	}
+      else if (is_ip4)
+	{
+	  uw->rx_ip4_packets += n_vectors;
+	  uw->rx_ip4_bytes += bytes;
+	}
+      else
+	{
+	  uw->rx_ip6_packets += n_vectors;
+	  uw->rx_ip6_bytes += bytes;
+	}
+
+      if (PREDICT_TRUE (ready_count == 1))
+	{
+	  uet_vpp_svm_spsc_ring_t *ring = single_channel->rx_ring;
+	  u32 producer = clib_atomic_load_relax_n (&ring->producer);
+	  u32 consumer = clib_atomic_load_acq_n (&ring->consumer);
+
+	  for (u32 i = 0; i < n_vectors; i++)
+	    {
+	      u32 buffer_index = from[i];
+	      vlib_buffer_t *buffer = vlib_get_buffer (vm, buffer_index);
+
+	      if (!uet_rx_publish (vm, node, um, uw, single_channel, buffer_index, buffer,
+				   &producer, consumer, is_ip4, is_udp, &trace_state))
+		drop_buffers[n_drop++] = buffer_index;
+	    }
+	  clib_atomic_store_rel_n (&ring->producer, producer);
+	}
+      else
+	for (u32 i = 0; i < n_vectors; i++)
+	  {
+	    u32 buffer_index = from[i];
+	    vlib_buffer_t *buffer = vlib_get_buffer (vm, buffer_index);
+	    uet_worker_channel_t *channel;
+	    u8 ambiguous;
+
+	    channel = uet_rx_channel_select (uw, buffer, is_ip4, is_udp, ready_count,
+					     single_channel, &ambiguous);
+	    if (PREDICT_FALSE (!channel))
+	      {
+		if (ambiguous)
+		  uw->rx_ambiguous++;
+		buffer->error = node->errors[ambiguous ? UET_LOCAL_ERROR_AMBIGUOUS_CLIENT :
+							 UET_LOCAL_ERROR_NO_CLIENT];
+		uet_trace_add (
+		  vm, node, buffer, &trace_state, UET_LOCAL_NEXT_DROP, 0,
+		  uet_rx_ip_packet_length (vm, buffer, is_ip4),
+		  vnet_buffer (buffer)->ip.rx_sw_if_index, 1 /* RX */, is_ip4 ? 4 : 6, is_udp,
+		  ambiguous ? UET_TRACE_RX_AMBIGUOUS_CLIENT : UET_TRACE_RX_NO_CLIENT, 0);
+		drop_buffers[n_drop++] = buffer_index;
+		continue;
+	      }
+
+	    {
+	      uet_vpp_svm_spsc_ring_t *ring = channel->rx_ring;
+	      u32 producer = clib_atomic_load_relax_n (&ring->producer);
+	      u32 consumer = clib_atomic_load_acq_n (&ring->consumer);
+
+	      if (!uet_rx_publish (vm, node, um, uw, channel, buffer_index, buffer, &producer,
+				   consumer, is_ip4, is_udp, &trace_state))
+		drop_buffers[n_drop++] = buffer_index;
+	      clib_atomic_store_rel_n (&ring->producer, producer);
+	    }
+	  }
+    }
+  else
+    {
+      for (u32 i = 0; i < n_vectors; i++)
+	{
+	  vlib_buffer_t *buffer = vlib_get_buffer (vm, from[i]);
+
+	  buffer->error = node->errors[UET_LOCAL_ERROR_NO_CLIENT];
+	  uet_trace_add (vm, node, buffer, &trace_state, UET_LOCAL_NEXT_DROP, 0,
+			 uet_rx_ip_packet_length (vm, buffer, is_ip4),
+			 vnet_buffer (buffer)->ip.rx_sw_if_index, 1 /* RX */, is_ip4 ? 4 : 6,
+			 is_udp, UET_TRACE_RX_NO_CLIENT, 0);
+	  drop_buffers[n_drop++] = from[i];
+	}
+    }
+
+  if (n_drop)
+    vlib_buffer_enqueue_to_single_next (vm, node, drop_buffers, UET_LOCAL_NEXT_DROP, n_drop);
+  return n_vectors;
+}
+
+static_always_inline u16
+uet_rx_target_thread (vlib_main_t *vm, vlib_buffer_t *buffer, u8 is_ip4)
+{
+  u8 *start = buffer->data + vnet_buffer (buffer)->l3_hdr_offset;
+  u8 *end = vlib_buffer_get_current (buffer) + buffer->current_length;
+  u8 *entropy;
+  u32 hash;
+  u16 value;
+
+  if (PREDICT_FALSE (start < buffer->data - VLIB_BUFFER_PRE_DATA_SIZE || start >= end))
+    return vm->thread_index;
+
+  if (is_ip4)
+    {
+      ip4_header_t *ip4 = (ip4_header_t *) start;
+      u32 header_length;
+
+      if (PREDICT_FALSE ((uword) (end - start) < sizeof (*ip4)))
+	return vm->thread_index;
+      header_length = ip4_header_bytes (ip4);
+      if (PREDICT_FALSE (header_length < sizeof (*ip4) ||
+			 (uword) (end - start) < header_length + sizeof (value)))
+	return vm->thread_index;
+      entropy = start + header_length;
+    }
+  else
+    {
+      if (PREDICT_FALSE ((uword) (end - start) < sizeof (ip6_header_t) + sizeof (value)))
+	return vm->thread_index;
+      entropy = start + sizeof (ip6_header_t);
+    }
+
+  clib_memcpy_fast (&value, entropy, sizeof (value));
+  hash = clib_net_to_host_u16 (value);
+  hash ^= hash >> 7;
+  hash *= 0x9e3779b1U;
+  hash ^= hash >> 16;
+  return vlib_get_worker_thread_index (hash % vlib_num_workers ());
+}
+
+static_always_inline uet_rx_path_t
+uet_rx_path (u8 is_ip4, u8 is_udp)
+{
+  if (is_udp)
+    return is_ip4 ? UET_RX_PATH_IP4_UDP : UET_RX_PATH_IP6_UDP;
+  return is_ip4 ? UET_RX_PATH_IP4_NATIVE : UET_RX_PATH_IP6_NATIVE;
+}
+
+static_always_inline uword
+uet_local_input (vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame, u8 is_ip4,
+		 u8 is_udp)
+{
+  uet_main_t *um = &uet_main;
+  u32 *from = vlib_frame_vector_args (frame);
+  u32 local_buffers[VLIB_FRAME_SIZE], remote_buffers[VLIB_FRAME_SIZE];
+  u16 remote_threads[VLIB_FRAME_SIZE];
+  u32 n_local = 0, n_remote = 0;
+
+  if (PREDICT_TRUE (!um->rx_entropy_handoff || vlib_num_workers () == 1))
+    return uet_local_deliver (vm, node, from, frame->n_vectors, is_ip4, is_udp);
+
+  for (u32 i = 0; i < frame->n_vectors; i++)
+    {
+      u16 target = uet_rx_target_thread (vm, vlib_get_buffer (vm, from[i]), is_ip4);
+
+      if (target == vm->thread_index)
+	local_buffers[n_local++] = from[i];
+      else
+	{
+	  remote_buffers[n_remote] = from[i];
+	  remote_threads[n_remote++] = target;
+	}
+    }
+
+  if (n_remote)
+    {
+      u32 n_enqueued = vlib_buffer_enqueue_to_thread (
+	vm, node, um->rx_handoff_queue_indices[uet_rx_path (is_ip4, is_udp)], remote_buffers,
+	remote_threads, n_remote);
+
+      if (PREDICT_FALSE (n_enqueued != n_remote))
+	vlib_node_increment_counter (vm, node->node_index, UET_LOCAL_ERROR_HANDOFF_QUEUE_FULL,
+				     n_remote - n_enqueued);
+    }
+  if (n_local)
+    uet_local_deliver (vm, node, local_buffers, n_local, is_ip4, is_udp);
+  return frame->n_vectors;
+}
+
+VLIB_NODE_FN (uet4_ip_input_node)
+(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame)
+{
+  return uet_local_input (vm, node, frame, 1 /* is_ip4 */, 0 /* is_udp */);
+}
+
+VLIB_NODE_FN (uet6_ip_input_node)
+(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame)
+{
+  return uet_local_input (vm, node, frame, 0 /* is_ip4 */, 0 /* is_udp */);
+}
+
+VLIB_NODE_FN (uet4_udp_input_node)
+(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame)
+{
+  return uet_local_input (vm, node, frame, 1 /* is_ip4 */, 1 /* is_udp */);
+}
+
+VLIB_NODE_FN (uet6_udp_input_node)
+(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame)
+{
+  return uet_local_input (vm, node, frame, 0 /* is_ip4 */, 1 /* is_udp */);
+}
+
+VLIB_NODE_FN (uet4_ip_handoff_node)
+(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame)
+{
+  return uet_local_deliver (vm, node, vlib_frame_vector_args (frame), frame->n_vectors,
+			    1 /* is_ip4 */, 0 /* is_udp */);
+}
+
+VLIB_NODE_FN (uet6_ip_handoff_node)
+(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame)
+{
+  return uet_local_deliver (vm, node, vlib_frame_vector_args (frame), frame->n_vectors,
+			    0 /* is_ip4 */, 0 /* is_udp */);
+}
+
+VLIB_NODE_FN (uet4_udp_handoff_node)
+(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame)
+{
+  return uet_local_deliver (vm, node, vlib_frame_vector_args (frame), frame->n_vectors,
+			    1 /* is_ip4 */, 1 /* is_udp */);
+}
+
+VLIB_NODE_FN (uet6_udp_handoff_node)
+(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame)
+{
+  return uet_local_deliver (vm, node, vlib_frame_vector_args (frame), frame->n_vectors,
+			    0 /* is_ip4 */, 1 /* is_udp */);
+}
+
+#ifndef CLIB_MARCH_VARIANT
+static char *uet_tx_error_strings[] = {
+#define _(name, string) string,
+  foreach_uet_tx_error
+#undef _
+};
+
+static char *uet_local_error_strings[] = {
+#define _(name, string) string,
+  foreach_uet_local_error
+#undef _
+};
+
+static u8 *
+format_uet_trace (u8 *s, va_list *args)
+{
+  CLIB_UNUSED (vlib_main_t * vm) = va_arg (*args, vlib_main_t *);
+  CLIB_UNUSED (vlib_node_t * node) = va_arg (*args, vlib_node_t *);
+  uet_trace_t *trace = va_arg (*args, uet_trace_t *);
+  const char *disposition = "unknown";
+
+  switch (trace->disposition)
+    {
+    case UET_TRACE_TX_ROUTED:
+      disposition = "routed";
+      break;
+    case UET_TRACE_RX_DELIVERED:
+      disposition = "delivered";
+      break;
+    case UET_TRACE_RX_NO_CLIENT:
+      disposition = "drop-no-client";
+      break;
+    case UET_TRACE_RX_AMBIGUOUS_CLIENT:
+      disposition = "drop-ambiguous-client";
+      break;
+    case UET_TRACE_RX_RING_FULL:
+      disposition = "drop-ring-full";
+      break;
+    case UET_TRACE_RX_BAD_CHAIN:
+      disposition = "drop-bad-chain";
+      break;
+    }
+
+  s = format (s, "UET %s: worker %u ip%u/%s length %u ", trace->direction ? "RX" : "TX",
+	      trace->thread_index, trace->ip_version, trace->is_udp ? "udp" : "native",
+	      trace->packet_length);
+  if (trace->direction)
+    s = format (s, "sw_if_index %u ", trace->sw_if_index_or_table_id);
+  else
+    s = format (s, "fib-table %u ", trace->sw_if_index_or_table_id);
+  return format (s, "id %llu segments %u next %u disposition %s", trace->id, trace->segment_count,
+		 trace->next_index, disposition);
+}
+
+VLIB_REGISTER_NODE(uet_input_node) = {
+    .name = "uet-input",
+    .type = VLIB_NODE_TYPE_INPUT,
+    .state = VLIB_NODE_STATE_DISABLED,
+    .format_trace = format_uet_trace,
+    .flags = VLIB_NODE_FLAG_TRACE_SUPPORTED,
+    .n_errors = ARRAY_LEN(uet_tx_error_strings),
+    .error_strings = uet_tx_error_strings,
+    .n_next_nodes = UET_TX_N_NEXT,
+    .next_nodes =
+        {
+            [UET_TX_NEXT_IP4_LOOKUP] = "ip4-lookup",
+            [UET_TX_NEXT_IP6_LOOKUP] = "ip6-lookup",
+        },
+};
+
+#define UET_LOCAL_NODE_REGISTER(registration, node_name)                                           \
+  VLIB_REGISTER_NODE (registration) = {                                                            \
+    .name = node_name,                                                                             \
+    .vector_size = sizeof (u32),                                                                   \
+    .type = VLIB_NODE_TYPE_INTERNAL,                                                               \
+    .format_trace = format_uet_trace,                                                              \
+    .flags = VLIB_NODE_FLAG_TRACE_SUPPORTED,                                                       \
+    .n_errors = ARRAY_LEN (uet_local_error_strings),                                               \
+    .error_strings = uet_local_error_strings,                                                      \
+    .n_next_nodes = UET_LOCAL_N_NEXT,                                                              \
+    .next_nodes = { [UET_LOCAL_NEXT_DROP] = "error-drop" },                                        \
+  }
+
+UET_LOCAL_NODE_REGISTER (uet4_ip_input_node, "uet4-ip-input");
+UET_LOCAL_NODE_REGISTER (uet6_ip_input_node, "uet6-ip-input");
+UET_LOCAL_NODE_REGISTER (uet4_udp_input_node, "uet4-udp-input");
+UET_LOCAL_NODE_REGISTER (uet6_udp_input_node, "uet6-udp-input");
+UET_LOCAL_NODE_REGISTER (uet4_ip_handoff_node, "uet4-ip-handoff");
+UET_LOCAL_NODE_REGISTER (uet6_ip_handoff_node, "uet6-ip-handoff");
+UET_LOCAL_NODE_REGISTER (uet4_udp_handoff_node, "uet4-udp-handoff");
+UET_LOCAL_NODE_REGISTER (uet6_udp_handoff_node, "uet6-udp-handoff");
+
+#undef UET_LOCAL_NODE_REGISTER
+#endif

--- a/vpp-plugin/uet/svm_abi.h
+++ b/vpp-plugin/uet/svm_abi.h
@@ -1,0 +1,283 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef included_uet_vpp_svm_abi_h
+#define included_uet_vpp_svm_abi_h
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define UET_VPP_SVM_ABI_MAGIC 0x53544555U
+#define UET_VPP_SVM_ABI_MAJOR 4
+#define UET_VPP_SVM_ABI_MINOR 2
+
+#define UET_VPP_SVM_DEFAULT_QUEUE_DEPTH 256
+#define UET_VPP_SVM_MIN_QUEUE_DEPTH	8
+#define UET_VPP_SVM_MAX_QUEUE_DEPTH	4096
+#define UET_VPP_SVM_SHARED_ALIGNMENT	64
+#define UET_VPP_SVM_INVALID_DMA_SLOT	UINT32_MAX
+
+#define UET_VPP_SVM_CAP_DMA_SLOTS	     (1U << 0)
+#define UET_VPP_SVM_CAP_TX_SPSC		     (1U << 1)
+#define UET_VPP_SVM_CAP_RX_SPSC		     (1U << 2)
+#define UET_VPP_SVM_CAP_TX_GRAPH_COMPLETION  (1U << 3)
+#define UET_VPP_SVM_CAP_EXCLUSIVE_OWNER	     (1U << 4)
+#define UET_VPP_SVM_CAP_MULTI_WORKER_SEGMENT (1U << 5)
+#define UET_VPP_SVM_CAP_ENDPOINT_DEMUX	     (1U << 6)
+#define UET_VPP_SVM_CAP_SNG_DEMUX	     (1U << 7)
+#define UET_VPP_SVM_REQUIRED_CAPABILITIES                                                          \
+  (UET_VPP_SVM_CAP_DMA_SLOTS | UET_VPP_SVM_CAP_TX_SPSC | UET_VPP_SVM_CAP_RX_SPSC |                 \
+   UET_VPP_SVM_CAP_TX_GRAPH_COMPLETION | UET_VPP_SVM_CAP_EXCLUSIVE_OWNER |                         \
+   UET_VPP_SVM_CAP_MULTI_WORKER_SEGMENT | UET_VPP_SVM_CAP_ENDPOINT_DEMUX |                         \
+   UET_VPP_SVM_CAP_SNG_DEMUX)
+
+#define UET_VPP_SVM_CLIENT_NAMESPACE_BITS 10
+#define UET_VPP_SVM_CLIENT_NAMESPACE_MAX  ((1U << UET_VPP_SVM_CLIENT_NAMESPACE_BITS) - 1)
+#define UET_VPP_SVM_PDC_LOCAL_BITS	  6
+#define UET_VPP_SVM_PDC_LOCAL_MASK	  ((1U << UET_VPP_SVM_PDC_LOCAL_BITS) - 1)
+#define UET_VPP_SVM_RUDI_LOCAL_BITS	  (32 - UET_VPP_SVM_CLIENT_NAMESPACE_BITS)
+#define UET_VPP_SVM_RUDI_LOCAL_MASK	  ((1U << UET_VPP_SVM_RUDI_LOCAL_BITS) - 1)
+
+#define UET_VPP_SVM_CLIENT_F_DMA_READY	   (1U << 0)
+#define UET_VPP_SVM_CLIENT_F_PDS_SNG	   (1U << 1)
+#define UET_VPP_SVM_SERVER_F_DMA_READY_ACK (1U << 0)
+
+#define UET_VPP_SVM_RX_F_IP4	(1U << 0)
+#define UET_VPP_SVM_RX_F_IP6	(1U << 1)
+#define UET_VPP_SVM_RX_F_UDP	(1U << 2)
+#define UET_VPP_SVM_MAX_RX_SEGS 8
+
+typedef enum
+{
+  UET_VPP_SVM_STATUS_OK = 0,
+  UET_VPP_SVM_STATUS_INVALID_PACKET = -1,
+  UET_VPP_SVM_STATUS_TX_NOT_CONFIGURED = -2,
+  UET_VPP_SVM_STATUS_SLOT_BUSY = -3,
+  UET_VPP_SVM_STATUS_NO_BUFFERS = -4,
+} uet_vpp_svm_status_t;
+
+/*
+ * All pointers crossing the process boundary are offsets from the SSVM
+ * segment base (the ssvm_shared_header_t address).  New fields may only be
+ * appended and require a minor ABI bump.
+ */
+typedef struct
+{
+  uint32_t magic;
+  uint16_t abi_major;
+  uint16_t abi_minor;
+  uint16_t header_size;
+  uint16_t reserved0;
+  uint32_t capabilities;
+  uint32_t queue_depth;
+  uint32_t worker_count;
+  uint64_t segment_size;
+  uint64_t generation;
+  uint64_t worker_channel_table_offset;
+  uint64_t dma_map_size;
+  uint32_t dma_buffer_data_size;
+  uint16_t dma_buffer_pool_index;
+  uint16_t worker_channel_desc_size;
+  uint32_t tx_desc_size;
+  uint32_t tx_completion_size;
+  uint32_t rx_desc_size;
+  uint32_t rx_release_size;
+  uint32_t client_flags;
+  uint32_t server_flags;
+  /* PID holding the lifetime lock on this application's SHM object. */
+  uint32_t owner_pid;
+  uint32_t server_dma_ready_count;
+  uint32_t client_namespace;
+  uint32_t control_ring_size;
+  uint64_t control_request_ring_offset;
+  uint64_t control_completion_ring_offset;
+  uint64_t reserved2;
+} uet_vpp_svm_shared_header_t;
+
+/*
+ * One descriptor per VPP worker.  Every offset addresses an independent
+ * SPSC object in the common application segment.  The descriptor is padded
+ * to two cache lines so future ABI-minor fields can be appended in place.
+ */
+typedef struct
+{
+  uint32_t worker_index;
+  uint32_t thread_index;
+  uint64_t dma_slot_table_offset;
+  uint32_t dma_slot_count;
+  uint32_t reserved0;
+  uint64_t tx_ring_offset;
+  uint64_t tx_completion_ring_offset;
+  uint32_t tx_ring_size;
+  uint32_t reserved1;
+  uint64_t rx_ring_offset;
+  uint64_t rx_release_ring_offset;
+  uint32_t rx_ring_size;
+  uint32_t reserved2;
+  uint64_t reserved3[7];
+} uet_vpp_svm_worker_channel_t;
+
+typedef struct
+{
+  uint64_t data_offset;
+  uint32_t capacity;
+  uint32_t reserved;
+} uet_vpp_svm_dma_slot_t;
+
+/*
+ * Dedicated SPSC rings keep producer and consumer indices on independent
+ * cache lines. Indices are monotonically increasing u32 counters; the ring
+ * size is at most 4096, so unsigned producer-consumer arithmetic is safe.
+ * Descriptor storage immediately follows this header.
+ */
+typedef struct
+{
+  uint32_t size;
+  uint32_t mask;
+  uint8_t reserved0[56];
+  uint32_t producer;
+  uint8_t producer_pad[60];
+  uint32_t consumer;
+  uint8_t consumer_pad[60];
+} uet_vpp_svm_spsc_ring_t;
+
+typedef struct
+{
+  uint32_t dma_slot;
+  uint32_t packet_length;
+  uint64_t request_id;
+  uint64_t user_context;
+  uint64_t reserved;
+} uet_vpp_svm_tx_desc_t;
+
+/*
+ * A successful completion transfers ownership of the submitted buffer to
+ * the VPP graph and makes dma_slot reusable through a replacement buffer.
+ * It does not report physical transmission by a device.
+ */
+typedef struct
+{
+  uint32_t dma_slot;
+  int32_t status;
+  uint32_t completed_length;
+  uint32_t reserved;
+  uint64_t request_id;
+  uint64_t user_context;
+} uet_vpp_svm_tx_completion_t;
+
+typedef struct
+{
+  uint64_t data_offset;
+  uint32_t length;
+  uint32_t reserved;
+} uet_vpp_svm_rx_segment_t;
+
+typedef struct
+{
+  uint64_t rx_id;
+  uint32_t release_token;
+  uint32_t packet_length;
+  uint32_t rx_sw_if_index;
+  uint16_t flags;
+  uint16_t segment_count;
+  uint64_t reserved;
+  uet_vpp_svm_rx_segment_t segments[UET_VPP_SVM_MAX_RX_SEGS];
+} uet_vpp_svm_rx_desc_t;
+
+typedef struct
+{
+  uint64_t rx_id;
+  uint32_t release_token;
+  uint32_t reserved;
+} uet_vpp_svm_rx_release_t;
+
+typedef enum
+{
+  UET_VPP_SVM_CONTROL_ENDPOINT_ADD = 1,
+  UET_VPP_SVM_CONTROL_ENDPOINT_DEL = 2,
+} uet_vpp_svm_control_op_t;
+
+typedef struct
+{
+  uint8_t ip_version;
+  uint8_t absolute;
+  uint16_t pid_on_fep;
+  uint16_t resource_index;
+  uint16_t reserved0;
+  uint32_t job_id;
+  uint8_t ip_address[16];
+  uint32_t reserved1;
+} uet_vpp_svm_endpoint_key_t;
+
+typedef struct
+{
+  uint64_t request_id;
+  uint16_t operation;
+  uint16_t reserved0;
+  uint32_t reserved1;
+  uet_vpp_svm_endpoint_key_t endpoint;
+  uint64_t reserved2[2];
+} uet_vpp_svm_control_request_t;
+
+typedef struct
+{
+  uint64_t request_id;
+  int32_t status;
+  uint32_t reserved0;
+  uint64_t reserved1[2];
+} uet_vpp_svm_control_completion_t;
+
+#ifdef __cplusplus
+#define UET_VPP_SVM_STATIC_ASSERT static_assert
+#else
+#define UET_VPP_SVM_STATIC_ASSERT _Static_assert
+#endif
+
+UET_VPP_SVM_STATIC_ASSERT (sizeof (uet_vpp_svm_shared_header_t) == 128,
+			   "unexpected UET SVM shared header size");
+UET_VPP_SVM_STATIC_ASSERT (offsetof (uet_vpp_svm_shared_header_t, segment_size) == 24,
+			   "unexpected UET SVM segment size field offset");
+UET_VPP_SVM_STATIC_ASSERT (offsetof (uet_vpp_svm_shared_header_t, worker_channel_table_offset) ==
+			     40,
+			   "unexpected UET SVM worker channel table offset field");
+UET_VPP_SVM_STATIC_ASSERT (offsetof (uet_vpp_svm_shared_header_t, client_flags) == 80,
+			   "unexpected UET SVM client flags offset");
+UET_VPP_SVM_STATIC_ASSERT (offsetof (uet_vpp_svm_shared_header_t, owner_pid) == 88,
+			   "unexpected UET SVM owner PID offset");
+UET_VPP_SVM_STATIC_ASSERT (offsetof (uet_vpp_svm_shared_header_t, server_dma_ready_count) == 92,
+			   "unexpected UET SVM DMA ready count offset");
+UET_VPP_SVM_STATIC_ASSERT (sizeof (uet_vpp_svm_worker_channel_t) == 128,
+			   "unexpected UET SVM worker channel descriptor size");
+UET_VPP_SVM_STATIC_ASSERT (offsetof (uet_vpp_svm_worker_channel_t, tx_ring_offset) == 24,
+			   "unexpected UET SVM worker TX ring offset field");
+UET_VPP_SVM_STATIC_ASSERT (offsetof (uet_vpp_svm_worker_channel_t, rx_ring_offset) == 48,
+			   "unexpected UET SVM worker RX ring offset field");
+UET_VPP_SVM_STATIC_ASSERT (sizeof (uet_vpp_svm_dma_slot_t) == 16,
+			   "unexpected UET SVM DMA slot size");
+UET_VPP_SVM_STATIC_ASSERT (sizeof (uet_vpp_svm_spsc_ring_t) == 192,
+			   "unexpected UET SVM SPSC ring header size");
+UET_VPP_SVM_STATIC_ASSERT (offsetof (uet_vpp_svm_spsc_ring_t, producer) == 64,
+			   "unexpected UET SVM SPSC producer offset");
+UET_VPP_SVM_STATIC_ASSERT (offsetof (uet_vpp_svm_spsc_ring_t, consumer) == 128,
+			   "unexpected UET SVM SPSC consumer offset");
+UET_VPP_SVM_STATIC_ASSERT (sizeof (uet_vpp_svm_tx_desc_t) == 32,
+			   "unexpected UET SVM TX descriptor size");
+UET_VPP_SVM_STATIC_ASSERT (sizeof (uet_vpp_svm_tx_completion_t) == 32,
+			   "unexpected UET SVM TX completion size");
+UET_VPP_SVM_STATIC_ASSERT (sizeof (uet_vpp_svm_rx_segment_t) == 16,
+			   "unexpected UET SVM RX segment size");
+UET_VPP_SVM_STATIC_ASSERT (sizeof (uet_vpp_svm_rx_desc_t) == 160,
+			   "unexpected UET SVM RX descriptor size");
+UET_VPP_SVM_STATIC_ASSERT (sizeof (uet_vpp_svm_rx_release_t) == 16,
+			   "unexpected UET SVM RX release size");
+UET_VPP_SVM_STATIC_ASSERT (offsetof (uet_vpp_svm_shared_header_t, client_namespace) == 96,
+			   "unexpected UET SVM client namespace offset");
+UET_VPP_SVM_STATIC_ASSERT (sizeof (uet_vpp_svm_endpoint_key_t) == 32,
+			   "unexpected UET SVM endpoint key size");
+UET_VPP_SVM_STATIC_ASSERT (sizeof (uet_vpp_svm_control_request_t) == 64,
+			   "unexpected UET SVM control request size");
+UET_VPP_SVM_STATIC_ASSERT (sizeof (uet_vpp_svm_control_completion_t) == 32,
+			   "unexpected UET SVM control completion size");
+
+#undef UET_VPP_SVM_STATIC_ASSERT
+
+#endif /* included_uet_vpp_svm_abi_h */

--- a/vpp-plugin/uet/uet.api
+++ b/vpp-plugin/uet/uet.api
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+option version = "0.10.0";
+
+/** Enable or disable the per-worker UET dataplane. */
+autoreply define uet_enable_disable
+{
+  u32 client_index;
+  u32 context;
+  bool enable;
+};
+
+/** Create one external dataplane channel for each VPP worker. */
+autoreply define uet_svm_create
+{
+  u32 client_index;
+  u32 context;
+  string segment_name[64];
+  u32 queue_depth;
+};
+
+/** Delete one application's per-worker SPSC channels. */
+autoreply define uet_svm_delete
+{
+  u32 client_index;
+  u32 context;
+  string segment_name[64];
+};
+
+/** Clear the counters maintained by the UET plugin workers. */
+autoreply define uet_clear_counters
+{
+  u32 client_index;
+  u32 context;
+};
+
+/** Select the IPv4 and IPv6 FIB tables used by routed transmit. */
+autoreply define uet_tx_fib_set
+{
+  u32 client_index;
+  u32 context;
+  u32 ip4_table_id;
+  u32 ip6_table_id;
+};
+
+service {
+  rpc uet_worker_dump returns stream uet_worker_details;
+};
+
+/** Request one operational snapshot for every VPP worker. */
+define uet_worker_dump
+{
+  u32 client_index;
+  u32 context;
+};
+
+/** Operational state and counters for one UET worker channel. */
+define uet_worker_details
+{
+  u32 context;
+  u32 worker_index;
+  u32 thread_index;
+  bool enabled;
+  bool svm_attached;
+  bool provider_ready;
+  bool tx_configured;
+  u32 tx_ip4_table_id;
+  u32 tx_ip6_table_id;
+  u64 generation;
+  u32 queue_depth;
+  u32 tx_pending;
+  u32 tx_completions_pending;
+  u32 rx_pending;
+  u32 rx_release_pending;
+  u64 tx_requests;
+  u64 invalid_requests;
+  u64 tx_completion_ring_full;
+  u64 tx_packets;
+  u64 tx_bytes;
+  u64 tx_completions;
+  u64 rx_delivered;
+  u64 rx_ring_full;
+  u64 rx_bad_chain;
+  u64 rx_releases;
+  u64 rx_invalid_releases;
+  u64 rx_outstanding;
+};

--- a/vpp-plugin/uet/uet.c
+++ b/vpp-plugin/uet/uet.c
@@ -1,0 +1,1500 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <uet/uet.h>
+
+#include <vlib/handoff.h>
+#include <vlib/physmem_funcs.h>
+#include <vlibapi/api.h>
+#include <vlibmemory/api.h>
+#include <vnet/api_errno.h>
+#include <vnet/fib/fib_table.h>
+#include <vnet/plugin/plugin.h>
+#include <vnet/udp/udp_local.h>
+#include <vpp/app/version.h>
+
+#include <uet/uet.api_enum.h>
+#include <uet/uet.api_types.h>
+
+#define REPLY_MSG_ID_BASE um->msg_id_base
+#include <vlibapi/api_helper_macros.h>
+
+#define UET_SVM_SEGMENT_BASE_SIZE (4ULL << 20)
+
+uet_main_t uet_main;
+
+VLIB_REGISTER_LOG_CLASS (uet_log) = {
+  .class_name = "uet",
+};
+
+VLIB_PLUGIN_REGISTER () = {
+  .version = UET_PLUGIN_BUILD_VERSION,
+  .version_required = VPP_BUILD_VER,
+  .description = "UET host dataplane (per-worker lockless channels)",
+  .default_disabled = 1,
+};
+
+static void
+uet_worker_counters_clear (uet_worker_t *uw)
+{
+  uw->poll_calls = 0;
+  uw->tx_requests = 0;
+  uw->invalid_requests = 0;
+  uw->tx_completion_ring_full = 0;
+  uw->tx_packets = 0;
+  uw->tx_bytes = 0;
+  uw->tx_completions = 0;
+  uw->rx_ip4_packets = 0;
+  uw->rx_ip4_bytes = 0;
+  uw->rx_ip6_packets = 0;
+  uw->rx_ip6_bytes = 0;
+  uw->rx_udp4_packets = 0;
+  uw->rx_udp4_bytes = 0;
+  uw->rx_udp6_packets = 0;
+  uw->rx_udp6_bytes = 0;
+  uw->rx_delivered = 0;
+  uw->rx_ambiguous = 0;
+  uw->rx_ring_full = 0;
+  uw->rx_bad_chain = 0;
+  uw->rx_releases = 0;
+  uw->rx_invalid_releases = 0;
+}
+
+void
+uet_counters_clear (void)
+{
+  uet_main_t *um = &uet_main;
+
+  um->dma_authorized_clients = 0;
+  um->dma_rejected_clients = 0;
+  vlib_worker_thread_barrier_sync (um->vlib_main);
+  um->endpoint_collisions = 0;
+  for (u32 worker = 0; worker < vlib_num_workers (); worker++)
+    {
+      u32 thread_index = vlib_get_worker_thread_index (worker);
+      uet_worker_t *uw = vec_elt_at_index (um->workers, thread_index);
+
+      uet_worker_counters_clear (uw);
+    }
+  vlib_worker_thread_barrier_release (um->vlib_main);
+}
+
+static int
+uet_svm_name_is_valid (const char *name)
+{
+  const u8 *p = (const u8 *) name;
+  uword len = clib_strnlen (name, 65);
+
+  if (len == 0 || len > 63)
+    return 0;
+
+  while (*p)
+    {
+      if (!((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') || (*p >= '0' && *p <= '9') ||
+	    *p == '-' || *p == '_' || *p == '.'))
+	return 0;
+      p++;
+    }
+  return 1;
+}
+
+static u32
+uet_client_count (const uet_main_t *um)
+{
+  return pool_elts (um->clients);
+}
+
+static uet_client_t *
+uet_client_find (uet_main_t *um, const char *segment_name)
+{
+  uet_client_t *client;
+
+  pool_foreach (client, um->clients)
+    if (!strcmp ((char *) client->segment.name, segment_name))
+      return client;
+  return 0;
+}
+
+static void
+uet_worker_channel_dma_buffers_free (uet_main_t *um, uet_worker_channel_t *channel)
+{
+  if (vec_len (channel->dma_buffer_indices))
+    vlib_buffer_free (um->vlib_main, channel->dma_buffer_indices,
+		      vec_len (channel->dma_buffer_indices));
+  vec_free (channel->dma_buffer_indices);
+}
+
+static void
+uet_dma_mapping_reset_if_unused (uet_main_t *um)
+{
+  if (uet_client_count (um))
+    return;
+  um->dma_buffer_pool_index = (u8) ~0;
+  um->dma_buffer_data_size = 0;
+  um->dma_map_size = 0;
+  um->dma_map_base = 0;
+}
+
+static void
+uet_worker_channel_runtime_vectors_free (uet_worker_channel_t *channel)
+{
+  vec_free (channel->rx_buffer_indices);
+  vec_free (channel->rx_ids);
+  vec_free (channel->rx_free_slots);
+}
+
+static void
+uet_worker_channel_outstanding_rx_free (uet_worker_t *uw, uet_worker_channel_t *channel)
+{
+  vlib_main_t *worker_vm = vlib_get_main_by_index (uw->thread_index);
+  u32 reclaimed = 0;
+
+  for (u32 token = 0; token < channel->dma_slot_count; token++)
+    if (channel->rx_ids[token] && channel->rx_buffer_indices[token] != ~0)
+      {
+	vlib_buffer_free_one (worker_vm, channel->rx_buffer_indices[token]);
+	reclaimed++;
+      }
+  if (reclaimed)
+    uet_log_warn ("reclaimed %u RX buffers from dead external owner %u on worker %u", reclaimed,
+		  channel->client_index, uw->thread_index);
+  ASSERT (uw->rx_outstanding >= channel->rx_outstanding);
+  uw->rx_outstanding -= channel->rx_outstanding;
+}
+
+static void
+uet_worker_channel_clear (uet_worker_channel_t *channel)
+{
+  clib_memset (channel, 0, sizeof (*channel));
+}
+
+static int
+uet_svm_segment_lock (uet_client_t *client, int *lock_fd)
+{
+  /* Keep new clients out from the readiness transition through shm_unlink. */
+  *lock_fd = shm_open ((char *) client->segment.name, O_RDWR, 0);
+  if (*lock_fd < 0 || flock (*lock_fd, LOCK_EX | LOCK_NB) < 0)
+    {
+      if (*lock_fd >= 0)
+	close (*lock_fd);
+      *lock_fd = -1;
+      return VNET_API_ERROR_INSTANCE_IN_USE;
+    }
+  return 0;
+}
+
+int
+uet_svm_create (const char *segment_name, u32 queue_depth)
+{
+  uet_main_t *um = &uet_main;
+  uet_client_t *client = 0;
+  uword tx_ring_size, tx_completion_ring_size, rx_ring_size, rx_release_ring_size;
+  uword control_request_ring_size, control_completion_ring_size;
+  vlib_buffer_pool_t *buffer_pool;
+  vlib_physmem_map_t *physmem_map;
+  u32 worker_count = vlib_num_workers ();
+  u32 client_index = ~0;
+  u8 selected_pool_index = (u8) ~0;
+  u8 worker_vectors_prepared = 0;
+  clib_error_t *error;
+  void *oldheap;
+  int rv;
+
+  if (!worker_count)
+    return VNET_API_ERROR_INVALID_WORKER;
+  if (!uet_svm_name_is_valid (segment_name) || queue_depth < UET_VPP_SVM_MIN_QUEUE_DEPTH ||
+      queue_depth > UET_VPP_SVM_MAX_QUEUE_DEPTH)
+    return VNET_API_ERROR_INVALID_VALUE;
+  if (uet_client_find (um, segment_name))
+    return VNET_API_ERROR_ENTRY_ALREADY_EXISTS;
+  if (um->next_client_namespace == UET_VPP_SVM_CLIENT_NAMESPACE_MAX)
+    return VNET_API_ERROR_LIMIT_EXCEEDED;
+
+  tx_ring_size =
+    sizeof (uet_vpp_svm_spsc_ring_t) + (uword) queue_depth * sizeof (uet_vpp_svm_tx_desc_t);
+  tx_completion_ring_size =
+    sizeof (uet_vpp_svm_spsc_ring_t) + (uword) queue_depth * sizeof (uet_vpp_svm_tx_completion_t);
+  rx_ring_size =
+    sizeof (uet_vpp_svm_spsc_ring_t) + (uword) queue_depth * sizeof (uet_vpp_svm_rx_desc_t);
+  rx_release_ring_size =
+    sizeof (uet_vpp_svm_spsc_ring_t) + (uword) queue_depth * sizeof (uet_vpp_svm_rx_release_t);
+  control_request_ring_size =
+    sizeof (uet_vpp_svm_spsc_ring_t) + (uword) queue_depth * sizeof (uet_vpp_svm_control_request_t);
+  control_completion_ring_size = sizeof (uet_vpp_svm_spsc_ring_t) +
+				 (uword) queue_depth * sizeof (uet_vpp_svm_control_completion_t);
+
+  if ((error = uet_dma_listener_init ()))
+    {
+      clib_error_free (error);
+      return VNET_API_ERROR_SYSCALL_ERROR_1;
+    }
+
+  for (u32 worker = 0; worker < worker_count; worker++)
+    {
+      u32 thread_index = vlib_get_worker_thread_index (worker);
+      vlib_main_t *worker_vm = vlib_get_main_by_index (thread_index);
+      u8 pool_index = vlib_buffer_pool_get_default_for_numa (um->vlib_main, worker_vm->numa_node);
+
+      if (worker == 0)
+	selected_pool_index = pool_index;
+      else if (pool_index != selected_pool_index)
+	return VNET_API_ERROR_INVALID_WORKER;
+    }
+  if (uet_client_count (um) && selected_pool_index != um->dma_buffer_pool_index)
+    return VNET_API_ERROR_INVALID_WORKER;
+  um->dma_buffer_pool_index = selected_pool_index;
+  buffer_pool = vlib_get_buffer_pool (um->vlib_main, um->dma_buffer_pool_index);
+  physmem_map = vlib_physmem_get_map (um->vlib_main, buffer_pool->physmem_map_index);
+  um->dma_buffer_data_size = buffer_pool->data_size;
+  um->dma_map_size = (u64) physmem_map->n_pages << physmem_map->log2_page_size;
+  um->dma_map_base = physmem_map->base;
+
+  um->svm_generation++;
+  pool_get_zero (um->clients, client);
+  client_index = client - um->clients;
+  client->index = client_index;
+  client->channel_count = worker_count;
+  client->queue_depth = queue_depth;
+  client->generation = um->svm_generation;
+  client->client_namespace = ++um->next_client_namespace;
+
+  client->segment.name = format (0, "%s%c", segment_name, 0);
+  client->segment.ssvm_size = (uword) UET_SVM_SEGMENT_BASE_SIZE * worker_count;
+  client->segment.my_pid = getpid ();
+  if ((rv = ssvm_server_init (&client->segment, SSVM_SEGMENT_SHM)))
+    {
+      vec_free (client->segment.name);
+      clib_memset (&client->segment, 0, sizeof (client->segment));
+      goto create_failed;
+    }
+
+  oldheap = ssvm_push_heap (client->segment.sh);
+  client->header = clib_mem_alloc_aligned (sizeof (*client->header), UET_VPP_SVM_SHARED_ALIGNMENT);
+  if (client->header)
+    client->shared_channels = clib_mem_alloc_aligned (
+      worker_count * sizeof (*client->shared_channels), UET_VPP_SVM_SHARED_ALIGNMENT);
+  if (client->shared_channels)
+    client->control_request_ring =
+      clib_mem_alloc_aligned (control_request_ring_size, UET_VPP_SVM_SHARED_ALIGNMENT);
+  if (client->control_request_ring)
+    client->control_completion_ring =
+      clib_mem_alloc_aligned (control_completion_ring_size, UET_VPP_SVM_SHARED_ALIGNMENT);
+  ssvm_pop_heap (oldheap);
+  if (!client->header || !client->shared_channels || !client->control_request_ring ||
+      !client->control_completion_ring)
+    goto create_failed;
+
+  clib_memset (client->header, 0, sizeof (*client->header));
+  clib_memset (client->shared_channels, 0, worker_count * sizeof (*client->shared_channels));
+  clib_memset (client->control_request_ring, 0, control_request_ring_size);
+  clib_memset (client->control_completion_ring, 0, control_completion_ring_size);
+  client->control_requests = (uet_vpp_svm_control_request_t *) (client->control_request_ring + 1);
+  client->control_completions =
+    (uet_vpp_svm_control_completion_t *) (client->control_completion_ring + 1);
+  client->header->magic = UET_VPP_SVM_ABI_MAGIC;
+  client->header->abi_major = UET_VPP_SVM_ABI_MAJOR;
+  client->header->abi_minor = UET_VPP_SVM_ABI_MINOR;
+  client->header->header_size = sizeof (*client->header);
+  client->header->capabilities = UET_VPP_SVM_REQUIRED_CAPABILITIES;
+  client->header->queue_depth = queue_depth;
+  client->header->worker_count = worker_count;
+  client->header->segment_size = client->segment.ssvm_size;
+  client->header->generation = client->generation;
+  client->header->worker_channel_table_offset =
+    (u8 *) client->shared_channels - (u8 *) client->segment.sh;
+  client->header->dma_map_size = um->dma_map_size;
+  client->header->dma_buffer_data_size = um->dma_buffer_data_size;
+  client->header->dma_buffer_pool_index = um->dma_buffer_pool_index;
+  client->header->worker_channel_desc_size = sizeof (*client->shared_channels);
+  client->header->tx_desc_size = sizeof (uet_vpp_svm_tx_desc_t);
+  client->header->tx_completion_size = sizeof (uet_vpp_svm_tx_completion_t);
+  client->header->rx_desc_size = sizeof (uet_vpp_svm_rx_desc_t);
+  client->header->rx_release_size = sizeof (uet_vpp_svm_rx_release_t);
+  client->header->client_namespace = client->client_namespace;
+  client->header->control_ring_size = queue_depth;
+  client->header->control_request_ring_offset =
+    (u8 *) client->control_request_ring - (u8 *) client->segment.sh;
+  client->header->control_completion_ring_offset =
+    (u8 *) client->control_completion_ring - (u8 *) client->segment.sh;
+  client->control_request_ring->size = queue_depth;
+  client->control_request_ring->mask = (queue_depth & (queue_depth - 1)) ? 0 : queue_depth - 1;
+  client->control_completion_ring->size = queue_depth;
+  client->control_completion_ring->mask = client->control_request_ring->mask;
+
+  /* Reserve the stable pool index in every worker vector while workers are
+   * stopped. The entries remain inactive until all shared state is ready.
+   */
+  vlib_worker_thread_barrier_sync (um->vlib_main);
+  for (u32 worker = 0; worker < worker_count; worker++)
+    {
+      u32 thread_index = vlib_get_worker_thread_index (worker);
+      uet_worker_t *uw = vec_elt_at_index (um->workers, thread_index);
+
+      vec_validate (uw->channels, client_index);
+      uet_worker_channel_clear (uw->channels + client_index);
+      uw->channels[client_index].client_index = client_index;
+    }
+  vlib_worker_thread_barrier_release (um->vlib_main);
+  worker_vectors_prepared = 1;
+
+  for (u32 worker = 0; worker < worker_count; worker++)
+    {
+      uet_vpp_svm_dma_slot_t *shared_dma_slots = 0;
+      uet_vpp_svm_spsc_ring_t *shared_tx_ring = 0;
+      uet_vpp_svm_spsc_ring_t *shared_tx_completion_ring = 0;
+      uet_vpp_svm_spsc_ring_t *shared_rx_ring = 0;
+      uet_vpp_svm_spsc_ring_t *shared_rx_release_ring = 0;
+      u32 thread_index = vlib_get_worker_thread_index (worker);
+      uet_worker_t *uw = vec_elt_at_index (um->workers, thread_index);
+      uet_worker_channel_t *channel = uw->channels + client_index;
+      uet_vpp_svm_worker_channel_t *shared_channel = client->shared_channels + worker;
+      u32 n_dma_alloc;
+
+      vec_validate (channel->dma_buffer_indices, queue_depth - 1);
+      n_dma_alloc = vlib_buffer_alloc_from_pool (um->vlib_main, channel->dma_buffer_indices,
+						 queue_depth, um->dma_buffer_pool_index);
+      if (n_dma_alloc != queue_depth)
+	{
+	  if (n_dma_alloc)
+	    vlib_buffer_free (um->vlib_main, channel->dma_buffer_indices, n_dma_alloc);
+	  vec_free (channel->dma_buffer_indices);
+	  goto create_failed;
+	}
+      oldheap = ssvm_push_heap (client->segment.sh);
+      shared_dma_slots = clib_mem_alloc_aligned (queue_depth * sizeof (*shared_dma_slots),
+						 UET_VPP_SVM_SHARED_ALIGNMENT);
+      if (shared_dma_slots)
+	shared_tx_ring = clib_mem_alloc_aligned (tx_ring_size, UET_VPP_SVM_SHARED_ALIGNMENT);
+      if (shared_tx_ring)
+	shared_tx_completion_ring =
+	  clib_mem_alloc_aligned (tx_completion_ring_size, UET_VPP_SVM_SHARED_ALIGNMENT);
+      if (shared_tx_completion_ring)
+	shared_rx_ring = clib_mem_alloc_aligned (rx_ring_size, UET_VPP_SVM_SHARED_ALIGNMENT);
+      if (shared_rx_ring)
+	shared_rx_release_ring =
+	  clib_mem_alloc_aligned (rx_release_ring_size, UET_VPP_SVM_SHARED_ALIGNMENT);
+      ssvm_pop_heap (oldheap);
+
+      if (!shared_dma_slots || !shared_tx_ring || !shared_tx_completion_ring || !shared_rx_ring ||
+	  !shared_rx_release_ring)
+	goto create_failed;
+
+      clib_memset (shared_dma_slots, 0, queue_depth * sizeof (*shared_dma_slots));
+      clib_memset (shared_tx_ring, 0, tx_ring_size);
+      clib_memset (shared_tx_completion_ring, 0, tx_completion_ring_size);
+      clib_memset (shared_rx_ring, 0, rx_ring_size);
+      clib_memset (shared_rx_release_ring, 0, rx_release_ring_size);
+      shared_channel->worker_index = worker;
+      shared_channel->thread_index = thread_index;
+      shared_channel->dma_slot_table_offset = (u8 *) shared_dma_slots - (u8 *) client->segment.sh;
+      shared_channel->dma_slot_count = queue_depth;
+      shared_channel->tx_ring_offset = (u8 *) shared_tx_ring - (u8 *) client->segment.sh;
+      shared_channel->tx_completion_ring_offset =
+	(u8 *) shared_tx_completion_ring - (u8 *) client->segment.sh;
+      shared_channel->tx_ring_size = queue_depth;
+      shared_channel->rx_ring_offset = (u8 *) shared_rx_ring - (u8 *) client->segment.sh;
+      shared_channel->rx_release_ring_offset =
+	(u8 *) shared_rx_release_ring - (u8 *) client->segment.sh;
+      shared_channel->rx_ring_size = queue_depth;
+
+      shared_tx_ring->size = queue_depth;
+      shared_tx_ring->mask = (queue_depth & (queue_depth - 1)) ? 0 : queue_depth - 1;
+      shared_tx_completion_ring->size = queue_depth;
+      shared_tx_completion_ring->mask = shared_tx_ring->mask;
+      shared_rx_ring->size = queue_depth;
+      shared_rx_ring->mask = shared_tx_ring->mask;
+      shared_rx_release_ring->size = queue_depth;
+      shared_rx_release_ring->mask = shared_tx_ring->mask;
+
+      for (u32 i = 0; i < queue_depth; i++)
+	{
+	  vlib_buffer_t *buffer = vlib_get_buffer (um->vlib_main, channel->dma_buffer_indices[i]);
+
+	  shared_dma_slots[i].data_offset = (u8 *) buffer->data - (u8 *) physmem_map->base;
+	  shared_dma_slots[i].capacity = buffer_pool->data_size;
+	}
+
+      channel->dma_slots = shared_dma_slots;
+      channel->svm_header = client->header;
+      channel->tx_ring = shared_tx_ring;
+      channel->tx_descs = (uet_vpp_svm_tx_desc_t *) (shared_tx_ring + 1);
+      channel->tx_completion_ring = shared_tx_completion_ring;
+      channel->tx_completion_entries =
+	(uet_vpp_svm_tx_completion_t *) (shared_tx_completion_ring + 1);
+      channel->rx_ring = shared_rx_ring;
+      channel->rx_descs = (uet_vpp_svm_rx_desc_t *) (shared_rx_ring + 1);
+      channel->rx_release_ring = shared_rx_release_ring;
+      channel->rx_release_entries = (uet_vpp_svm_rx_release_t *) (shared_rx_release_ring + 1);
+      channel->control_request_ring = client->control_request_ring;
+      channel->control_requests = client->control_requests;
+      channel->control_completion_ring = client->control_completion_ring;
+      channel->control_completions = client->control_completions;
+      channel->client_namespace = client->client_namespace;
+
+      vec_validate (channel->rx_buffer_indices, queue_depth - 1);
+      vec_validate (channel->rx_ids, queue_depth - 1);
+      vec_validate (channel->rx_free_slots, queue_depth - 1);
+      clib_memset (channel->rx_ids, 0, queue_depth * sizeof (*channel->rx_ids));
+      for (u32 i = 0; i < queue_depth; i++)
+	{
+	  channel->rx_buffer_indices[i] = ~0;
+	  channel->rx_free_slots[i] = i;
+	}
+      channel->dma_slot_count = queue_depth;
+      channel->rx_free_count = queue_depth;
+      channel->next_rx_id = (client->generation << 32) | ((u64) worker << 24) | 1;
+    }
+
+  client->segment.sh->opaque[0] = (void *) ((u8 *) client->header - (u8 *) client->segment.sh);
+
+  vlib_worker_thread_barrier_sync (um->vlib_main);
+  for (u32 worker = 0; worker < worker_count; worker++)
+    {
+      u32 thread_index = vlib_get_worker_thread_index (worker);
+      uet_worker_t *uw = vec_elt_at_index (um->workers, thread_index);
+      uet_worker_channel_t *channel = uw->channels + client_index;
+
+      uw->thread_index = thread_index;
+      channel->active = 1;
+    }
+  um->client_by_namespace[client->client_namespace] = client_index;
+  vlib_worker_thread_barrier_release (um->vlib_main);
+
+  clib_atomic_store_rel_n (&client->segment.sh->ready, 1);
+  uet_log_notice ("created application segment %s generation %llu with %u worker channels, "
+		  "queue depth %u and DMA map size %llu",
+		  segment_name, client->generation, worker_count, queue_depth, um->dma_map_size);
+  return 0;
+
+create_failed:
+  if (worker_vectors_prepared)
+    {
+      vlib_worker_thread_barrier_sync (um->vlib_main);
+      for (u32 worker = 0; worker < worker_count; worker++)
+	{
+	  u32 thread_index = vlib_get_worker_thread_index (worker);
+	  uet_worker_t *uw = vec_elt_at_index (um->workers, thread_index);
+
+	  uw->channels[client_index].active = 0;
+	}
+      vlib_worker_thread_barrier_release (um->vlib_main);
+      for (u32 worker = 0; worker < worker_count; worker++)
+	{
+	  u32 thread_index = vlib_get_worker_thread_index (worker);
+	  uet_worker_t *uw = vec_elt_at_index (um->workers, thread_index);
+	  uet_worker_channel_t *channel = uw->channels + client_index;
+
+	  uet_worker_channel_runtime_vectors_free (channel);
+	  uet_worker_channel_dma_buffers_free (um, channel);
+	  uet_worker_channel_clear (channel);
+	}
+    }
+  if (client->segment.sh)
+    ssvm_delete (&client->segment);
+  else
+    vec_free (client->segment.name);
+  ASSERT (client->client_namespace == um->next_client_namespace);
+  um->next_client_namespace--;
+  pool_put (um->clients, client);
+  uet_dma_mapping_reset_if_unused (um);
+  uet_log_warn ("failed to create worker channels for generation %llu", um->svm_generation);
+  return VNET_API_ERROR_SVM_SEGMENT_CREATE_FAIL;
+}
+
+int
+uet_tx_set_fib_tables (u32 ip4_table_id, u32 ip6_table_id)
+{
+  uet_main_t *um = &uet_main;
+  u32 old_ip4_fib_index = um->tx_ip4_fib_index;
+  u32 old_ip6_fib_index = um->tx_ip6_fib_index;
+  u32 ip4_fib_index, ip6_fib_index;
+
+  if (!vlib_num_workers ())
+    return VNET_API_ERROR_INVALID_WORKER;
+
+  ip4_fib_index = fib_table_find (FIB_PROTOCOL_IP4, ip4_table_id);
+  ip6_fib_index = fib_table_find (FIB_PROTOCOL_IP6, ip6_table_id);
+  if (ip4_fib_index == ~0 || ip6_fib_index == ~0)
+    return VNET_API_ERROR_NO_SUCH_FIB;
+
+  if (!um->tx_configured || ip4_fib_index != old_ip4_fib_index)
+    fib_table_lock (ip4_fib_index, FIB_PROTOCOL_IP4, um->fib_source);
+  if (!um->tx_configured || ip6_fib_index != old_ip6_fib_index)
+    fib_table_lock (ip6_fib_index, FIB_PROTOCOL_IP6, um->fib_source);
+
+  vlib_worker_thread_barrier_sync (um->vlib_main);
+  for (u32 worker = 0; worker < vlib_num_workers (); worker++)
+    {
+      u32 thread_index = vlib_get_worker_thread_index (worker);
+      uet_worker_t *uw = vec_elt_at_index (um->workers, thread_index);
+
+      uw->tx_ip4_fib_index = ip4_fib_index;
+      uw->tx_ip6_fib_index = ip6_fib_index;
+      uw->tx_ip4_table_id = ip4_table_id;
+      uw->tx_ip6_table_id = ip6_table_id;
+      uw->tx_configured = 1;
+    }
+  um->tx_ip4_fib_index = ip4_fib_index;
+  um->tx_ip6_fib_index = ip6_fib_index;
+  um->tx_ip4_table_id = ip4_table_id;
+  um->tx_ip6_table_id = ip6_table_id;
+  um->tx_configured = 1;
+  vlib_worker_thread_barrier_release (um->vlib_main);
+
+  if (old_ip4_fib_index != ~0 && old_ip4_fib_index != ip4_fib_index)
+    fib_table_unlock (old_ip4_fib_index, FIB_PROTOCOL_IP4, um->fib_source);
+  if (old_ip6_fib_index != ~0 && old_ip6_fib_index != ip6_fib_index)
+    fib_table_unlock (old_ip6_fib_index, FIB_PROTOCOL_IP6, um->fib_source);
+
+  uet_log_notice ("TX routing uses IPv4 table %u and IPv6 table %u", ip4_table_id, ip6_table_id);
+  return 0;
+}
+
+static int
+uet_protocols_register (vlib_main_t *vm)
+{
+  uet_main_t *um = &uet_main;
+
+  if (um->protocols_registered)
+    return 0;
+  if (ip4_main.lookup_main.local_next_by_ip_protocol[UET_IP_PROTOCOL] != IP_LOCAL_NEXT_PUNT ||
+      ip6_main.lookup_main.local_next_by_ip_protocol[UET_IP_PROTOCOL] != IP_LOCAL_NEXT_PUNT ||
+      udp_is_valid_dst_port (UET_UDP_PORT, 1 /* is_ip4 */) ||
+      udp_is_valid_dst_port (UET_UDP_PORT, 0 /* is_ip4 */))
+    return VNET_API_ERROR_ADDRESS_IN_USE;
+
+  ip4_register_protocol (UET_IP_PROTOCOL, uet4_ip_input_node.index);
+  ip6_register_protocol (UET_IP_PROTOCOL, uet6_ip_input_node.index);
+  udp_register_dst_port (vm, UET_UDP_PORT, uet4_udp_input_node.index, 1 /* is_ip4 */);
+  udp_register_dst_port (vm, UET_UDP_PORT, uet6_udp_input_node.index, 0 /* is_ip4 */);
+  um->protocols_registered = 1;
+  uet_log_debug ("registered IP protocol %u and UDP destination port %u", UET_IP_PROTOCOL,
+		 UET_UDP_PORT);
+  return 0;
+}
+
+static void
+uet_protocols_unregister (vlib_main_t *vm)
+{
+  uet_main_t *um = &uet_main;
+
+  if (!um->protocols_registered)
+    return;
+
+  udp_unregister_dst_port (vm, UET_UDP_PORT, 1 /* is_ip4 */);
+  udp_unregister_dst_port (vm, UET_UDP_PORT, 0 /* is_ip4 */);
+  ip4_unregister_protocol (UET_IP_PROTOCOL);
+  ip6_unregister_protocol (UET_IP_PROTOCOL);
+  um->protocols_registered = 0;
+  uet_log_debug ("unregistered IP protocol %u and UDP destination port %u", UET_IP_PROTOCOL,
+		 UET_UDP_PORT);
+}
+
+typedef struct
+{
+  uet_main_t *um;
+  u32 client_namespace;
+} uet_endpoint_cleanup_ctx_t;
+
+static int
+uet_endpoint_client_cleanup_cb (clib_bihash_kv_40_8_t *kv, void *arg)
+{
+  uet_endpoint_cleanup_ctx_t *ctx = arg;
+
+  if (kv->value == ctx->client_namespace)
+    {
+      clib_bihash_kv_40_8_t copy = *kv;
+
+      if (!clib_bihash_add_del_40_8 (&ctx->um->endpoint_hash, &copy, 0))
+	{
+	  ASSERT (ctx->um->endpoint_registrations > 0);
+	  ctx->um->endpoint_registrations--;
+	}
+    }
+  return BIHASH_WALK_CONTINUE;
+}
+
+static void
+uet_endpoint_client_cleanup (uet_client_t *client)
+{
+  uet_endpoint_cleanup_ctx_t ctx = {
+    .um = &uet_main,
+    .client_namespace = client->client_namespace,
+  };
+
+  clib_bihash_foreach_key_value_pair_40_8 (&ctx.um->endpoint_hash, uet_endpoint_client_cleanup_cb,
+					   &ctx);
+}
+
+int
+uet_svm_delete (const char *segment_name)
+{
+  uet_main_t *um = &uet_main;
+  uet_client_t *client = 0;
+  u32 client_index;
+  int lock_fd = -1;
+  int rv;
+
+  if (segment_name && segment_name[0])
+    client = uet_client_find (um, segment_name);
+  else if (uet_client_count (um) == 1)
+    pool_foreach (client, um->clients)
+      break;
+  else if (uet_client_count (um) > 1)
+    return VNET_API_ERROR_INVALID_VALUE;
+  if (!client)
+    return VNET_API_ERROR_NO_SUCH_ENTRY;
+  client_index = client->index;
+
+  rv = uet_svm_segment_lock (client, &lock_fd);
+  if (rv)
+    return rv;
+
+  clib_atomic_store_rel_n (&client->segment.sh->ready, 0);
+
+  vlib_worker_thread_barrier_sync (um->vlib_main);
+  for (u32 worker = 0; worker < client->channel_count; worker++)
+    {
+      u32 thread_index = vlib_get_worker_thread_index (worker);
+      uet_worker_t *uw = vec_elt_at_index (um->workers, thread_index);
+      uet_worker_channel_t *channel = uw->channels + client_index;
+
+      channel->active = 0;
+      uet_worker_channel_outstanding_rx_free (uw, channel);
+      uet_worker_channel_runtime_vectors_free (channel);
+    }
+  uet_endpoint_client_cleanup (client);
+  um->client_by_namespace[client->client_namespace] = UET_INVALID_CLIENT_INDEX;
+  vlib_worker_thread_barrier_release (um->vlib_main);
+
+  for (u32 worker = 0; worker < client->channel_count; worker++)
+    {
+      u32 thread_index = vlib_get_worker_thread_index (worker);
+      uet_worker_t *uw = vec_elt_at_index (um->workers, thread_index);
+      uet_worker_channel_t *channel = uw->channels + client_index;
+
+      uet_worker_channel_dma_buffers_free (um, channel);
+      uet_worker_channel_clear (channel);
+    }
+  uet_log_notice ("deleting application segment %s generation %llu", client->segment.name,
+		  client->generation);
+  ssvm_delete (&client->segment);
+  close (lock_fd);
+  pool_put (um->clients, client);
+  uet_dma_mapping_reset_if_unused (um);
+  return 0;
+}
+
+int
+uet_enable_disable (u8 enable)
+{
+  uet_main_t *um = &uet_main;
+  vlib_main_t *vm = um->vlib_main;
+
+  if (!vlib_num_workers ())
+    return VNET_API_ERROR_INVALID_WORKER;
+
+  if (um->enabled == !!enable)
+    return 0;
+
+  if (enable)
+    {
+      int rv;
+
+      if (!um->tx_configured)
+	{
+	  rv = uet_tx_set_fib_tables (0, 0);
+	  if (rv)
+	    return rv;
+	}
+
+      rv = uet_protocols_register (vm);
+
+      if (rv)
+	return rv;
+    }
+
+  vlib_worker_thread_barrier_sync (vm);
+
+  if (enable)
+    {
+      for (u32 worker = 0; worker < vlib_num_workers (); worker++)
+	{
+	  u32 thread_index = vlib_get_worker_thread_index (worker);
+	  uet_worker_t *uw = vec_elt_at_index (um->workers, thread_index);
+	  vlib_main_t *worker_vm = vlib_get_main_by_index (thread_index);
+
+	  uw->thread_index = thread_index;
+	  uet_worker_counters_clear (uw);
+	  vlib_node_set_state (worker_vm, uet_input_node.index, VLIB_NODE_STATE_POLLING);
+	}
+      um->enabled = 1;
+    }
+  else
+    {
+      for (u32 worker = 0; worker < vlib_num_workers (); worker++)
+	{
+	  u32 thread_index = vlib_get_worker_thread_index (worker);
+	  uet_worker_t *uw = vec_elt_at_index (um->workers, thread_index);
+
+	  if (uw->rx_outstanding)
+	    {
+	      vlib_worker_thread_barrier_release (vm);
+	      return VNET_API_ERROR_INSTANCE_IN_USE;
+	    }
+	  for (u32 client_index = 0; client_index < vec_len (uw->channels); client_index++)
+	    {
+	      uet_worker_channel_t *channel = uw->channels + client_index;
+
+	      if (channel->active && (clib_atomic_load_acq_n (&channel->svm_header->client_flags) &
+				      UET_VPP_SVM_CLIENT_F_DMA_READY))
+		{
+		  vlib_worker_thread_barrier_release (vm);
+		  return VNET_API_ERROR_INSTANCE_IN_USE;
+		}
+	    }
+	}
+      for (u32 worker = 0; worker < vlib_num_workers (); worker++)
+	{
+	  u32 thread_index = vlib_get_worker_thread_index (worker);
+	  vlib_main_t *worker_vm = vlib_get_main_by_index (thread_index);
+
+	  vlib_node_set_state (worker_vm, uet_input_node.index, VLIB_NODE_STATE_DISABLED);
+	}
+      um->enabled = 0;
+      uet_protocols_unregister (vm);
+    }
+
+  vlib_worker_thread_barrier_release (vm);
+  uet_log_notice ("dataplane %s with %u workers", enable ? "enabled" : "disabled",
+		  vlib_num_workers ());
+  return 0;
+}
+
+static clib_error_t *
+uet_enable_disable_command_fn (vlib_main_t *vm, unformat_input_t *input, vlib_cli_command_t *cmd)
+{
+  u8 enable = 1;
+  int rv;
+
+  if (unformat_check_input (input) != UNFORMAT_END_OF_INPUT)
+    {
+      if (unformat (input, "disable"))
+	enable = 0;
+      else if (!unformat (input, "enable"))
+	return clib_error_return (0, "unknown input `%U'", format_unformat_error, input);
+
+      if (unformat_check_input (input) != UNFORMAT_END_OF_INPUT)
+	return clib_error_return (0, "unexpected input `%U'", format_unformat_error, input);
+    }
+
+  rv = uet_enable_disable (enable);
+  if (rv == VNET_API_ERROR_INVALID_WORKER)
+    return clib_error_return (0, "UET requires at least one VPP worker");
+  if (rv)
+    return clib_error_return (0, "UET enable/disable failed: %U", format_vnet_api_errno, rv);
+
+  return 0;
+}
+
+VLIB_CLI_COMMAND (uet_enable_disable_command, static) = {
+  .path = "uet",
+  .short_help = "uet [enable|disable]",
+  .function = uet_enable_disable_command_fn,
+};
+
+static clib_error_t *
+uet_svm_create_command_fn (vlib_main_t *vm, unformat_input_t *input, vlib_cli_command_t *cmd)
+{
+  u32 queue_depth = UET_VPP_SVM_DEFAULT_QUEUE_DEPTH;
+  u8 *segment_name = 0;
+  int rv;
+
+  while (unformat_check_input (input) != UNFORMAT_END_OF_INPUT)
+    {
+      if (unformat (input, "name %s", &segment_name))
+	;
+      else if (unformat (input, "queue-size %u", &queue_depth))
+	;
+      else
+	{
+	  vec_free (segment_name);
+	  return clib_error_return (0, "unknown input `%U'", format_unformat_error, input);
+	}
+    }
+
+  if (!segment_name)
+    return clib_error_return (0, "segment name is required");
+
+  vec_add1 (segment_name, 0);
+  rv = uet_svm_create ((char *) segment_name, queue_depth);
+  vec_free (segment_name);
+  if (rv)
+    return clib_error_return (0, "UET SVM create failed: %U", format_vnet_api_errno, rv);
+  return 0;
+}
+
+VLIB_CLI_COMMAND (uet_svm_create_command, static) = {
+  .path = "uet svm create",
+  .short_help = "uet svm create name <segment-name> [queue-size <8-4096>]",
+  .function = uet_svm_create_command_fn,
+};
+
+static clib_error_t *
+uet_svm_delete_command_fn (vlib_main_t *vm, unformat_input_t *input, vlib_cli_command_t *cmd)
+{
+  u8 *segment_name = 0;
+  int rv;
+
+  while (unformat_check_input (input) != UNFORMAT_END_OF_INPUT)
+    if (unformat (input, "name %s", &segment_name))
+      ;
+    else
+      {
+	vec_free (segment_name);
+	return clib_error_return (0, "unexpected input `%U'", format_unformat_error, input);
+      }
+
+  if (segment_name)
+    vec_add1 (segment_name, 0);
+  rv = uet_svm_delete ((char *) segment_name);
+  vec_free (segment_name);
+  if (rv)
+    return clib_error_return (0, "UET SVM delete failed: %U", format_vnet_api_errno, rv);
+  return 0;
+}
+
+VLIB_CLI_COMMAND (uet_svm_delete_command, static) = {
+  .path = "uet svm delete",
+  .short_help = "uet svm delete [name <segment-name>]",
+  .function = uet_svm_delete_command_fn,
+};
+
+static clib_error_t *
+uet_tx_fib_command_fn (vlib_main_t *vm, unformat_input_t *input, vlib_cli_command_t *cmd)
+{
+  u32 ip4_table_id = ~0, ip6_table_id = ~0, table_id = ~0;
+  int rv;
+
+  while (unformat_check_input (input) != UNFORMAT_END_OF_INPUT)
+    {
+      if (unformat (input, "table %u", &table_id))
+	;
+      else if (unformat (input, "ip4-table %u", &ip4_table_id))
+	;
+      else if (unformat (input, "ip6-table %u", &ip6_table_id))
+	;
+      else
+	return clib_error_return (0, "unknown input `%U'", format_unformat_error, input);
+    }
+
+  if (table_id != ~0)
+    {
+      if (ip4_table_id != ~0 || ip6_table_id != ~0)
+	return clib_error_return (0, "use either table or both ip4-table and ip6-table");
+      ip4_table_id = table_id;
+      ip6_table_id = table_id;
+    }
+  if (ip4_table_id == ~0 || ip6_table_id == ~0)
+    return clib_error_return (0, "table or both ip4-table and ip6-table are required");
+
+  rv = uet_tx_set_fib_tables (ip4_table_id, ip6_table_id);
+  if (rv)
+    return clib_error_return (0, "UET TX FIB configuration failed: %U", format_vnet_api_errno, rv);
+  return 0;
+}
+
+VLIB_CLI_COMMAND (uet_tx_fib_command, static) = {
+  .path = "uet tx fib",
+  .short_help = "uet tx fib table <table-id> | ip4-table <table-id> "
+		"ip6-table <table-id>",
+  .function = uet_tx_fib_command_fn,
+};
+
+static clib_error_t *
+uet_rx_placement_command_fn (vlib_main_t *vm, unformat_input_t *input, vlib_cli_command_t *cmd)
+{
+  u8 entropy_handoff;
+
+  if (unformat (input, "current-worker"))
+    entropy_handoff = 0;
+  else if (unformat (input, "entropy-handoff"))
+    entropy_handoff = 1;
+  else
+    return clib_error_return (0, "expected current-worker or entropy-handoff");
+  if (unformat_check_input (input) != UNFORMAT_END_OF_INPUT)
+    return clib_error_return (0, "unexpected input `%U'", format_unformat_error, input);
+
+  vlib_worker_thread_barrier_sync (vm);
+  uet_main.rx_entropy_handoff = entropy_handoff;
+  vlib_worker_thread_barrier_release (vm);
+  uet_log_notice ("RX placement uses %s",
+		  entropy_handoff ? "entropy handoff" : "the current worker");
+  return 0;
+}
+
+VLIB_CLI_COMMAND (uet_rx_placement_command, static) = {
+  .path = "uet rx placement",
+  .short_help = "uet rx placement current-worker|entropy-handoff",
+  .function = uet_rx_placement_command_fn,
+};
+
+typedef struct
+{
+  u32 thread_index;
+  u8 svm_attached;
+  u64 tx_requests;
+  u64 tx_packets;
+  u64 rx_delivered;
+  u64 rx_ring_full;
+} uet_cli_worker_snapshot_t;
+
+static clib_error_t *
+show_uet_command_fn (vlib_main_t *vm, unformat_input_t *input, vlib_cli_command_t *cmd)
+{
+  uet_main_t *um = &uet_main;
+  u64 poll_calls = 0, tx_requests = 0;
+  u64 invalid_requests = 0, tx_completion_ring_full = 0;
+  u64 tx_packets = 0, tx_bytes = 0, tx_completions = 0;
+  u32 tx_pending = 0, tx_completions_pending = 0;
+  u64 rx_ip4_packets = 0, rx_ip4_bytes = 0, rx_ip6_packets = 0, rx_ip6_bytes = 0;
+  u64 rx_udp4_packets = 0, rx_udp4_bytes = 0, rx_udp6_packets = 0, rx_udp6_bytes = 0;
+  u64 rx_delivered = 0, rx_ambiguous = 0, rx_ring_full = 0, rx_bad_chain = 0, rx_releases = 0;
+  u64 rx_invalid_releases = 0, rx_outstanding = 0;
+  u64 endpoint_registrations = 0, endpoint_collisions = 0;
+  u32 tx_ip4_table_id = ~0, tx_ip6_table_id = ~0;
+  u32 rx_pending = 0, rx_release_pending = 0;
+  u32 svm_attached = 0;
+  u8 tx_configured = 0;
+  u8 provider_ready = 0;
+  u32 owner_pid = 0;
+  u32 worker_count = vlib_num_workers ();
+  u32 client_count = uet_client_count (um);
+  uet_vpp_svm_shared_header_t *first_header = 0;
+  uet_client_t *first_client = 0;
+  uet_cli_worker_snapshot_t *worker_snapshots = 0;
+
+  if (unformat_check_input (input) != UNFORMAT_END_OF_INPUT)
+    return clib_error_return (0, "unexpected input `%U'", format_unformat_error, input);
+
+  if (worker_count && um->workers)
+    {
+      vec_validate (worker_snapshots, worker_count - 1);
+      vlib_worker_thread_barrier_sync (vm);
+      for (u32 worker = 0; worker < worker_count; worker++)
+	{
+	  u32 thread_index = vlib_get_worker_thread_index (worker);
+	  uet_worker_t *uw = vec_elt_at_index (um->workers, thread_index);
+	  uet_cli_worker_snapshot_t *snapshot = vec_elt_at_index (worker_snapshots, worker);
+
+	  snapshot->thread_index = thread_index;
+	  snapshot->svm_attached = 0;
+	  snapshot->tx_requests = uw->tx_requests;
+	  snapshot->tx_packets = uw->tx_packets;
+	  snapshot->rx_delivered = uw->rx_delivered;
+	  snapshot->rx_ring_full = uw->rx_ring_full;
+	  poll_calls += uw->poll_calls;
+	  tx_requests += uw->tx_requests;
+	  invalid_requests += uw->invalid_requests;
+	  tx_completion_ring_full += uw->tx_completion_ring_full;
+	  tx_packets += uw->tx_packets;
+	  tx_bytes += uw->tx_bytes;
+	  tx_completions += uw->tx_completions;
+	  rx_ip4_packets += uw->rx_ip4_packets;
+	  rx_ip4_bytes += uw->rx_ip4_bytes;
+	  rx_ip6_packets += uw->rx_ip6_packets;
+	  rx_ip6_bytes += uw->rx_ip6_bytes;
+	  rx_udp4_packets += uw->rx_udp4_packets;
+	  rx_udp4_bytes += uw->rx_udp4_bytes;
+	  rx_udp6_packets += uw->rx_udp6_packets;
+	  rx_udp6_bytes += uw->rx_udp6_bytes;
+	  rx_delivered += uw->rx_delivered;
+	  rx_ambiguous += uw->rx_ambiguous;
+	  rx_ring_full += uw->rx_ring_full;
+	  rx_bad_chain += uw->rx_bad_chain;
+	  rx_releases += uw->rx_releases;
+	  rx_invalid_releases += uw->rx_invalid_releases;
+	  rx_outstanding += uw->rx_outstanding;
+	  if (worker == 0)
+	    {
+	      tx_configured = uw->tx_configured;
+	      tx_ip4_table_id = uw->tx_ip4_table_id;
+	      tx_ip6_table_id = uw->tx_ip6_table_id;
+	    }
+	  else
+	    tx_configured &= uw->tx_configured;
+	  for (u32 client_index = 0; client_index < vec_len (uw->channels); client_index++)
+	    {
+	      uet_worker_channel_t *channel = uw->channels + client_index;
+	      u32 client_flags, server_flags;
+
+	      if (!channel->active)
+		continue;
+	      client_flags = clib_atomic_load_acq_n (&channel->svm_header->client_flags);
+	      server_flags = clib_atomic_load_acq_n (&channel->svm_header->server_flags);
+	      snapshot->svm_attached = 1;
+	      if (!first_header)
+		{
+		  first_header = channel->svm_header;
+		  first_client = pool_elt_at_index (um->clients, client_index);
+		  owner_pid = clib_atomic_load_acq_n (&channel->svm_header->owner_pid);
+		  provider_ready = !!(client_flags & UET_VPP_SVM_CLIENT_F_DMA_READY) &&
+				   !!(server_flags & UET_VPP_SVM_SERVER_F_DMA_READY_ACK);
+		}
+	      svm_attached++;
+	      tx_pending += clib_atomic_load_acq_n (&channel->tx_ring->producer) -
+			    clib_atomic_load_acq_n (&channel->tx_ring->consumer);
+	      tx_completions_pending +=
+		clib_atomic_load_acq_n (&channel->tx_completion_ring->producer) -
+		clib_atomic_load_acq_n (&channel->tx_completion_ring->consumer);
+	      rx_pending += clib_atomic_load_acq_n (&channel->rx_ring->producer) -
+			    clib_atomic_load_acq_n (&channel->rx_ring->consumer);
+	      rx_release_pending += clib_atomic_load_acq_n (&channel->rx_release_ring->producer) -
+				    clib_atomic_load_acq_n (&channel->rx_release_ring->consumer);
+	    }
+	  endpoint_registrations = um->endpoint_registrations;
+	  endpoint_collisions = um->endpoint_collisions;
+	}
+      vlib_worker_thread_barrier_release (vm);
+    }
+
+  vlib_cli_output (vm, "state %s", um->enabled ? "enabled" : "disabled");
+  vlib_cli_output (vm, "main-thread 0");
+  vlib_cli_output (vm, "workers %u", worker_count);
+  vlib_cli_output (vm, "rx-placement %s",
+		   um->rx_entropy_handoff ? "entropy-handoff" : "current-worker");
+  if (worker_count == 1)
+    vlib_cli_output (vm, "owner-worker %U", format_vlib_thread_name_and_index,
+		     vlib_get_worker_thread_index (0));
+  else
+    vlib_cli_output (vm, "owner-workers %u", worker_count);
+  vlib_cli_output (vm, "poll-calls %llu", poll_calls);
+  vlib_cli_output (vm, "tx-requests %llu", tx_requests);
+  vlib_cli_output (vm, "invalid-requests %llu", invalid_requests);
+  vlib_cli_output (vm, "tx-completion-ring-full %llu", tx_completion_ring_full);
+  if (tx_configured)
+    {
+      vlib_cli_output (vm, "tx-ip4-table %u", tx_ip4_table_id);
+      vlib_cli_output (vm, "tx-ip6-table %u", tx_ip6_table_id);
+    }
+  else
+    vlib_cli_output (vm, "tx-fib unconfigured");
+  vlib_cli_output (vm, "tx-packets %llu", tx_packets);
+  vlib_cli_output (vm, "tx-bytes %llu", tx_bytes);
+  vlib_cli_output (vm, "tx-completions %llu", tx_completions);
+  vlib_cli_output (vm, "rx-ip4-packets %llu", rx_ip4_packets);
+  vlib_cli_output (vm, "rx-ip4-bytes %llu", rx_ip4_bytes);
+  vlib_cli_output (vm, "rx-ip6-packets %llu", rx_ip6_packets);
+  vlib_cli_output (vm, "rx-ip6-bytes %llu", rx_ip6_bytes);
+  vlib_cli_output (vm, "rx-udp4-packets %llu", rx_udp4_packets);
+  vlib_cli_output (vm, "rx-udp4-bytes %llu", rx_udp4_bytes);
+  vlib_cli_output (vm, "rx-udp6-packets %llu", rx_udp6_packets);
+  vlib_cli_output (vm, "rx-udp6-bytes %llu", rx_udp6_bytes);
+  vlib_cli_output (vm, "rx-delivered %llu", rx_delivered);
+  vlib_cli_output (vm, "rx-ambiguous %llu", rx_ambiguous);
+  vlib_cli_output (vm, "rx-ring-full %llu", rx_ring_full);
+  vlib_cli_output (vm, "rx-bad-chain %llu", rx_bad_chain);
+  vlib_cli_output (vm, "rx-releases %llu", rx_releases);
+  vlib_cli_output (vm, "rx-invalid-releases %llu", rx_invalid_releases);
+  vlib_cli_output (vm, "rx-outstanding %llu", rx_outstanding);
+  vlib_cli_output (vm, "endpoint-registrations %llu", endpoint_registrations);
+  vlib_cli_output (vm, "endpoint-collisions %llu", endpoint_collisions);
+  vlib_cli_output (vm, "dma-authorized-clients %llu", um->dma_authorized_clients);
+  vlib_cli_output (vm, "dma-rejected-clients %llu", um->dma_rejected_clients);
+  vlib_cli_output (vm, "local-dispatch %s ip-protocol %u udp-port %u",
+		   um->protocols_registered ? "registered" : "unregistered", UET_IP_PROTOCOL,
+		   UET_UDP_PORT);
+  vlib_cli_output (vm, "svm-state %s",
+		   svm_attached == worker_count * client_count && worker_count && client_count ?
+		     "attached" :
+		   svm_attached ? "partial" :
+				  "detached");
+  vlib_cli_output (vm, "svm-segments %u", client_count);
+  if (first_header && first_client && client_count == 1)
+    {
+      vlib_cli_output (vm, "svm-segment %s", first_client->segment.name);
+      vlib_cli_output (vm, "svm-channels %u", first_client->channel_count);
+      vlib_cli_output (vm, "svm-abi %u.%u", first_header->abi_major, first_header->abi_minor);
+      vlib_cli_output (vm, "svm-generation %llu", first_header->generation);
+      vlib_cli_output (vm, "svm-queue-depth %u", first_header->queue_depth);
+      vlib_cli_output (vm, "svm-dma-slot-count %u",
+		       first_header->queue_depth * first_header->worker_count);
+      vlib_cli_output (vm, "svm-dma-buffer-data-size %u", first_header->dma_buffer_data_size);
+      vlib_cli_output (vm, "svm-dma-map-size %llu", first_header->dma_map_size);
+      vlib_cli_output (vm, "svm-dma-socket %s", um->dma_socket_name);
+      vlib_cli_output (vm, "provider-ready %s", provider_ready ? "yes" : "no");
+      vlib_cli_output (vm, "provider-owner-pid %u", owner_pid);
+      vlib_cli_output (vm, "tx-pending %u", tx_pending);
+      vlib_cli_output (vm, "tx-completions-pending %u", tx_completions_pending);
+      vlib_cli_output (vm, "rx-pending %u", rx_pending);
+      vlib_cli_output (vm, "rx-release-pending %u", rx_release_pending);
+    }
+
+  {
+    uet_client_t *client;
+
+    pool_foreach (client, um->clients)
+      {
+	u32 client_flags = clib_atomic_load_acq_n (&client->header->client_flags);
+	u32 server_flags = clib_atomic_load_acq_n (&client->header->server_flags);
+	u32 client_owner = clib_atomic_load_acq_n (&client->header->owner_pid);
+	u8 ready = !!(client_flags & UET_VPP_SVM_CLIENT_F_DMA_READY) &&
+		   !!(server_flags & UET_VPP_SVM_SERVER_F_DMA_READY_ACK);
+
+	vlib_cli_output (vm, "application-%u-segment %s", client->index, client->segment.name);
+	vlib_cli_output (vm, "application-%u-generation %llu", client->index, client->generation);
+	vlib_cli_output (vm, "application-%u-namespace %u", client->index,
+			 client->client_namespace);
+	vlib_cli_output (vm, "application-%u-channels %u", client->index, client->channel_count);
+	vlib_cli_output (vm, "application-%u-queue-depth %u", client->index, client->queue_depth);
+	vlib_cli_output (vm, "application-%u-provider-ready %s", client->index,
+			 ready ? "yes" : "no");
+	vlib_cli_output (vm, "application-%u-pds-mode %s", client->index,
+			 client_flags & UET_VPP_SVM_CLIENT_F_PDS_SNG ? "sng" : "pds");
+	vlib_cli_output (vm, "application-%u-owner-pid %u", client->index, client_owner);
+      }
+  }
+
+  for (u32 worker = 0; worker < vec_len (worker_snapshots); worker++)
+    {
+      uet_cli_worker_snapshot_t *snapshot = vec_elt_at_index (worker_snapshots, worker);
+
+      vlib_cli_output (vm, "worker-%u-thread %U", worker, format_vlib_thread_name_and_index,
+		       snapshot->thread_index);
+      vlib_cli_output (vm, "worker-%u-channel %s", worker,
+		       snapshot->svm_attached ? "attached" : "detached");
+      vlib_cli_output (vm, "worker-%u-tx-requests %llu", worker, snapshot->tx_requests);
+      vlib_cli_output (vm, "worker-%u-tx-packets %llu", worker, snapshot->tx_packets);
+      vlib_cli_output (vm, "worker-%u-rx-delivered %llu", worker, snapshot->rx_delivered);
+      vlib_cli_output (vm, "worker-%u-rx-ring-full %llu", worker, snapshot->rx_ring_full);
+    }
+  vec_free (worker_snapshots);
+
+  return 0;
+}
+
+VLIB_CLI_COMMAND (show_uet_command, static) = {
+  .path = "show uet",
+  .short_help = "show uet",
+  .function = show_uet_command_fn,
+};
+
+static clib_error_t *
+uet_clear_counters_command_fn (vlib_main_t *vm, unformat_input_t *input, vlib_cli_command_t *cmd)
+{
+  if (unformat_check_input (input) != UNFORMAT_END_OF_INPUT)
+    return clib_error_return (0, "unexpected input `%U'", format_unformat_error, input);
+
+  uet_counters_clear ();
+  uet_log_info ("plugin counters cleared");
+  return 0;
+}
+
+VLIB_CLI_COMMAND (uet_clear_counters_command, static) = {
+  .path = "clear uet counters",
+  .short_help = "clear uet counters",
+  .function = uet_clear_counters_command_fn,
+};
+
+static void
+vl_api_uet_enable_disable_t_handler (vl_api_uet_enable_disable_t *mp)
+{
+  vl_api_uet_enable_disable_reply_t *rmp;
+  uet_main_t *um = &uet_main;
+  int rv;
+
+  rv = uet_enable_disable (mp->enable);
+  REPLY_MACRO (VL_API_UET_ENABLE_DISABLE_REPLY);
+}
+
+static void
+vl_api_uet_svm_create_t_handler (vl_api_uet_svm_create_t *mp)
+{
+  vl_api_uet_svm_create_reply_t *rmp;
+  uet_main_t *um = &uet_main;
+  char segment_name[65];
+  int rv;
+
+  clib_memcpy_fast (segment_name, mp->segment_name, 64);
+  segment_name[64] = 0;
+  rv = uet_svm_create (segment_name, clib_net_to_host_u32 (mp->queue_depth));
+  REPLY_MACRO (VL_API_UET_SVM_CREATE_REPLY);
+}
+
+static void
+vl_api_uet_svm_delete_t_handler (vl_api_uet_svm_delete_t *mp)
+{
+  vl_api_uet_svm_delete_reply_t *rmp;
+  uet_main_t *um = &uet_main;
+  char segment_name[65];
+  int rv;
+
+  clib_memcpy_fast (segment_name, mp->segment_name, 64);
+  segment_name[64] = 0;
+  rv = uet_svm_delete (segment_name);
+  REPLY_MACRO (VL_API_UET_SVM_DELETE_REPLY);
+}
+
+static void
+vl_api_uet_clear_counters_t_handler (vl_api_uet_clear_counters_t *mp)
+{
+  vl_api_uet_clear_counters_reply_t *rmp;
+  uet_main_t *um = &uet_main;
+  int rv = 0;
+
+  uet_counters_clear ();
+  uet_log_info ("plugin counters cleared through the binary API");
+  REPLY_MACRO (VL_API_UET_CLEAR_COUNTERS_REPLY);
+}
+
+static void
+vl_api_uet_tx_fib_set_t_handler (vl_api_uet_tx_fib_set_t *mp)
+{
+  vl_api_uet_tx_fib_set_reply_t *rmp;
+  uet_main_t *um = &uet_main;
+  int rv;
+
+  rv = uet_tx_set_fib_tables (clib_net_to_host_u32 (mp->ip4_table_id),
+			      clib_net_to_host_u32 (mp->ip6_table_id));
+  REPLY_MACRO (VL_API_UET_TX_FIB_SET_REPLY);
+}
+
+typedef struct
+{
+  u64 generation;
+  u64 tx_requests;
+  u64 invalid_requests;
+  u64 tx_completion_ring_full;
+  u64 tx_packets;
+  u64 tx_bytes;
+  u64 tx_completions;
+  u64 rx_delivered;
+  u64 rx_ring_full;
+  u64 rx_bad_chain;
+  u64 rx_releases;
+  u64 rx_invalid_releases;
+  u64 rx_outstanding;
+  u32 worker_index;
+  u32 thread_index;
+  u32 queue_depth;
+  u32 tx_ip4_table_id;
+  u32 tx_ip6_table_id;
+  u32 tx_pending;
+  u32 tx_completions_pending;
+  u32 rx_pending;
+  u32 rx_release_pending;
+  u8 enabled;
+  u8 svm_attached;
+  u8 provider_ready;
+  u8 tx_configured;
+} uet_api_worker_snapshot_t;
+
+static void
+uet_api_worker_snapshot_read (uet_main_t *um, u32 worker_index, const uet_worker_t *uw,
+			      uet_api_worker_snapshot_t *snapshot)
+{
+  clib_memset (snapshot, 0, sizeof (*snapshot));
+  snapshot->worker_index = worker_index;
+  snapshot->thread_index = uw->thread_index;
+  snapshot->enabled = um->enabled;
+  snapshot->tx_configured = uw->tx_configured;
+  snapshot->tx_ip4_table_id = uw->tx_ip4_table_id;
+  snapshot->tx_ip6_table_id = uw->tx_ip6_table_id;
+  snapshot->tx_requests = uw->tx_requests;
+  snapshot->invalid_requests = uw->invalid_requests;
+  snapshot->tx_completion_ring_full = uw->tx_completion_ring_full;
+  snapshot->tx_packets = uw->tx_packets;
+  snapshot->tx_bytes = uw->tx_bytes;
+  snapshot->tx_completions = uw->tx_completions;
+  snapshot->rx_delivered = uw->rx_delivered;
+  snapshot->rx_ring_full = uw->rx_ring_full;
+  snapshot->rx_bad_chain = uw->rx_bad_chain;
+  snapshot->rx_releases = uw->rx_releases;
+  snapshot->rx_invalid_releases = uw->rx_invalid_releases;
+  snapshot->rx_outstanding = uw->rx_outstanding;
+
+  for (u32 client_index = 0; client_index < vec_len (uw->channels); client_index++)
+    {
+      const uet_worker_channel_t *channel = uw->channels + client_index;
+      u32 client_flags, server_flags;
+
+      if (!channel->active)
+	continue;
+      client_flags = clib_atomic_load_acq_n (&channel->svm_header->client_flags);
+      server_flags = clib_atomic_load_acq_n (&channel->svm_header->server_flags);
+      if (!snapshot->svm_attached)
+	{
+	  snapshot->generation = channel->svm_header->generation;
+	  snapshot->queue_depth = channel->svm_header->queue_depth;
+	}
+      snapshot->svm_attached = 1;
+      snapshot->provider_ready |= !!(client_flags & UET_VPP_SVM_CLIENT_F_DMA_READY) &&
+				  !!(server_flags & UET_VPP_SVM_SERVER_F_DMA_READY_ACK);
+      snapshot->tx_pending += clib_atomic_load_acq_n (&channel->tx_ring->producer) -
+			      clib_atomic_load_acq_n (&channel->tx_ring->consumer);
+      snapshot->tx_completions_pending +=
+	clib_atomic_load_acq_n (&channel->tx_completion_ring->producer) -
+	clib_atomic_load_acq_n (&channel->tx_completion_ring->consumer);
+      snapshot->rx_pending += clib_atomic_load_acq_n (&channel->rx_ring->producer) -
+			      clib_atomic_load_acq_n (&channel->rx_ring->consumer);
+      snapshot->rx_release_pending += clib_atomic_load_acq_n (&channel->rx_release_ring->producer) -
+				      clib_atomic_load_acq_n (&channel->rx_release_ring->consumer);
+    }
+}
+
+static void
+uet_send_worker_details (vl_api_registration_t *registration, u32 context,
+			 const uet_api_worker_snapshot_t *snapshot)
+{
+  uet_main_t *um = &uet_main;
+  vl_api_uet_worker_details_t *rmp;
+
+  REPLY_MACRO_DETAILS4 (
+    VL_API_UET_WORKER_DETAILS, registration, context, ({
+      rmp->worker_index = clib_host_to_net_u32 (snapshot->worker_index);
+      rmp->thread_index = clib_host_to_net_u32 (snapshot->thread_index);
+      rmp->enabled = snapshot->enabled;
+      rmp->svm_attached = snapshot->svm_attached;
+      rmp->provider_ready = snapshot->provider_ready;
+      rmp->tx_configured = snapshot->tx_configured;
+      rmp->tx_ip4_table_id = clib_host_to_net_u32 (snapshot->tx_ip4_table_id);
+      rmp->tx_ip6_table_id = clib_host_to_net_u32 (snapshot->tx_ip6_table_id);
+      rmp->generation = clib_host_to_net_u64 (snapshot->generation);
+      rmp->queue_depth = clib_host_to_net_u32 (snapshot->queue_depth);
+      rmp->tx_pending = clib_host_to_net_u32 (snapshot->tx_pending);
+      rmp->tx_completions_pending = clib_host_to_net_u32 (snapshot->tx_completions_pending);
+      rmp->rx_pending = clib_host_to_net_u32 (snapshot->rx_pending);
+      rmp->rx_release_pending = clib_host_to_net_u32 (snapshot->rx_release_pending);
+      rmp->tx_requests = clib_host_to_net_u64 (snapshot->tx_requests);
+      rmp->invalid_requests = clib_host_to_net_u64 (snapshot->invalid_requests);
+      rmp->tx_completion_ring_full = clib_host_to_net_u64 (snapshot->tx_completion_ring_full);
+      rmp->tx_packets = clib_host_to_net_u64 (snapshot->tx_packets);
+      rmp->tx_bytes = clib_host_to_net_u64 (snapshot->tx_bytes);
+      rmp->tx_completions = clib_host_to_net_u64 (snapshot->tx_completions);
+      rmp->rx_delivered = clib_host_to_net_u64 (snapshot->rx_delivered);
+      rmp->rx_ring_full = clib_host_to_net_u64 (snapshot->rx_ring_full);
+      rmp->rx_bad_chain = clib_host_to_net_u64 (snapshot->rx_bad_chain);
+      rmp->rx_releases = clib_host_to_net_u64 (snapshot->rx_releases);
+      rmp->rx_invalid_releases = clib_host_to_net_u64 (snapshot->rx_invalid_releases);
+      rmp->rx_outstanding = clib_host_to_net_u64 (snapshot->rx_outstanding);
+    }));
+}
+
+static void
+vl_api_uet_worker_dump_t_handler (vl_api_uet_worker_dump_t *mp)
+{
+  uet_main_t *um = &uet_main;
+  vl_api_registration_t *registration;
+  uet_api_worker_snapshot_t *snapshots = 0;
+  u32 worker_count = vlib_num_workers ();
+
+  registration = vl_api_client_index_to_registration (mp->client_index);
+  if (!registration)
+    return;
+
+  if (!worker_count || !um->workers)
+    return;
+
+  vec_validate (snapshots, worker_count - 1);
+  vlib_worker_thread_barrier_sync (um->vlib_main);
+  for (u32 worker = 0; worker < worker_count; worker++)
+    {
+      u32 thread_index = vlib_get_worker_thread_index (worker);
+      uet_worker_t *uw = vec_elt_at_index (um->workers, thread_index);
+
+      uet_api_worker_snapshot_read (um, worker, uw, vec_elt_at_index (snapshots, worker));
+    }
+  vlib_worker_thread_barrier_release (um->vlib_main);
+
+  for (u32 worker = 0; worker < worker_count; worker++)
+    uet_send_worker_details (registration, mp->context, vec_elt_at_index (snapshots, worker));
+  vec_free (snapshots);
+}
+
+#include <uet/uet.api.c>
+
+static clib_error_t *
+uet_init (vlib_main_t *vm)
+{
+  uet_main_t *um = &uet_main;
+  vlib_node_registration_t *rx_handoff_nodes[UET_RX_N_PATHS] = {
+    [UET_RX_PATH_IP4_NATIVE] = &uet4_ip_handoff_node,
+    [UET_RX_PATH_IP6_NATIVE] = &uet6_ip_handoff_node,
+    [UET_RX_PATH_IP4_UDP] = &uet4_udp_handoff_node,
+    [UET_RX_PATH_IP6_UDP] = &uet6_udp_handoff_node,
+  };
+  u32 n_threads = vlib_get_thread_main ()->n_vlib_mains;
+  u32 i;
+
+  um->vlib_main = vm;
+  um->vnet_main = vnet_get_main ();
+  um->dma_buffer_pool_index = (u8) ~0;
+  um->dma_listener_file_index = ~0;
+  um->tx_ip4_fib_index = ~0;
+  um->tx_ip6_fib_index = ~0;
+  um->tx_ip4_table_id = ~0;
+  um->tx_ip6_table_id = ~0;
+  clib_memset (um->client_by_namespace, 0xff, sizeof (um->client_by_namespace));
+  clib_bihash_init_40_8 (&um->endpoint_hash, "uet endpoint registrations", 1024, 1 << 20);
+  um->fib_source = fib_source_allocate ("uet", FIB_SOURCE_PRIORITY_HI, FIB_SOURCE_BH_SIMPLE);
+  vec_validate_aligned (um->workers, n_threads - 1, CLIB_CACHE_LINE_BYTES);
+
+  for (uet_rx_path_t path = 0; path < UET_RX_N_PATHS; path++)
+    um->rx_handoff_queue_indices[path] =
+      vlib_handoff_alloc_queues (&(vlib_handoff_alloc_queues_args_t){
+	.node_index = rx_handoff_nodes[path]->index,
+      });
+
+  for (i = 0; i < n_threads; i++)
+    {
+      um->workers[i].thread_index = UET_INVALID_THREAD_INDEX;
+      um->workers[i].tx_ip4_fib_index = ~0;
+      um->workers[i].tx_ip6_fib_index = ~0;
+      um->workers[i].tx_ip4_table_id = ~0;
+      um->workers[i].tx_ip6_table_id = ~0;
+    }
+
+  um->msg_id_base = setup_message_id_table ();
+  uet_log_debug ("initialized plugin version %s", UET_PLUGIN_BUILD_VERSION);
+  return 0;
+}
+
+VLIB_INIT_FUNCTION (uet_init);
+
+static clib_error_t *
+uet_exit (vlib_main_t *vm)
+{
+  while (pool_elts (uet_main.clients))
+    {
+      uet_client_t *client;
+      u8 *name = 0;
+
+      pool_foreach (client, uet_main.clients)
+	{
+	  name = format (0, "%s%c", client->segment.name, 0);
+	  break;
+	}
+      if (!name || uet_svm_delete ((char *) name))
+	{
+	  vec_free (name);
+	  break;
+	}
+      vec_free (name);
+    }
+  uet_protocols_unregister (vm);
+  uet_dma_listener_delete ();
+  clib_bihash_free_40_8 (&uet_main.endpoint_hash);
+  if (uet_main.tx_configured)
+    {
+      fib_table_unlock (uet_main.tx_ip4_fib_index, FIB_PROTOCOL_IP4, uet_main.fib_source);
+      fib_table_unlock (uet_main.tx_ip6_fib_index, FIB_PROTOCOL_IP6, uet_main.fib_source);
+      uet_main.tx_configured = 0;
+    }
+  return 0;
+}
+
+VLIB_MAIN_LOOP_EXIT_FUNCTION (uet_exit);

--- a/vpp-plugin/uet/uet.h
+++ b/vpp-plugin/uet/uet.h
@@ -1,0 +1,199 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef included_uet_vpp_plugin_h
+#define included_uet_vpp_plugin_h
+
+#include <svm/ssvm.h>
+#include <vlib/vlib.h>
+#include <vnet/fib/fib_source.h>
+#include <vnet/ip/ip.h>
+#include <vnet/vnet.h>
+#include <vppinfra/socket.h>
+#include <vppinfra/bihash_40_8.h>
+
+#include <uet/dma_abi.h>
+#include <uet/svm_abi.h>
+
+#define UET_PLUGIN_BUILD_VERSION "0.10.0"
+#define UET_INVALID_THREAD_INDEX ((u32) ~0)
+#define UET_IP_PROTOCOL		 253
+#define UET_UDP_PORT		 49150
+#define UET_INVALID_CLIENT_INDEX ((u32) ~0)
+
+typedef enum
+{
+  UET_RX_PATH_IP4_NATIVE,
+  UET_RX_PATH_IP6_NATIVE,
+  UET_RX_PATH_IP4_UDP,
+  UET_RX_PATH_IP6_UDP,
+  UET_RX_N_PATHS,
+} uet_rx_path_t;
+
+typedef struct
+{
+  CLIB_CACHE_LINE_ALIGN_MARK (cacheline0);
+
+  u8 active;
+  u8 dma_ready_ack;
+  u32 client_index;
+  u32 client_namespace;
+  uet_vpp_svm_shared_header_t *svm_header;
+
+  u32 *dma_buffer_indices;
+  uet_vpp_svm_dma_slot_t *dma_slots;
+  u32 dma_slot_count;
+
+  u64 next_rx_id;
+  u32 *rx_buffer_indices;
+  u64 *rx_ids;
+  u16 *rx_free_slots;
+  u32 rx_free_count;
+  u32 rx_outstanding;
+
+  uet_vpp_svm_spsc_ring_t *tx_ring;
+  uet_vpp_svm_tx_desc_t *tx_descs;
+  uet_vpp_svm_spsc_ring_t *tx_completion_ring;
+  uet_vpp_svm_tx_completion_t *tx_completion_entries;
+  uet_vpp_svm_spsc_ring_t *rx_ring;
+  uet_vpp_svm_rx_desc_t *rx_descs;
+  uet_vpp_svm_spsc_ring_t *rx_release_ring;
+  uet_vpp_svm_rx_release_t *rx_release_entries;
+  uet_vpp_svm_spsc_ring_t *control_request_ring;
+  uet_vpp_svm_control_request_t *control_requests;
+  uet_vpp_svm_spsc_ring_t *control_completion_ring;
+  uet_vpp_svm_control_completion_t *control_completions;
+} uet_worker_channel_t;
+
+/*
+ * Each worker owns one independent channel for every application segment.
+ * The main thread may change this vector only while holding the worker
+ * barrier. No datapath lock is allowed in this structure.
+ */
+typedef struct
+{
+  CLIB_CACHE_LINE_ALIGN_MARK (cacheline0);
+
+  u32 thread_index;
+  u64 poll_calls;
+  u64 tx_requests;
+  u64 invalid_requests;
+  u64 tx_completion_ring_full;
+  u64 tx_packets;
+  u64 tx_bytes;
+  u64 tx_completions;
+  u64 rx_ip4_packets;
+  u64 rx_ip4_bytes;
+  u64 rx_ip6_packets;
+  u64 rx_ip6_bytes;
+  u64 rx_udp4_packets;
+  u64 rx_udp4_bytes;
+  u64 rx_udp6_packets;
+  u64 rx_udp6_bytes;
+  u64 rx_delivered;
+  u64 rx_ambiguous;
+  u64 rx_ring_full;
+  u64 rx_bad_chain;
+  u64 rx_releases;
+  u64 rx_invalid_releases;
+  u64 rx_outstanding;
+  uet_worker_channel_t *channels;
+
+  /* FIB indices copied from main-thread control state under the barrier. */
+  u32 tx_ip4_fib_index;
+  u32 tx_ip6_fib_index;
+  u32 tx_ip4_table_id;
+  u32 tx_ip6_table_id;
+  u8 tx_configured;
+
+} uet_worker_t;
+
+/* One application process owns one segment with one channel per VPP worker. */
+typedef struct
+{
+  u32 index;
+  ssvm_private_t segment;
+  uet_vpp_svm_shared_header_t *header;
+  uet_vpp_svm_worker_channel_t *shared_channels;
+  uet_vpp_svm_spsc_ring_t *control_request_ring;
+  uet_vpp_svm_control_request_t *control_requests;
+  uet_vpp_svm_spsc_ring_t *control_completion_ring;
+  uet_vpp_svm_control_completion_t *control_completions;
+  u32 channel_count;
+  u32 queue_depth;
+  u64 generation;
+  u32 client_namespace;
+} uet_client_t;
+
+/* Main-thread-owned control state. */
+typedef struct
+{
+  u16 msg_id_base;
+  u8 enabled;
+  u8 protocols_registered;
+
+  vlib_main_t *vlib_main;
+  vnet_main_t *vnet_main;
+
+  /* Indexed by VPP thread index; index zero is the main thread. */
+  uet_worker_t *workers;
+
+  /* Optional generic RX placement by native EV or UDP source port. */
+  u32 rx_handoff_queue_indices[UET_RX_N_PATHS];
+  u8 rx_entropy_handoff;
+
+  /* Main-thread-owned pool; pool indices also index worker channel vectors. */
+  uet_client_t *clients;
+  u64 svm_generation;
+  u32 next_client_namespace;
+  u32 client_by_namespace[UET_VPP_SVM_CLIENT_NAMESPACE_MAX + 1];
+  clib_bihash_40_8_t endpoint_hash;
+  u64 endpoint_registrations;
+  u64 endpoint_collisions;
+
+  u8 dma_buffer_pool_index;
+  u32 dma_buffer_data_size;
+  u64 dma_map_size;
+  u8 *dma_map_base;
+  u64 dma_authorized_clients;
+  u64 dma_rejected_clients;
+
+  /* Main-thread-owned TX routing configuration and FIB locks. */
+  u32 tx_ip4_fib_index;
+  u32 tx_ip6_fib_index;
+  u32 tx_ip4_table_id;
+  u32 tx_ip6_table_id;
+  u8 tx_configured;
+  fib_source_t fib_source;
+
+  clib_socket_t *dma_listener;
+  u32 dma_listener_file_index;
+  u8 *dma_socket_name;
+} uet_main_t;
+
+extern uet_main_t uet_main;
+extern vlib_log_class_registration_t uet_log;
+extern vlib_node_registration_t uet_input_node;
+extern vlib_node_registration_t uet4_ip_input_node;
+extern vlib_node_registration_t uet6_ip_input_node;
+extern vlib_node_registration_t uet4_udp_input_node;
+extern vlib_node_registration_t uet6_udp_input_node;
+extern vlib_node_registration_t uet4_ip_handoff_node;
+extern vlib_node_registration_t uet6_ip_handoff_node;
+extern vlib_node_registration_t uet4_udp_handoff_node;
+extern vlib_node_registration_t uet6_udp_handoff_node;
+
+int uet_enable_disable (u8 enable);
+int uet_svm_create (const char *segment_name, u32 queue_depth);
+int uet_svm_delete (const char *segment_name);
+void uet_counters_clear (void);
+clib_error_t *uet_dma_listener_init (void);
+void uet_dma_listener_delete (void);
+int uet_tx_set_fib_tables (u32 ip4_table_id, u32 ip6_table_id);
+
+#define uet_log_debug(...)  vlib_log_debug (uet_log.class, __VA_ARGS__)
+#define uet_log_info(...)   vlib_log_info (uet_log.class, __VA_ARGS__)
+#define uet_log_notice(...) vlib_log_notice (uet_log.class, __VA_ARGS__)
+#define uet_log_warn(...)   vlib_log_warn (uet_log.class, __VA_ARGS__)
+#define uet_log_err(...)    vlib_log_err (uet_log.class, __VA_ARGS__)
+
+#endif /* included_uet_vpp_plugin_h */


### PR DESCRIPTION
This is the first VPP-specific component split out of #143 at the maintainer's request.

## Scope

This PR contains only the out-of-tree VPP host-dataplane plugin and its external-process client API:

- IPv4/IPv6 local delivery for native UET and UDP port 49150;
- normal VPP FIB lookup, multipath, adjacency and device graphs on TX;
- one lockless SPSC dataplane channel per VPP worker;
- multiple independently owned application segments;
- shared VLIB-buffer TX/RX ownership and explicit RX release;
- endpoint registration and deterministic multi-process RX demultiplexing;
- optional driver-independent entropy handoff;
- CLI, binary APIs, counters, logs and packet tracing; and
- focused lifecycle, ownership, routing and negative validation tools.

## Deliberately excluded

- the UET NIC shim, which is submitted separately;
- all `libfabric-provider/` code and provider documentation;
- generic endpoint, entropy and ownership fixes, now split into #151-#154;
- the provider-based AF_PACKET/`fi_pingpong` test; and
- changes to the repository's GitHub sanity workflow.

The plugin remains disabled by default and requires an explicit external VPP SDK build. Its internal tests remain manual so the core UET CI does not consume additional action credits.

The design, ABI, build procedure, CLI and manual low-level tests are documented in `vpp-plugin/README.md`.
