### PR TITLE
api: preserve resolved software endpoint fields

### DIFF
--- a/uet_api.c
+++ b/uet_api.c
@@ -4519,13 +4519,22 @@ static int uet_pds_to_ses_pds_err(uet_pkt_handle_t tx_pkt_handle,
 #if !ENABLE_VERBS
 static int uet_addr_resolution(struct uet_addr *uet_addr, uint32_t *job_id)
 {
-	uet_addr->pid_on_fep = UET_ADDR_DEF_PID_ON_FEP;
-	uet_addr->num_indices = 1;
-	uet_addr->start_index = UET_ADDR_DEF_INDEX;
-	uet_addr->initiator_id = UET_ADDR_DEF_INITIATOR_ID;
-
-	uet_addr->flags |= (UET_ADDR_PID_ON_FEP_V | UET_ADDR_INDEX_V |
-			    UET_ADDR_INITIATOR_V);
+	/* Preserve fields supplied by an address-management layer. Software
+	 * backends still receive the historical defaults for unresolved fields.
+	 */
+	if (!(uet_addr->flags & UET_ADDR_PID_ON_FEP_V)) {
+		uet_addr->pid_on_fep = UET_ADDR_DEF_PID_ON_FEP;
+		uet_addr->flags |= UET_ADDR_PID_ON_FEP_V;
+	}
+	if (!(uet_addr->flags & UET_ADDR_INDEX_V)) {
+		uet_addr->num_indices = 1;
+		uet_addr->start_index = UET_ADDR_DEF_INDEX;
+		uet_addr->flags |= UET_ADDR_INDEX_V;
+	}
+	if (!(uet_addr->flags & UET_ADDR_INITIATOR_V)) {
+		uet_addr->initiator_id = UET_ADDR_DEF_INITIATOR_ID;
+		uet_addr->flags |= UET_ADDR_INITIATOR_V;
+	}
 
 	*job_id = UET_DEF_JOB_ID;
 


### PR DESCRIPTION
This backend-neutral correction is split out of #143 so the VPP NIC-shim PR does not carry unrelated transport-core behavior.

The software address-resolution path currently overwrites PIDonFEP, Resource Index and Initiator ID even when an address-management layer has already populated and marked those fields valid.

This change applies the historical defaults only to unresolved fields. Existing raw-socket and AF_XDP callers that do not supply an address are unchanged, while a backend with an external address allocator can preserve its assigned identity.

No VPP, provider, build-system or CI code is included.
