### PR TITLE
nic: add the VPP transport shim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,18 @@ XDP_KERN_BIN=uet_xdp_kern.o
 xdp: CFLAGS+=-DENABLE_XDP -DXDP_PROG=$(XDP_KERN_BIN)
 xdp: LDFLAGS+=-lbpf -lxdp
 
+# VPP NIC-shim build. VPP_PLUGIN_BUILD points to the separate plugin/client
+# CMake build containing lib/libuet_vpp_client.so.
+VPP_PLUGIN_BUILD ?= build/vpp-plugin
+VPP_LIBNAME=vppuet
+VPP_LIB=lib$(VPP_LIBNAME).so
+VPP_LIB_SRC=$(LIB_SRC)
+VPP_LIB_OBJ_DIR=obj_vpp_lib
+VPP_LIB_OBJ=$(patsubst %.c, $(VPP_LIB_OBJ_DIR)/%.o, $(VPP_LIB_SRC))
+VPP_BIN=uet_vpp
+VPP_OBJ_DIR=obj_vpp
+VPP_MAIN_OBJ=$(VPP_OBJ_DIR)/uet.o
+
 CC_SIM_BIN=uet_cc_sim
 CC_SIM_SRC=$(wildcard cc/*.c cc_sim/*.c)
 CC_SIM_OBJ_DIR=obj_cc_sim
@@ -118,6 +130,9 @@ xdp: $(XDP_BIN) $(XDP_KERN_BIN)
 # Check project sources with diagnostics that are suppressed for some external
 # libfabric headers used by the standalone application.
 strict-core: $(STRICT_FABRIC_OBJ) $(STRICT_VERBS_OBJ)
+
+# VPP target
+vpp: $(VPP_BIN)
 
 # CC sim target
 cc_sim: $(CC_SIM_BIN)
@@ -195,6 +210,29 @@ $(XDP_KERN_BIN): $(XDP_KERN_SRC)
 		  -I/usr/include/$(shell uname -m)-linux-gnu \
 		  -c -o $(XDP_KERN_BIN) $(XDP_KERN_SRC)
 
+$(VPP_LIB_OBJ_DIR)/%.o: %.c $(HDRS)
+	@mkdir -p $(VPP_LIB_OBJ_DIR)/$(dir $<)
+	@echo 'Building VPP library object: $<'
+	@$(CC) $(CFLAGS) -DENABLE_VERBS=0 -DENABLE_VPP=1 \
+		$(INCS) $(LF_LOCAL_HDRS) -Ivpp-plugin/client \
+		-fPIC -c -o $@ $<
+
+$(VPP_LIB): $(VPP_LIB_OBJ)
+	@echo 'Building VPP shared library: $@'
+	@$(CC) -shared $(VPP_LIB_OBJ) -o $@ $(LDFLAGS) \
+		-L$(VPP_PLUGIN_BUILD)/lib -luet_vpp_client
+
+$(VPP_OBJ_DIR)/%.o: %.c $(HDRS)
+	@mkdir -p $(VPP_OBJ_DIR)/$(dir $<)
+	@echo 'Building VPP file: $<'
+	@$(CC) $(CFLAGS) -D_GNU_SOURCE $(INCS) $(LF_HDRS) -c -o $@ $<
+
+$(VPP_BIN): $(VPP_LIB) $(VPP_MAIN_OBJ)
+	@echo 'Building VPP program: $@'
+	@$(CC) $(VPP_MAIN_OBJ) -o $@ -L. -l$(VPP_LIBNAME) \
+		-L$(VPP_PLUGIN_BUILD)/lib -luet_vpp_client \
+		$(LDFLAGS) $(LF_LIBS)
+
 $(CC_SIM_OBJ_DIR)/%.o: %.c $(HDRS)
 	@mkdir -p $(CC_SIM_OBJ_DIR)/$(dir $<)
 	@echo 'Building file: $<'
@@ -212,6 +250,8 @@ clean:
 		$(XDP_LIB_OBJ_DIR) $(XDP_LIB) \
 		$(XDP_OBJ_DIR) $(XDP_BIN) \
 		$(XDP_KERN_BIN) \
+		$(VPP_LIB_OBJ_DIR) $(VPP_LIB) \
+		$(VPP_OBJ_DIR) $(VPP_BIN) \
 		$(CC_SIM_OBJ_DIR) $(CC_SIM_BIN)
 
-.PHONY: all xdp strict-core cc_sim clean
+.PHONY: all xdp vpp strict-core cc_sim clean

--- a/README.md
+++ b/README.md
@@ -195,6 +195,33 @@ over the interface.
        ./uet_xdp client 192.168.1.1
 ```
 
+### vpp
+
+The experimental `vpp` NIC shim connects the existing UET transport to the
+out-of-tree VPP host-dataplane plugin and `libuet_vpp_client`. VPP owns packet
+I/O, IPv4/IPv6 FIB lookup, multipath, adjacency resolution and interface
+output; UET transport termination remains in the `uet_vpp` process.
+
+Build the separate VPP plugin/client contribution first, then build the shim:
+
+```sh
+cmake -S vpp-plugin -B build/vpp-plugin \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH=/opt/vpp \
+  -DVPP_DIR=/opt/vpp/lib/x86_64-linux-gnu/cmake/vpp
+cmake --build build/vpp-plugin
+
+make vpp \
+  LIBFABRIC=/path/to/libfabric \
+  VPP_PLUGIN_BUILD=build/vpp-plugin
+```
+
+The dedicated binary defaults to `UET_NIC_SHIM=vpp`. Configure one VPP-owned
+application segment per process and provide its name, DMA socket, local IP
+address and optional MTU through the variables below. The plugin architecture,
+VPP CLI and manual low-level tests are documented in
+[`vpp-plugin/README.md`](vpp-plugin/README.md).
+
 ### CC Tester
 
 Simulation parameters (link speed, RTT, queue size, drop thresholds etc.) can be set by modifying
@@ -211,7 +238,14 @@ Replace `2` with the desired number of senders.
 
 - **LD_LIBRARY_PATH** - Needed for dynamic linking to the `libfabric` and `libuet` libraries.
 - **UET_IFNAME** - The ifname of the interface to attach to.
-- **UET_NIC_SHIM** - [ `rawsock` | `xdp` ]
+- **UET_NIC_SHIM** - [ `rawsock` | `xdp` | `vpp` ] (`vpp` is available in
+  the dedicated `make vpp` build).
+- **UET_VPP_SEGMENT** - VPP-owned application segment used by the `vpp` shim.
+- **UET_VPP_DMA_SOCKET** - Unix socket used to receive the authorized VPP
+  buffer-pool mapping.
+- **UET_VPP_IPV4_ADDR** / **UET_VPP_IPV6_ADDR** - One or both local addresses
+  exposed by the `vpp` shim.
+- **UET_VPP_MTU** - IP MTU exposed by the `vpp` shim (default=`1500`).
 - **UET_PDS** - [ `sng` | `pds` ] (default=`sng` stop-n-go)
 - **UET_PDS_PER_PKT_ACK_ENB** - [ `0` | `1` ] (default=`0`)
 - **UET_PDS_ACK_TYPE** - [ `ack` | `ack_cc` | `ack_ccx` ] (default=`ack`)

--- a/nic_shim/nic_vpp.c
+++ b/nic_shim/nic_vpp.c
@@ -1,0 +1,1215 @@
+// SPDX-License-Identifier: MIT
+
+/* Functional UET NIC shim over the out-of-tree VPP termination plugin. */
+
+#if ENABLE_VPP
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <linux/if_ether.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/udp.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <uet_vpp_client.h>
+
+#include "uet_api.h"
+#include "uet_api_private.h"
+#include "uet_pkt_hdr.h"
+#include "uet_nic.h"
+#include "crc32c.h"
+
+#define UET_NETWORK_TYPE_VPP "VPP"
+#define UET_VPP_TX_BATCH_SIZE 64
+#define UET_VPP_DEFAULT_MTU 1500
+#define UET_VPP_MAX_CHANNELS 256
+#define UET_VPP_CHANNEL_ALIGNMENT 64
+#define UET_VPP_CLOSE_TIMEOUT_NS (5ULL * 1000 * 1000 * 1000)
+#define UET_VPP_INITIATOR_LOCAL_BITS 22
+#define UET_VPP_INITIATOR_LOCAL_MASK \
+	((1U << UET_VPP_INITIATOR_LOCAL_BITS) - 1)
+
+struct vpp_endpoint_registration {
+	struct vpp_data *vdata;
+	uet_vpp_client_endpoint_t endpoint;
+};
+
+struct __attribute__((aligned(UET_VPP_CHANNEL_ALIGNMENT))) vpp_channel {
+	uet_vpp_client_t *client;
+	uint32_t channel_index;
+	uet_vpp_client_rx_t pending_rx;
+	bool rx_pending;
+	uint64_t next_request_id;
+	uint64_t tx_inflight;
+	pthread_mutex_t lock;
+	bool lock_initialized;
+};
+
+struct vpp_data {
+	uet_vpp_client_t *client;
+	struct vpp_channel *channels;
+	size_t channel_count;
+	size_t rx_cursor;
+	size_t pending_channel;
+	pthread_mutex_t rx_lock;
+	bool rx_lock_initialized;
+	bool dma_mapped;
+	bool pds_sng;
+	uet_vpp_client_info_t info;
+	_Atomic uint64_t rudi_last_sequence_plus_one;
+};
+
+struct nic_vpp_packet_view {
+	uint8_t *ip;
+	uint8_t *pds;
+	size_t ip_length;
+	size_t pds_length;
+	uint8_t type;
+	uint8_t next_header;
+	uint8_t flags;
+	bool is_ipv6;
+};
+
+static int nic_vpp_monotonic_ns(uint64_t *now)
+{
+	struct timespec ts;
+
+	if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
+		return -errno;
+	*now = (uint64_t)ts.tv_sec * 1000000000ULL +
+	       (uint64_t)ts.tv_nsec;
+	return 0;
+}
+
+static int nic_vpp_completion_error(int32_t status)
+{
+	switch (status) {
+	case UET_VPP_CLIENT_STATUS_OK:
+		return 0;
+	case UET_VPP_CLIENT_STATUS_INVALID_PACKET:
+		return -EINVAL;
+	case UET_VPP_CLIENT_STATUS_TX_NOT_CONFIGURED:
+		return -ENETDOWN;
+	case UET_VPP_CLIENT_STATUS_SLOT_BUSY:
+		return -EBUSY;
+	case UET_VPP_CLIENT_STATUS_NO_BUFFERS:
+		return -ENOBUFS;
+	default:
+		return -EPROTO;
+	}
+}
+
+static int nic_vpp_poll_tx(struct vpp_channel *channel,
+			   int *completion_error)
+{
+	uet_vpp_client_completion_t completions[UET_VPP_TX_BATCH_SIZE];
+	int error = 0;
+	int i, rc;
+
+	rc = uet_vpp_client_poll_batch(channel->client,
+				       channel->channel_index, completions,
+				       UET_VPP_TX_BATCH_SIZE);
+	if (rc < 0)
+		return rc;
+	for (i = 0; i < rc; i++) {
+		int status_error =
+			nic_vpp_completion_error(completions[i].status);
+
+		if (channel->tx_inflight)
+			channel->tx_inflight--;
+		else if (!error)
+			error = -EPROTO;
+		if (!error && status_error)
+			error = status_error;
+	}
+	*completion_error = error;
+	return rc;
+}
+
+static int nic_vpp_progress_tx(struct vpp_channel *channel)
+{
+	int completion_error;
+	int rc;
+
+	rc = nic_vpp_poll_tx(channel, &completion_error);
+	if (rc < 0)
+		return rc;
+	return completion_error ? completion_error : rc;
+}
+
+static int nic_vpp_release_pending_rx(struct vpp_data *vdata)
+{
+	struct vpp_channel *channel;
+	int rc;
+
+	if (vdata->pending_channel >= vdata->channel_count)
+		return 0;
+	channel = &vdata->channels[vdata->pending_channel];
+	rc = uet_vpp_client_release_rx(channel->client,
+				       channel->channel_index,
+				       &channel->pending_rx);
+	if (!rc) {
+		channel->rx_pending = false;
+		vdata->pending_channel = SIZE_MAX;
+	}
+	return rc;
+}
+
+static int nic_vpp_ip_length(void *iphdr, size_t available,
+			     size_t *ip_length)
+{
+	uint8_t version;
+
+	if (!iphdr || available < sizeof(struct iphdr))
+		return -EINVAL;
+	version = (*(uint8_t *)iphdr) >> 4;
+	if (version == 4) {
+		struct iphdr *ipv4 = iphdr;
+		size_t header_length = ipv4->ihl << 2;
+
+		if (header_length < sizeof(*ipv4))
+			return -EINVAL;
+		*ip_length = ntohs(ipv4->tot_len);
+	} else if (version == 6) {
+		struct ipv6hdr *ipv6 = iphdr;
+
+		if (available < sizeof(*ipv6))
+			return -EINVAL;
+		*ip_length = sizeof(*ipv6) + ntohs(ipv6->payload_len);
+	} else {
+		return -EINVAL;
+	}
+
+	if (*ip_length > available)
+		return -EMSGSIZE;
+	return 0;
+}
+
+static int nic_vpp_packet_view(struct uet_nic *nic, void *iphdr,
+			       size_t available,
+			       struct nic_vpp_packet_view *view)
+{
+	struct uet_pds_prlg *prologue;
+	uint16_t type_next_flags;
+	uint8_t protocol;
+	size_t offset;
+	int rc;
+
+	memset(view, 0, sizeof(*view));
+	rc = nic_vpp_ip_length(iphdr, available, &view->ip_length);
+	if (rc)
+		return rc;
+	view->ip = iphdr;
+	view->is_ipv6 = (view->ip[0] >> 4) == 6;
+	if (view->is_ipv6) {
+		struct ipv6hdr *ipv6 = iphdr;
+
+		protocol = ipv6->nexthdr;
+		offset = sizeof(*ipv6);
+	} else {
+		struct iphdr *ipv4 = iphdr;
+
+		protocol = ipv4->protocol;
+		offset = ipv4->ihl << 2;
+	}
+	if (protocol == nic->uet_ipproto)
+		offset += sizeof(struct uet_entropy);
+	else if (protocol == IPPROTO_UDP)
+		offset += sizeof(struct udphdr);
+	else
+		return -EPROTONOSUPPORT;
+	if (offset + sizeof(*prologue) > view->ip_length)
+		return -EINVAL;
+
+	view->pds = view->ip + offset;
+	prologue = (struct uet_pds_prlg *)view->pds;
+	type_next_flags = ntohs(prologue->type_next_flags);
+	view->type = (type_next_flags & UET_PDS_TYPE_MASK) >>
+		     UET_PDS_TYPE_SHIFT;
+	view->next_header = (type_next_flags & UET_PDS_NEXT_HDR_MASK) >>
+			    UET_PDS_NEXT_HDR_SHIFT;
+	view->flags = type_next_flags & UET_PDS_FLAGS_MASK;
+
+	switch (view->type) {
+	case UET_PDS_TYPE_RUD_REQ:
+	case UET_PDS_TYPE_ROD_REQ:
+		view->pds_length = sizeof(struct uet_pds_req);
+		break;
+	case UET_PDS_TYPE_RUD_CC_REQ:
+	case UET_PDS_TYPE_ROD_CC_REQ:
+		view->pds_length = sizeof(struct uet_pds_req) +
+				   sizeof(struct uet_pds_req_cc_state);
+		break;
+	case UET_PDS_TYPE_ACK:
+		view->pds_length = sizeof(struct uet_pds_ack);
+		break;
+	case UET_PDS_TYPE_ACK_CC:
+		view->pds_length = sizeof(struct uet_pds_ack_cc);
+		break;
+	case UET_PDS_TYPE_ACK_CCX:
+		view->pds_length = sizeof(struct uet_pds_ack_ccx);
+		break;
+	case UET_PDS_TYPE_NACK:
+		view->pds_length = sizeof(struct uet_pds_nack);
+		break;
+	case UET_PDS_TYPE_NACK_CCX:
+		view->pds_length = sizeof(struct uet_pds_nack_ccx);
+		break;
+	case UET_PDS_TYPE_CTRL:
+		view->pds_length = sizeof(struct uet_pds_ctrl);
+		break;
+	case UET_PDS_TYPE_RUDI_REQ:
+	case UET_PDS_TYPE_RUDI_RESP:
+		view->pds_length = sizeof(struct uet_pds_rudi_req);
+		break;
+	case UET_PDS_TYPE_UUD_REQ:
+		view->pds_length = sizeof(struct uet_pds_uud_req);
+		break;
+	case UET_PDS_TYPE_SECURITY:
+		/* Endpoint demultiplexing cannot inspect encrypted transport
+		 * headers yet. Preserve the historical single-client behavior.
+		 */
+		return -EOPNOTSUPP;
+	default:
+		return -EINVAL;
+	}
+	if (offset + view->pds_length > view->ip_length)
+		return -EINVAL;
+	return 0;
+}
+
+static int nic_vpp_pdc_to_wire(const struct vpp_data *vdata,
+			       uint16_t local_id, uint16_t *wire_id)
+{
+	if (!local_id || local_id > UET_VPP_CLIENT_PDC_LOCAL_MASK)
+		return -ERANGE;
+	*wire_id = ((uint16_t)vdata->info.client_namespace <<
+		    UET_VPP_CLIENT_PDC_LOCAL_BITS) | local_id;
+	return 0;
+}
+
+static int nic_vpp_pdc_from_wire(const struct vpp_data *vdata,
+				 uint16_t wire_id, uint16_t *local_id)
+{
+	if ((wire_id >> UET_VPP_CLIENT_PDC_LOCAL_BITS) !=
+	    vdata->info.client_namespace)
+		return -EPROTO;
+	*local_id = wire_id & UET_VPP_CLIENT_PDC_LOCAL_MASK;
+	return 0;
+}
+
+static int nic_vpp_rudi_to_wire(struct vpp_data *vdata, uint32_t local_id,
+				uint32_t *wire_id)
+{
+	const uint64_t wrap = (uint64_t)UINT32_MAX + 1;
+	uint64_t observed, desired, last, sequence;
+
+	/* The software RUDI allocator is a monotonic uint32_t counter. Keep its
+	 * logical epoch so a response can recover the full ID after only the low
+	 * 22 bits crossed the VPP boundary. No per-packet state is added here.
+	 */
+	observed = atomic_load_explicit(&vdata->rudi_last_sequence_plus_one,
+					memory_order_relaxed);
+	for (;;) {
+		if (!observed) {
+			sequence = local_id;
+			desired = sequence + 1;
+		} else {
+			last = observed - 1;
+			sequence = (last & ~(wrap - 1)) | local_id;
+			if (sequence < last && last - sequence > wrap / 2)
+				sequence += wrap;
+			else if (sequence > last && sequence - last > wrap / 2 &&
+				 sequence >= wrap)
+				sequence -= wrap;
+			if (sequence <= last)
+				break;
+			desired = sequence + 1;
+		}
+		if (atomic_compare_exchange_weak_explicit(
+			    &vdata->rudi_last_sequence_plus_one, &observed,
+			    desired, memory_order_relaxed, memory_order_relaxed))
+			break;
+	}
+	*wire_id = (vdata->info.client_namespace <<
+		    UET_VPP_CLIENT_RUDI_LOCAL_BITS) |
+		   (local_id & UET_VPP_CLIENT_RUDI_LOCAL_MASK);
+	return 0;
+}
+
+static int nic_vpp_rudi_from_wire(struct vpp_data *vdata,
+				  uint32_t wire_id, uint32_t *local_id)
+{
+	const uint64_t span = (uint64_t)1 << UET_VPP_CLIENT_RUDI_LOCAL_BITS;
+	uint64_t last_plus_one, last, sequence;
+
+	if ((wire_id >> UET_VPP_CLIENT_RUDI_LOCAL_BITS) !=
+	    vdata->info.client_namespace)
+		return -EPROTO;
+	last_plus_one = atomic_load_explicit(
+		&vdata->rudi_last_sequence_plus_one, memory_order_relaxed);
+	if (!last_plus_one)
+		return -ENOENT;
+	last = last_plus_one - 1;
+	/* Reconstruction is unambiguous while fewer than one 22-bit span of
+	 * requests are outstanding. The engine queue limits are far below that.
+	 */
+	sequence = (last & ~(span - 1)) |
+		   (wire_id & UET_VPP_CLIENT_RUDI_LOCAL_MASK);
+	if (sequence > last) {
+		if (sequence < span)
+			return -ENOENT;
+		sequence -= span;
+	}
+	*local_id = (uint32_t)sequence;
+	return 0;
+}
+
+static void nic_vpp_update_crc(const struct nic_vpp_packet_view *view)
+{
+	size_t start_offset = view->is_ipv6 ? 8 : 12;
+	uint32_t crc;
+
+	if (view->ip_length < start_offset + CRC_LEN)
+		return;
+	crc = crc32c(view->ip + start_offset,
+		     view->ip_length - start_offset - CRC_LEN);
+	memcpy(view->ip + view->ip_length - CRC_LEN, &crc, CRC_LEN);
+}
+
+static int nic_vpp_translate_ids(struct uet_nic *nic, void *iphdr,
+				 size_t available, bool tx)
+{
+	struct vpp_data *vdata = nic->nic_priv_data;
+	struct nic_vpp_packet_view view;
+	uint16_t value16;
+	uint32_t value32;
+	bool changed = false;
+	int rc;
+
+	rc = nic_vpp_packet_view(nic, iphdr, available, &view);
+	if (rc == -EOPNOTSUPP)
+		return 0;
+	if (rc)
+		return rc;
+
+	/* SNG repurposes spdcid/dpdcid as an endpoint-address overlay. */
+	if (vdata->pds_sng)
+		return 0;
+
+	switch (view.type) {
+	case UET_PDS_TYPE_RUD_REQ:
+	case UET_PDS_TYPE_ROD_REQ:
+	case UET_PDS_TYPE_RUD_CC_REQ:
+	case UET_PDS_TYPE_ROD_CC_REQ: {
+		struct uet_pds_req *request = (struct uet_pds_req *)view.pds;
+
+		if (tx) {
+			rc = nic_vpp_pdc_to_wire(vdata,
+					     ntohs(request->spdcid), &value16);
+			if (rc)
+				return rc;
+			request->spdcid = htons(value16);
+			changed = true;
+		} else if (!(view.flags & UET_PDS_REQ_FLAGS_SYN)) {
+			rc = nic_vpp_pdc_from_wire(vdata,
+						ntohs(request->dpdcid), &value16);
+			if (rc)
+				return rc;
+			request->dpdcid = htons(value16);
+			changed = true;
+		}
+		break;
+	}
+	case UET_PDS_TYPE_ACK:
+	case UET_PDS_TYPE_ACK_CC:
+	case UET_PDS_TYPE_ACK_CCX: {
+		struct uet_pds_ack *ack = (struct uet_pds_ack *)view.pds;
+
+		if (tx) {
+			rc = nic_vpp_pdc_to_wire(vdata, ntohs(ack->spdcid),
+					     &value16);
+			if (rc)
+				return rc;
+			ack->spdcid = htons(value16);
+		} else {
+			rc = nic_vpp_pdc_from_wire(vdata, ntohs(ack->dpdcid),
+						&value16);
+			if (rc)
+				return rc;
+			ack->dpdcid = htons(value16);
+		}
+		changed = true;
+		break;
+	}
+	case UET_PDS_TYPE_NACK:
+	case UET_PDS_TYPE_NACK_CCX: {
+		struct uet_pds_nack *nack = (struct uet_pds_nack *)view.pds;
+
+		if (view.flags & UET_PDS_NACK_FLAGS_NT) {
+			if (!tx) {
+				rc = nic_vpp_rudi_from_wire(
+					vdata, ntohl(nack->nack_pkt_id), &value32);
+				if (rc)
+					return rc;
+				nack->nack_pkt_id = htonl(value32);
+				changed = true;
+			}
+		} else if (tx) {
+			rc = nic_vpp_pdc_to_wire(vdata, ntohs(nack->spdcid),
+					     &value16);
+			if (rc)
+				return rc;
+			nack->spdcid = htons(value16);
+			changed = true;
+		} else {
+			rc = nic_vpp_pdc_from_wire(vdata, ntohs(nack->dpdcid),
+						&value16);
+			if (rc)
+				return rc;
+			nack->dpdcid = htons(value16);
+			changed = true;
+		}
+		break;
+	}
+	case UET_PDS_TYPE_CTRL: {
+		struct uet_pds_ctrl *control = (struct uet_pds_ctrl *)view.pds;
+
+		if (tx) {
+			rc = nic_vpp_pdc_to_wire(vdata,
+					     ntohs(control->spdcid), &value16);
+			if (rc)
+				return rc;
+			control->spdcid = htons(value16);
+			changed = true;
+		} else if (!(view.flags & UET_PDS_CTRL_FLAGS_SYN)) {
+			rc = nic_vpp_pdc_from_wire(vdata,
+						ntohs(control->dpdcid), &value16);
+			if (rc)
+				return rc;
+			control->dpdcid = htons(value16);
+			changed = true;
+		}
+		break;
+	}
+	case UET_PDS_TYPE_RUDI_REQ:
+		if (tx) {
+			struct uet_pds_rudi_req *rudi =
+				(struct uet_pds_rudi_req *)view.pds;
+
+			rc = nic_vpp_rudi_to_wire(vdata, ntohl(rudi->pkt_id),
+						&value32);
+			if (rc)
+				return rc;
+			rudi->pkt_id = htonl(value32);
+			changed = true;
+		}
+		break;
+	case UET_PDS_TYPE_RUDI_RESP:
+		if (!tx) {
+			struct uet_pds_rudi_req *rudi =
+				(struct uet_pds_rudi_req *)view.pds;
+
+			rc = nic_vpp_rudi_from_wire(vdata, ntohl(rudi->pkt_id),
+						&value32);
+			if (rc)
+				return rc;
+			rudi->pkt_id = htonl(value32);
+			changed = true;
+		}
+		break;
+	default:
+		break;
+	}
+
+	if (changed)
+		nic_vpp_update_crc(&view);
+	return 0;
+}
+
+static uint32_t nic_vpp_hash_mix(uint32_t hash, uint32_t value)
+{
+	hash ^= value + 0x9e3779b9U + (hash << 6) + (hash >> 2);
+	return hash;
+}
+
+static uint32_t nic_vpp_hash_finalize(uint32_t hash)
+{
+	hash ^= hash >> 16;
+	hash *= 0x7feb352dU;
+	hash ^= hash >> 15;
+	hash *= 0x846ca68bU;
+	return hash ^ (hash >> 16);
+}
+
+/*
+ * Select a stable worker channel from the fields normally used as network
+ * entropy.  Native UET places EV at the start of its entropy header; UDP uses
+ * the source port.  Keeping one EV on one channel avoids introducing packet
+ * reordering while allowing future per-endpoint/per-message EV selection to
+ * spread traffic across VPP workers.
+ */
+static size_t nic_vpp_select_channel(const struct vpp_data *vdata,
+				     const void *iphdr, size_t ip_length)
+{
+	const uint8_t *ip = iphdr;
+	const uint8_t *l4;
+	uint32_t hash = 0x811c9dc5U;
+	uint16_t entropy;
+	uint8_t protocol;
+	size_t l4_length;
+
+	if (vdata->channel_count == 1)
+		return 0;
+	if ((ip[0] >> 4) == 4) {
+		const struct iphdr *ipv4 = iphdr;
+		size_t header_length = ipv4->ihl << 2;
+
+		if (header_length > ip_length)
+			return 0;
+		hash = nic_vpp_hash_mix(hash, ntohl(ipv4->saddr));
+		hash = nic_vpp_hash_mix(hash, ntohl(ipv4->daddr));
+		protocol = ipv4->protocol;
+		l4 = ip + header_length;
+		l4_length = ip_length - header_length;
+	} else {
+		const struct ipv6hdr *ipv6 = iphdr;
+		uint32_t word;
+
+		if (ip_length < sizeof(*ipv6))
+			return 0;
+		for (size_t i = 0; i < sizeof(ipv6->saddr); i += sizeof(word)) {
+			memcpy(&word, (const uint8_t *)&ipv6->saddr + i,
+			       sizeof(word));
+			hash = nic_vpp_hash_mix(hash, ntohl(word));
+			memcpy(&word, (const uint8_t *)&ipv6->daddr + i,
+			       sizeof(word));
+			hash = nic_vpp_hash_mix(hash, ntohl(word));
+		}
+		protocol = ipv6->nexthdr;
+		l4 = ip + sizeof(*ipv6);
+		l4_length = ip_length - sizeof(*ipv6);
+	}
+
+	hash = nic_vpp_hash_mix(hash, protocol);
+	if (l4_length >= sizeof(entropy)) {
+		memcpy(&entropy, l4, sizeof(entropy));
+		hash = nic_vpp_hash_mix(hash, ntohs(entropy));
+	}
+	return nic_vpp_hash_finalize(hash) % vdata->channel_count;
+}
+
+int nic_vpp_getinfo(struct uet_nic *nic, struct uet_nic_info *nic_info)
+{
+	nic_info->ifname = nic->ifname;
+	nic_info->network_type = nic->network_type;
+	nic_info->mac_addr_str = nic->mac_addr_str;
+	nic_info->mtu = nic->mtu;
+	nic_info->link_state = UET_NIC_LINK_STATE_UP;
+	return 0;
+}
+
+static void nic_vpp_endpoint_init(uet_vpp_client_endpoint_t *endpoint,
+				  const struct uet_addr *addr,
+				  uint32_t job_id, bool absolute)
+{
+	*endpoint = (uet_vpp_client_endpoint_t) {
+		.ip_version = uet_addr_is_ipv6(addr) ? 6 : 4,
+		.absolute = absolute,
+		.pid_on_fep = addr->pid_on_fep,
+		.resource_index = addr->start_index,
+		.job_id = job_id,
+	};
+
+	if (endpoint->ip_version == 6)
+		memcpy(endpoint->ip_address, addr->fa.v6,
+		       sizeof(endpoint->ip_address));
+	else {
+		uint32_t address = htonl(addr->fa.v4);
+
+		memcpy(endpoint->ip_address, &address, sizeof(address));
+	}
+}
+
+int nic_vpp_configure_info(struct uet_nic *nic, struct fi_info *info)
+{
+	struct vpp_data *vdata;
+	struct uet_addr *addr;
+	uint32_t client_namespace;
+
+	if (!nic || !info || !info->src_addr ||
+	    info->src_addrlen != sizeof(*addr))
+		return -FI_EINVAL;
+	vdata = nic->nic_priv_data;
+	if (!vdata || !vdata->client)
+		return -FI_EOPBADSTATE;
+	client_namespace = vdata->info.client_namespace;
+	if (!client_namespace ||
+	    client_namespace > UET_VPP_CLIENT_NAMESPACE_MAX)
+		return -FI_EIO;
+
+	addr = info->src_addr;
+	addr->pid_on_fep = (uint16_t)client_namespace;
+	addr->initiator_id =
+		(client_namespace << UET_VPP_INITIATOR_LOCAL_BITS) |
+		(UET_ADDR_DEF_INITIATOR_ID & UET_VPP_INITIATOR_LOCAL_MASK);
+	addr->flags |= UET_ADDR_PID_ON_FEP_V | UET_ADDR_INITIATOR_V;
+	return FI_SUCCESS;
+}
+
+int nic_vpp_ep_register(struct uet_nic *nic, struct uet_ep *ep,
+			void **context)
+{
+	struct vpp_endpoint_registration *registration;
+	struct vpp_data *vdata;
+	int rc;
+
+	if (!nic || !ep || !context)
+		return -FI_EINVAL;
+	vdata = nic->nic_priv_data;
+	if (!vdata || !vdata->client)
+		return -FI_EOPBADSTATE;
+	registration = calloc(1, sizeof(*registration));
+	if (!registration)
+		return -FI_ENOMEM;
+	registration->vdata = vdata;
+	nic_vpp_endpoint_init(&registration->endpoint, &ep->uet_addr,
+			      ep->job_id, ep->absolute);
+	rc = uet_vpp_client_endpoint_add(vdata->client,
+					 &registration->endpoint);
+	if (rc) {
+		free(registration);
+		return rc == -EADDRINUSE ? -FI_EADDRINUSE : -FI_EIO;
+	}
+	*context = registration;
+	return FI_SUCCESS;
+}
+
+void nic_vpp_ep_unregister(struct uet_nic *nic, void *context)
+{
+	struct vpp_endpoint_registration *registration = context;
+	int rc;
+
+	(void)nic;
+	if (!registration)
+		return;
+	rc = uet_vpp_client_endpoint_del(registration->vdata->client,
+					 &registration->endpoint);
+	if (rc)
+		UET_API_ERR("failed to unregister VPP endpoint: %d", rc);
+	free(registration);
+}
+
+int nic_vpp_get_nh(struct uet_nic *nic, const struct uet_fa *fa,
+		   bool is_ipv6, uint8_t *mac)
+{
+	/* VPP owns FIB lookup, adjacency resolution and the Ethernet rewrite.
+	 * The existing transport still builds an Ethernet header, so give it a
+	 * stable placeholder which the VPP shim discards on transmit.
+	 */
+	(void)nic;
+	(void)fa;
+	(void)is_ipv6;
+	memset(mac, 0, ETH_ALEN);
+	mac[0] = 0x02;
+	mac[3] = 0x55;
+	mac[4] = 0x45;
+	mac[5] = 0x54;
+	return 0;
+}
+
+int nic_vpp_tx_pkt(struct uet_nic *nic, void *pkt, void *iphdr,
+		   size_t pkt_size)
+{
+	struct vpp_data *vdata = nic->nic_priv_data;
+	struct vpp_channel *channel;
+	uet_vpp_client_tx_request_t request;
+	uint8_t *packet = pkt;
+	uint8_t *ip = iphdr;
+	void *dma_data;
+	size_t channel_index;
+	size_t available, capacity, ip_length;
+	int rc;
+
+	if (!vdata || ip < packet || (size_t)(ip - packet) > pkt_size)
+		return -EINVAL;
+	available = pkt_size - (size_t)(ip - packet);
+	rc = nic_vpp_ip_length(ip, available, &ip_length);
+	if (rc)
+		return rc;
+	channel_index = nic_vpp_select_channel(vdata, ip, ip_length);
+	channel = &vdata->channels[channel_index];
+	rc = pthread_mutex_lock(&channel->lock);
+	if (rc)
+		return -rc;
+
+	for (;;) {
+		rc = uet_vpp_client_acquire_dma(channel->client,
+						channel->channel_index,
+						&request.dma_slot,
+						&dma_data, &capacity);
+		if (rc != -EAGAIN)
+			break;
+		rc = nic_vpp_progress_tx(channel);
+		if (rc < 0)
+			goto out_unlock;
+	}
+	if (rc)
+		goto out_unlock;
+	if (ip_length > capacity) {
+		uet_vpp_client_release_dma(channel->client,
+					   channel->channel_index,
+					   request.dma_slot);
+		rc = -EMSGSIZE;
+		goto out_unlock;
+	}
+
+	memcpy(dma_data, ip, ip_length);
+	rc = nic_vpp_translate_ids(nic, dma_data, ip_length, true);
+	if (rc) {
+		uet_vpp_client_release_dma(channel->client,
+					   channel->channel_index,
+					   request.dma_slot);
+		goto out_unlock;
+	}
+	request.packet_length = ip_length;
+	request.request_id = ++channel->next_request_id;
+	request.user_context = 0;
+	for (;;) {
+		rc = uet_vpp_client_submit_ip_batch(channel->client,
+						channel->channel_index,
+						&request, 1);
+		if (rc != -EAGAIN)
+			break;
+		rc = nic_vpp_progress_tx(channel);
+		if (rc < 0)
+			break;
+	}
+	if (rc) {
+		uet_vpp_client_release_dma(channel->client,
+					   channel->channel_index,
+					   request.dma_slot);
+		goto out_unlock;
+	}
+	channel->tx_inflight++;
+
+out_unlock:
+	pthread_mutex_unlock(&channel->lock);
+	return rc;
+}
+
+static int nic_vpp_rx_poll_locked(struct vpp_data *vdata)
+{
+	int lock_rc, rc;
+
+	if (vdata->pending_channel < vdata->channel_count)
+		return 1;
+
+	for (size_t i = 0; i < vdata->channel_count; i++) {
+		size_t index = (vdata->rx_cursor + i) % vdata->channel_count;
+		struct vpp_channel *channel = &vdata->channels[index];
+
+		lock_rc = pthread_mutex_lock(&channel->lock);
+		if (lock_rc)
+			return -lock_rc;
+		rc = nic_vpp_progress_tx(channel);
+		if (rc >= 0 && !channel->rx_pending) {
+			rc = uet_vpp_client_poll_rx(channel->client,
+						channel->channel_index,
+						&channel->pending_rx);
+			channel->rx_pending = rc == 1;
+		}
+		if (rc >= 0 && channel->rx_pending) {
+			vdata->pending_channel = index;
+			vdata->rx_cursor = (index + 1) % vdata->channel_count;
+			pthread_mutex_unlock(&channel->lock);
+			return 1;
+		}
+		pthread_mutex_unlock(&channel->lock);
+		if (rc < 0)
+			return rc;
+	}
+	return 0;
+}
+
+int nic_vpp_rx_poll(struct uet_nic *nic)
+{
+	struct vpp_data *vdata = nic->nic_priv_data;
+	int lock_rc, rc;
+
+	if (!vdata)
+		return -EINVAL;
+	lock_rc = pthread_mutex_lock(&vdata->rx_lock);
+	if (lock_rc)
+		return -lock_rc;
+	rc = nic_vpp_rx_poll_locked(vdata);
+	pthread_mutex_unlock(&vdata->rx_lock);
+	return rc;
+}
+
+int nic_vpp_rx_pkt(struct uet_nic *nic, void *pkt, size_t pkt_buf_size,
+		   size_t *rx_pkt_size)
+{
+	struct vpp_data *vdata = nic->nic_priv_data;
+	struct vpp_channel *channel;
+	struct ethhdr *eth = pkt;
+	size_t frame_length, offset = sizeof(*eth);
+	uint16_t i;
+	int lock_rc, rc;
+
+	if (!vdata)
+		return -EINVAL;
+	lock_rc = pthread_mutex_lock(&vdata->rx_lock);
+	if (lock_rc)
+		return -lock_rc;
+	if (vdata->pending_channel >= vdata->channel_count) {
+		rc = nic_vpp_rx_poll_locked(vdata);
+		if (rc <= 0)
+			goto out_unlock_rx;
+	}
+	channel = &vdata->channels[vdata->pending_channel];
+	lock_rc = pthread_mutex_lock(&channel->lock);
+	if (lock_rc) {
+		rc = -lock_rc;
+		goto out_unlock_rx;
+	}
+
+	frame_length = sizeof(*eth) + channel->pending_rx.packet_length;
+	if (frame_length < nic->min_pkt_size)
+		frame_length = nic->min_pkt_size;
+	if (frame_length > pkt_buf_size) {
+		rc = nic_vpp_release_pending_rx(vdata);
+		if (!rc)
+			rc = -EMSGSIZE;
+		goto out_unlock_channel;
+	}
+
+	memset(pkt, 0, frame_length);
+	memcpy(eth->h_dest, nic->mac_addr, ETH_ALEN);
+	eth->h_source[0] = 0x02;
+	eth->h_source[3] = 0x50;
+	eth->h_source[4] = 0x45;
+	eth->h_source[5] = 0x45;
+	eth->h_proto = htons((channel->pending_rx.flags &
+			      UET_VPP_CLIENT_RX_F_IP6) ?
+			     ETH_P_IPV6 : ETH_P_IP);
+	for (i = 0; i < channel->pending_rx.iov_count; i++) {
+		memcpy((uint8_t *)pkt + offset,
+		       channel->pending_rx.iov[i].base,
+		       channel->pending_rx.iov[i].length);
+		offset += channel->pending_rx.iov[i].length;
+	}
+	rc = nic_vpp_translate_ids(nic, (uint8_t *)pkt + sizeof(*eth),
+				   channel->pending_rx.packet_length, false);
+	if (rc) {
+		int release_rc = nic_vpp_release_pending_rx(vdata);
+
+		if (release_rc)
+			rc = release_rc;
+		goto out_unlock_channel;
+	}
+
+	rc = nic_vpp_release_pending_rx(vdata);
+	if (!rc) {
+		*rx_pkt_size = frame_length;
+		rc = 1;
+	}
+
+out_unlock_channel:
+	pthread_mutex_unlock(&channel->lock);
+out_unlock_rx:
+	pthread_mutex_unlock(&vdata->rx_lock);
+	return rc;
+}
+
+static int nic_vpp_discard_rx(struct vpp_channel *channel)
+{
+	int rc;
+
+	if (!channel->rx_pending) {
+		rc = uet_vpp_client_poll_rx(channel->client,
+					    channel->channel_index,
+					    &channel->pending_rx);
+		if (rc <= 0)
+			return rc;
+		channel->rx_pending = true;
+	}
+	rc = uet_vpp_client_release_rx(channel->client,
+				       channel->channel_index,
+				       &channel->pending_rx);
+	if (!rc)
+		channel->rx_pending = false;
+	return rc ? rc : 1;
+}
+
+void nic_vpp_finalize(struct uet_nic *nic)
+{
+	struct vpp_data *vdata = nic->nic_priv_data;
+	uint64_t deadline = 0, now = 0;
+	int drain_error = 0;
+	int close_error = 0;
+	bool timed = true;
+
+	if (!vdata)
+		return;
+	if (nic_vpp_monotonic_ns(&now)) {
+		timed = false;
+		drain_error = -EIO;
+	} else {
+		deadline = now + UET_VPP_CLOSE_TIMEOUT_NS;
+	}
+	while (timed && vdata->client && vdata->dma_mapped) {
+		bool drained = true;
+		bool progressed = false;
+
+		for (size_t i = 0; i < vdata->channel_count; i++) {
+			struct vpp_channel *channel = &vdata->channels[i];
+			int completion_error = 0;
+			int rx_rc, tx_rc;
+
+			tx_rc = nic_vpp_poll_tx(channel, &completion_error);
+			if (tx_rc < 0) {
+				if (!drain_error)
+					drain_error = tx_rc;
+				timed = false;
+				break;
+			}
+			progressed |= tx_rc > 0;
+			if (completion_error && !drain_error)
+				drain_error = completion_error;
+
+			rx_rc = nic_vpp_discard_rx(channel);
+			if (rx_rc < 0 && rx_rc != -EAGAIN) {
+				if (!drain_error)
+					drain_error = rx_rc;
+				timed = false;
+				break;
+			}
+			progressed |= rx_rc > 0;
+			drained &= !channel->tx_inflight &&
+				   !channel->rx_pending && rx_rc == 0;
+		}
+
+		if (!timed)
+			break;
+		if (drained) {
+			close_error = uet_vpp_client_close(vdata->client);
+			if (!close_error) {
+				vdata->client = NULL;
+				break;
+			}
+			if (close_error != -EBUSY)
+				break;
+		}
+		if (nic_vpp_monotonic_ns(&now)) {
+			if (!drain_error)
+				drain_error = -EIO;
+			break;
+		}
+		if (now >= deadline)
+			break;
+		if (!progressed)
+			usleep(50);
+	}
+	if (vdata->client) {
+		close_error = uet_vpp_client_close(vdata->client);
+		if (!close_error)
+			vdata->client = NULL;
+	}
+	if (close_error)
+		UET_API_ERR("VPP client close failed: %d", close_error);
+	if (drain_error)
+		UET_API_ERR("VPP channel-set drain failed: %d", drain_error);
+	for (size_t i = 0; i < vdata->channel_count; i++)
+		if (vdata->channels[i].lock_initialized)
+			pthread_mutex_destroy(&vdata->channels[i].lock);
+	if (vdata->rx_lock_initialized)
+		pthread_mutex_destroy(&vdata->rx_lock);
+	free(vdata->channels);
+	free(vdata);
+	nic->nic_priv_data = NULL;
+}
+
+static int nic_vpp_configure_mtu(struct uet_nic *nic,
+				 struct vpp_data *vdata)
+{
+	const char *text = getenv(UET_VPP_MTU);
+	unsigned long long mtu = UET_VPP_DEFAULT_MTU;
+	char *end = NULL;
+
+	if (text) {
+		errno = 0;
+		mtu = strtoull(text, &end, 10);
+		if (errno || end == text || *end != '\0' || text[0] == '-')
+			return -EINVAL;
+	}
+	if (mtu < nic->min_ip_pkt_size ||
+	    mtu > vdata->info.dma_buffer_data_size)
+		return -ERANGE;
+	nic->mtu = (size_t)mtu;
+	nic->max_pkt_size = nic->mtu + nic->l2_hdr_size;
+	return 0;
+}
+
+static int nic_vpp_parse_addresses(struct uet_nic *nic)
+{
+	const char *ipv4_text = getenv(UET_VPP_IPV4_ADDR);
+	const char *ipv6_text = getenv(UET_VPP_IPV6_ADDR);
+	struct in_addr ipv4;
+
+	if (ipv4_text) {
+		if (inet_pton(AF_INET, ipv4_text, &ipv4) != 1)
+			return -EINVAL;
+		nic->ipv4_addr = ntohl(ipv4.s_addr);
+		snprintf(nic->ipv4_addr_str, sizeof(nic->ipv4_addr_str),
+			 "%s", ipv4_text);
+		nic->has_ipv4 = true;
+	}
+	if (ipv6_text) {
+		if (inet_pton(AF_INET6, ipv6_text, nic->ipv6_addr) != 1)
+			return -EINVAL;
+		snprintf(nic->ipv6_addr_str, sizeof(nic->ipv6_addr_str),
+			 "%s", ipv6_text);
+		nic->has_ipv6 = true;
+	}
+	return (nic->has_ipv4 || nic->has_ipv6) ? 0 : -EINVAL;
+}
+
+static void nic_vpp_initialize_cleanup(struct vpp_data *vdata)
+{
+	if (!vdata)
+		return;
+	for (size_t i = 0; i < vdata->channel_count; i++) {
+		struct vpp_channel *channel = &vdata->channels[i];
+
+		if (channel->lock_initialized)
+			pthread_mutex_destroy(&channel->lock);
+	}
+	if (vdata->client)
+		uet_vpp_client_close(vdata->client);
+	if (vdata->rx_lock_initialized)
+		pthread_mutex_destroy(&vdata->rx_lock);
+	free(vdata->channels);
+	free(vdata);
+}
+
+int nic_vpp_initialize(struct uet_nic *nic)
+{
+	const char *segment_name = getenv(UET_VPP_SEGMENT);
+	const char *dma_socket = getenv(UET_VPP_DMA_SOCKET);
+	const char *ifname = getenv(UET_IFNAME);
+	const char *pds = getenv(UET_PDS);
+	struct vpp_data *vdata;
+	int rc;
+
+	if (!segment_name || !dma_socket) {
+		UET_API_ERR("%s and %s are required for the VPP shim",
+			    UET_VPP_SEGMENT, UET_VPP_DMA_SOCKET);
+		return -EINVAL;
+	}
+	vdata = calloc(1, sizeof(*vdata));
+	if (!vdata)
+		return -ENOMEM;
+	vdata->pds_sng = !pds || strcmp(pds, "sng") == 0;
+	atomic_init(&vdata->rudi_last_sequence_plus_one, 0);
+	vdata->pending_channel = SIZE_MAX;
+	rc = uet_vpp_client_open(&vdata->client, segment_name,
+				 &vdata->info);
+	if (rc) {
+		UET_API_ERR("could not open VPP channel-set %s: %d",
+			    segment_name, rc);
+		goto err_cleanup;
+	}
+	rc = uet_vpp_client_set_pds_sng(vdata->client, vdata->pds_sng);
+	if (rc)
+		goto err_cleanup;
+	if (!vdata->info.channel_count ||
+	    vdata->info.channel_count > UET_VPP_MAX_CHANNELS) {
+		rc = -EPROTO;
+		goto err_cleanup;
+	}
+	vdata->channel_count = vdata->info.channel_count;
+	if (!vdata->info.client_namespace ||
+	    vdata->info.client_namespace > UET_VPP_CLIENT_NAMESPACE_MAX) {
+		rc = -EPROTO;
+		goto err_cleanup;
+	}
+	rc = uet_vpp_client_map_dma(vdata->client, dma_socket);
+	if (rc)
+		goto err_cleanup;
+	vdata->dma_mapped = true;
+	rc = posix_memalign((void **)&vdata->channels,
+			    UET_VPP_CHANNEL_ALIGNMENT,
+			    vdata->channel_count * sizeof(*vdata->channels));
+	if (rc) {
+		rc = rc == ENOMEM ? -ENOMEM : -EINVAL;
+		goto err_cleanup;
+	}
+	memset(vdata->channels, 0,
+	       vdata->channel_count * sizeof(*vdata->channels));
+	rc = pthread_mutex_init(&vdata->rx_lock, NULL);
+	if (rc)
+		goto err_cleanup;
+	vdata->rx_lock_initialized = true;
+	for (size_t i = 0; i < vdata->channel_count; i++) {
+		struct vpp_channel *channel = &vdata->channels[i];
+
+		rc = pthread_mutex_init(&channel->lock, NULL);
+		if (rc)
+			goto err_cleanup;
+		channel->lock_initialized = true;
+		channel->client = vdata->client;
+		channel->channel_index = (uint32_t)i;
+		channel->next_request_id = (uint64_t)i << 56;
+	}
+
+	nic->nic_priv_data = vdata;
+	nic->min_pkt_size = UET_MIN_PKT_SIZE;
+	nic->l2_hdr_size = sizeof(struct ethhdr);
+	nic->min_ip_pkt_size = nic->min_pkt_size - nic->l2_hdr_size;
+	rc = nic_vpp_configure_mtu(nic, vdata);
+	if (rc) {
+		UET_API_ERR("%s must be between %zu and %u (default %u)",
+			    UET_VPP_MTU, nic->min_ip_pkt_size,
+			    vdata->info.dma_buffer_data_size,
+			    UET_VPP_DEFAULT_MTU);
+		goto err_finalize;
+	}
+	nic->sock_fd = -1;
+	snprintf(nic->network_type, sizeof(nic->network_type), "%s",
+		 UET_NETWORK_TYPE_VPP);
+	snprintf(nic->ifname, sizeof(nic->ifname), "%s",
+		 ifname ? ifname : "vpp0");
+	nic->mac_addr[0] = 0x02;
+	nic->mac_addr[3] = 0x55;
+	nic->mac_addr[4] = 0x45;
+	nic->mac_addr[5] = 0x54;
+	uet_mac_addr_to_str(nic->mac_addr_str, nic->mac_addr);
+	rc = nic_vpp_parse_addresses(nic);
+	if (rc) {
+		UET_API_ERR("set %s and/or %s for the VPP shim",
+			    UET_VPP_IPV4_ADDR, UET_VPP_IPV6_ADDR);
+		goto err_finalize;
+	}
+	return 0;
+
+err_finalize:
+	nic_vpp_finalize(nic);
+	return rc;
+err_cleanup:
+	if (rc > 0)
+		rc = -rc;
+	nic_vpp_initialize_cleanup(vdata);
+	return rc;
+}
+
+#endif /* ENABLE_VPP */

--- a/nic_shim/uet_nic.c
+++ b/nic_shim/uet_nic.c
@@ -349,6 +349,26 @@ extern void nic_xdp_finalize(struct uet_nic *nic);
 extern int nic_xdp_initialize(struct uet_nic *nic);
 #endif
 
+#if ENABLE_VPP
+/* VPP NIC protocol callbacks remain private to the shim implementation. */
+extern int nic_vpp_getinfo(struct uet_nic *nic,
+			   struct uet_nic_info *nic_info);
+extern int nic_vpp_configure_info(struct uet_nic *nic,
+				  struct fi_info *info);
+extern int nic_vpp_ep_register(struct uet_nic *nic,
+			       struct uet_ep *ep, void **context);
+extern void nic_vpp_ep_unregister(struct uet_nic *nic, void *context);
+extern int nic_vpp_get_nh(struct uet_nic *nic, const struct uet_fa *fa,
+			  bool is_ipv6, uint8_t *mac);
+extern int nic_vpp_tx_pkt(struct uet_nic *nic, void *pkt, void *iphdr,
+			  size_t pkt_size);
+extern int nic_vpp_rx_pkt(struct uet_nic *nic, void *pkt,
+			  size_t pkt_buf_size, size_t *rx_pkt_size);
+extern int nic_vpp_rx_poll(struct uet_nic *nic);
+extern void nic_vpp_finalize(struct uet_nic *nic);
+extern int nic_vpp_initialize(struct uet_nic *nic);
+#endif
+
 /* init nic resources */
 int uet_nic_initialize(struct uet_nic *nic)
 {
@@ -357,7 +377,11 @@ int uet_nic_initialize(struct uet_nic *nic)
 	/* get interface name from environment variable */
 	nic_shim = getenv(UET_NIC_SHIM);
 
-#if ENABLE_XDP
+#if ENABLE_VPP
+	/* The dedicated VPP build uses VPP unless explicitly overridden. */
+	if (nic_shim == NULL)
+		nic_shim = "vpp";
+#elif ENABLE_XDP
 	/* for an XDP build, make its shim the default */
 	if (nic_shim == NULL)
 		nic_shim = "xdp";
@@ -378,6 +402,19 @@ int uet_nic_initialize(struct uet_nic *nic)
 		nic->nic_rx_poll     = nic_xdp_rx_poll;
 		nic->nic_finalize    = nic_xdp_finalize;
 		nic->nic_initialize  = nic_xdp_initialize;
+#endif
+#if ENABLE_VPP
+	} else if (strcmp(nic_shim, "vpp") == 0) {
+		nic->nic_getinfo       = nic_vpp_getinfo;
+		nic->nic_configure_info = nic_vpp_configure_info;
+		nic->nic_ep_register   = nic_vpp_ep_register;
+		nic->nic_ep_unregister = nic_vpp_ep_unregister;
+		nic->nic_get_nh        = nic_vpp_get_nh;
+		nic->nic_tx_pkt        = nic_vpp_tx_pkt;
+		nic->nic_rx_pkt        = nic_vpp_rx_pkt;
+		nic->nic_rx_poll       = nic_vpp_rx_poll;
+		nic->nic_finalize      = nic_vpp_finalize;
+		nic->nic_initialize    = nic_vpp_initialize;
 #endif
 	} else {
 		UET_API_ERR("invalid UET_NIC_SHIM environment variable");

--- a/nic_shim/uet_nic.h
+++ b/nic_shim/uet_nic.h
@@ -23,6 +23,11 @@
 /* environment variables to control the NIC interface */
 #define UET_NIC_SHIM  "UET_NIC_SHIM"
 #define UET_IFNAME    "UET_IFNAME"
+#define UET_VPP_SEGMENT     "UET_VPP_SEGMENT"
+#define UET_VPP_DMA_SOCKET  "UET_VPP_DMA_SOCKET"
+#define UET_VPP_IPV4_ADDR   "UET_VPP_IPV4_ADDR"
+#define UET_VPP_IPV6_ADDR   "UET_VPP_IPV6_ADDR"
+#define UET_VPP_MTU         "UET_VPP_MTU"
 
 #define UET_MAX_SYS_CMD_OCTETS  256
 #define UET_NET_TYPE_SIZE 32
@@ -31,6 +36,8 @@
 
 struct uet_mr_buf_desc;
 struct uet_instance;
+struct uet_ep;
+struct fi_info;
 
 enum uet_nic_link_state {
 	UET_NIC_LINK_STATE_UNKNOWN = 0,
@@ -83,6 +90,16 @@ struct uet_nic {
 	/* function pointers supporting different NIC interfaces */
 	int (*nic_getinfo)(struct uet_nic *nic,
 			   struct uet_nic_info *nic_info);
+	int (*nic_configure_info)(struct uet_nic *nic,
+				  struct fi_info *info);
+	int (*nic_ep_register)(struct uet_nic *nic,
+			       struct uet_ep *ep,
+			       void **context);
+	void (*nic_ep_unregister)(struct uet_nic *nic, void *context);
+	int (*nic_get_nh)(struct uet_nic *nic,
+			  const struct uet_fa *fa,
+			  bool is_ipv6,
+			  uint8_t *mac);
 	int (*nic_tx_pkt)(struct uet_nic *nic,
 			  void *pkt,
 			  void *iphdr,
@@ -211,6 +228,40 @@ static inline void uet_nic_finalize(struct uet_nic *nic)
 int uet_nic_getinfo(struct uet_nic *nic,
 		    struct uet_nic_info *nic_info);
 
+static inline int uet_nic_configure_info(struct uet_nic *nic,
+					 struct fi_info *info)
+{
+	if (!nic || !info)
+		assert(0);
+
+	if (!nic->nic_configure_info)
+		return 0;
+	return nic->nic_configure_info(nic, info);
+}
+
+static inline int uet_nic_ep_register(struct uet_nic *nic,
+				      struct uet_ep *ep,
+				      void **context)
+{
+	if (!nic || !ep || !context)
+		assert(0);
+
+	if (!nic->nic_ep_register)
+		return 0;
+	return nic->nic_ep_register(nic, ep, context);
+}
+
+static inline void uet_nic_ep_unregister(struct uet_nic *nic, void *context)
+{
+	if (!nic)
+		assert(0);
+	if (!context)
+		return;
+
+	if (nic->nic_ep_unregister)
+		nic->nic_ep_unregister(nic, context);
+}
+
 /*
  * get next-hop info for ipv4 destination address
  *
@@ -276,6 +327,8 @@ static inline int uet_nic_get_nh(struct uet_nic *nic,
 	if (!nic || !fa || !mac)
 		assert(0);
 
+	if (nic->nic_get_nh)
+		return nic->nic_get_nh(nic, fa, is_ipv6, mac);
 	if (is_ipv6)
 		return uet_nic_get_ipv6_nh(nic, fa->v6, mac);
 	else

--- a/uet_api.c
+++ b/uet_api.c
@@ -1913,6 +1913,10 @@ static void uet_ep_free(struct uet_ep *uet_ep)
 {
 	struct dlist_entry *item;
 	struct uet_pds *pds = &uet_ep->uet_domain->uet->pds;
+	struct uet_nic *nic = UET_NIC(uet_ep->uet_domain->uet);
+
+	uet_nic_ep_unregister(nic, uet_ep->nic_ep_context);
+	uet_ep->nic_ep_context = NULL;
 
 	uet_rx_msg_hash_finalize(uet_ep);
 	uet_tag_initiator_hash_finalize(uet_ep);
@@ -2046,8 +2050,8 @@ static void uet_finalize_core(struct uet_instance *uet)
 	uet_sec_finalize();
 	uet_ep_hash_finalize(uet);
 	imp_shim_finalize();
-	uet_nic_finalize(UET_NIC(uet));
 	uet_domain_free_all(uet);
+	uet_nic_finalize(UET_NIC(uet));
 	uet->pds.downcall.finalize(uet);
 }
 
@@ -6004,6 +6008,12 @@ int uet_getinfo(uet_handle_t handle, struct uet_addr *node,
 	new_info->src_addrlen = sizeof(struct uet_addr);
 	new_info->src_addr = src_addr;
 
+	rc = uet_nic_configure_info(UET_NIC(uet), new_info);
+	if (rc != FI_SUCCESS) {
+		UET_API_ERR("uet_nic_configure_info");
+		goto err_return;
+	}
+
 	new_info->nic = nic;
 
 	*info = new_info;
@@ -6251,6 +6261,12 @@ int uet_endpoint(uet_domain_handle_t domain_handle,
 	uet_ep->context = context;
 	uet_ep->send_cq.cq_state = UET_CQ_DOWN;
 	uet_ep->recv_cq.cq_state = UET_CQ_DOWN;
+	rc = uet_nic_ep_register(UET_NIC(uet_dom->uet), uet_ep,
+				 &uet_ep->nic_ep_context);
+	if (rc != FI_SUCCESS) {
+		UET_API_ERR("uet_nic_ep_register");
+		goto err_exit;
+	}
 
 	if (uet_ep->uet_addr.flags & UET_ADDR_IPV6)
 		uet_ep->ep_key.ipv6_addr = true;
@@ -6282,6 +6298,9 @@ int uet_endpoint(uet_domain_handle_t domain_handle,
 
 err_exit:
 	if (uet_ep) {
+		uet_nic_ep_unregister(UET_NIC(uet_dom->uet),
+				      uet_ep->nic_ep_context);
+		uet_ep->nic_ep_context = NULL;
 		uet_desc_free(uet_ep);
 		free(uet_ep);
 	}

--- a/uet_api_private.h
+++ b/uet_api_private.h
@@ -628,6 +628,7 @@ struct uet_ep {
 		  /* head of list containing mr's with provider-assigned keys */
 	struct dlist_entry mr_list_head;
 	void *pds;                                               /* pds state */
+	void *nic_ep_context;                   /* optional NIC endpoint state */
 	uint32_t job_id;                                /* ses job identifier */
 	uint16_t entropy;             /* stable endpoint entropy value (EV) */
 	bool absolute;       /* endpoint uses absolute addressing (any JobID) */


### PR DESCRIPTION
This is the focused VPP NIC-shim contribution split out of #143 at the maintainer's request.

## Scope

- add the `vpp` NIC implementation used by the existing UET transport;
- add an optional `make vpp` build producing `libvppuet.so` and `uet_vpp`;
- let VPP own FIB lookup, adjacency resolution and packet I/O;
- translate the process namespace only at the NIC boundary;
- register and unregister endpoint identities through the NIC lifecycle; and
- document VPP beside the existing `rawsock` and `xdp` backends.

The review feedback about NIC transparency is incorporated: VPP functions are no longer declared in the common header and there are no `uet_fi_backend_*` symbols. Configuration, next-hop behavior and endpoint lifecycle use optional function pointers in `struct uet_nic`; raw-socket and AF_XDP leave those callbacks null and retain their current behavior.

## Dependencies

- #155, now merged, supplies the VPP plugin and `libuet_vpp_client`.
- #156, now merged, preserves the process identity assigned by the VPP client during software address resolution.
- #154, now merged, provides endpoint-derived transport entropy.
- #153 independently supplies the multi-endpoint software identity behavior used for scaling.

## Deliberately excluded

- the entire `libfabric-provider/` directory and its documentation;
- provider-specific tests and `fi_pingpong` setup;
- GitHub workflow changes; and
- the implementation of the VPP plugin/client itself.

The normal raw-socket/verbs build does not enable or link VPP. The VPP target is explicit and currently builds the existing transport through its libfabric-style frontend (`ENABLE_VERBS=0`). A future Verbs+VPP target can reuse the generic NIC callbacks introduced here, but requires a separately reviewed Verbs build/frontend selection rather than changing this focused shim PR.

## Validation

The branch was rebuilt on the current `main` after #148, #149, #154, #155 and #156 were merged. On a dedicated Linux test host, against VPP `v26.10-rc0~318-ga4b80adfc` and libfabric 1.20.1:

- the normal, `strict-core`, VPP plugin/client and `make vpp` builds pass;
- the non-root one-worker smoke test passes; and
- the non-root two-worker/two-process test passes routed IPv4/IPv6 native/UDP TX, endpoint collision handling and exact endpoint RX demultiplexing.
