### PR TITLE
api: memory regions for device-model use (page lists, segments)

### DIFF
--- a/uet.c
+++ b/uet.c
@@ -130,7 +130,31 @@ void UET_USAGE(char *cmd)
 	         "    UET_FORCE_RUDI=1  force RUDI (reliable unordered, idempotent)\n"
 	         "                      on the 'rma' command\n"
 	         "    UET_FORCE_UUD=1   force UUD (unreliable datagram, best-effort)\n"
-	         "                      on the 'uud' command\n",
+	         "                      on the 'uud' command\n"
+	         "\n"
+	         "  Memory region overrides (env vars):\n"
+	         "    UET_MR_IOV=<n>    register the RMA memory region as <n>\n"
+	         "                      iovec entries (uet_mr_regv) instead of\n"
+	         "                      one contiguous region. Same bytes, same\n"
+	         "                      order - exercises UET_MR_BUF_TYPE_IOV.\n"
+	         "                      Applies to rma/sync_rma/atomic tests.\n"
+	         "    UET_MR_PBL=<sz>   register the RMA memory region as a page\n"
+	         "                      buffer list with <sz> byte pages, as a\n"
+	         "                      device driver would. Same bytes, same\n"
+	         "                      order. Takes precedence over UET_MR_IOV.\n"
+	         "    UET_MR_PBL_LEVEL=<n> PBL level: 0 contiguous, 1 one-level\n"
+	         "                      page directory (default), 2 two-level.\n"
+	         "    UET_MR_PBL_OFFSET=<n> start the region <n> bytes into its\n"
+	         "                      first page, as an unaligned base VA\n"
+	         "                      does. Must be less than the page size.\n"
+	         "    UET_LOCAL_SEG=<n> describe the LOCAL rma buffer as <n>\n"
+	         "                      segments naming memory regions rather\n"
+	         "                      than as a process address, using the\n"
+	         "                      uet_*seg apis.\n"
+	         "    UET_LOCAL_SEG_MRS=<m> spread those segments over <m>\n"
+	         "                      distinct regions, so one operation\n"
+	         "                      crosses several lkeys as a multi-SGE\n"
+	         "                      work request does.\n",
 	         cmd);
 }
 
@@ -149,6 +173,27 @@ struct uet_cfg {
 	bool unexpected_msg_test;  /* true => this is unexpected message test */
 	bool dsend_test;                        /* true => this is dsend test */
 	bool iov_test;                               /* true => test uses iov */
+	         /* When > 1, the RMA memory region is registered with        */
+	         /* uet_mr_regv() as this many iovec entries carved from the  */
+	         /* same buffer, exercising UET_MR_BUF_TYPE_IOV. 0 or 1 keeps */
+	         /* the contiguous registration. Set via UET_MR_IOV.          */
+	size_t mr_iov_count;
+	         /* When non-zero, the RMA memory region is registered with   */
+	         /* uet_mr_reg_pbl() using this page size. Set via UET_MR_PBL.*/
+	size_t mr_pbl_page_size;
+	int mr_pbl_level;              /* PBL level, set via UET_MR_PBL_LEVEL */
+	         /* Offset of the region within its first page, exercising    */
+	         /* the unaligned base VA a real driver may see. Set via      */
+	         /* UET_MR_PBL_OFFSET.                                        */
+	size_t mr_pbl_page_offset;
+	         /* When > 0, rma operations describe their LOCAL buffer as   */
+	         /* this many segments over memory regions instead of as a    */
+	         /* process address. Set via UET_LOCAL_SEG.                   */
+	size_t local_seg_count;
+	         /* Spread those segments across this many distinct regions,  */
+	         /* which is the multi-lkey case a single-region design       */
+	         /* cannot express. Set via UET_LOCAL_SEG_MRS.                */
+	size_t local_seg_mrs;
 	int num_iterations;                 /* number of messages to exchange */
 	size_t msg_size;                         /* size of messages in bytes */
 	char *peer_ip_addr_string;             /* peer ip addr in string form */
@@ -192,7 +237,23 @@ struct uet_context {
 	uint8_t tx_count;
 	struct iovec *rx_iov;
 	uint8_t rx_count;
-	uet_mr_handle_t mr_handle;           /*handle for local memory region */
+	uet_mr_handle_t mr_handle;          /* handle for local memory region */
+	uet_dma_addr_t *pbl_root;      /* page dir (L-1) or dir of dirs (L-2) */
+	uet_dma_addr_t **pbl_mid;                   /* L-2 middle directories */
+	size_t pbl_mid_cnt;
+	        /* The region's pages, individually allocated and mapped to   */
+	        /* region page N in a deliberately permuted order, so that a  */
+	        /* wrong page index yields wrong data rather than the right   */
+	        /* bytes by accident.                                         */
+	uint8_t **pbl_pages;
+	size_t pbl_page_cnt;
+	uint8_t *pbl_base;                       /* L-0 the single allocation */
+	        /* local buffer expressed as segments, and the extra regions  */
+	        /* those segments name when more than one is asked for        */
+	struct uet_mr_seg *local_seg;
+	size_t local_seg_count;
+	uet_mr_handle_t *extra_mr;
+	size_t extra_mr_cnt;
 	/* buf addr and key for memory regions */
 	struct uet_mem_region_info local_mr, remote_mr;
 };
@@ -289,6 +350,51 @@ static void uet_free_res(struct uet_context *ctx)
 		ctx->rx_msg = NULL;
 	}
 
+	if (ctx->local_seg) {
+		free(ctx->local_seg);
+		ctx->local_seg = NULL;
+		ctx->local_seg_count = 0;
+	}
+
+	if (ctx->extra_mr) {
+		free(ctx->extra_mr);
+		ctx->extra_mr = NULL;
+		ctx->extra_mr_cnt = 0;
+	}
+
+	if (ctx->pbl_mid) {
+		size_t i;
+
+		for (i = 0; i < ctx->pbl_mid_cnt; i++)
+			free(ctx->pbl_mid[i]);
+
+		free(ctx->pbl_mid);
+		ctx->pbl_mid = NULL;
+		ctx->pbl_mid_cnt = 0;
+	}
+
+	if (ctx->pbl_root) {
+		free(ctx->pbl_root);
+		ctx->pbl_root = NULL;
+	}
+
+	if (ctx->pbl_pages) {
+		size_t i;
+
+		for (i = 0; i < ctx->pbl_page_cnt; i++)
+			free(ctx->pbl_pages[i]);
+
+		free(ctx->pbl_pages);
+		ctx->pbl_pages = NULL;
+		ctx->pbl_page_cnt = 0;
+	}
+
+	if (ctx->pbl_base) {
+		free(ctx->pbl_base);
+		ctx->pbl_base = NULL;
+		ctx->mr_buf = NULL;
+	}
+
 	if (ctx->mr_buf) {
 		free(ctx->mr_buf);
 		ctx->mr_buf = NULL;
@@ -351,6 +457,66 @@ static uet_rc_t uet_init_cfg(int argc, char *argv[],
 	 * message size is capped to a single packet.
 	 */
 	ctx->cfg.uud = (getenv("UET_FORCE_UUD") != NULL);
+
+	/* When UET_MR_IOV=<n> is set with n > 1, the RMA memory region is
+	 * registered with uet_mr_regv() as n iovec entries carved from the
+	 * same buffer instead of one contiguous region.
+	 */
+	{
+		const char *mr_iov = getenv("UET_MR_IOV");
+
+		ctx->cfg.mr_iov_count =
+			(mr_iov != NULL) ?
+				(size_t)strtoul(mr_iov, NULL, 0) :
+				0;
+	}
+
+	/* When UET_MR_PBL=<page_size> is set, the RMA memory region is
+	 * registered with uet_mr_reg_pbl() as a page buffer list. The pages
+	 * are separately allocated and deliberately permuted, so a resolver
+	 * that computes the wrong page index returns the wrong bytes rather
+	 * than accidentally-correct adjacent ones.
+	 */
+	{
+		const char *pbl = getenv("UET_MR_PBL");
+		const char *lvl = getenv("UET_MR_PBL_LEVEL");
+		const char *po  = getenv("UET_MR_PBL_OFFSET");
+
+		ctx->cfg.mr_pbl_page_size =
+			(pbl != NULL) ?
+				(size_t)strtoul(pbl, NULL, 0) :
+				0;
+
+		ctx->cfg.mr_pbl_level =
+			(lvl != NULL) ?
+				(int)strtol(lvl, NULL, 0) :
+				UET_PBL_LEVEL_1;
+
+		ctx->cfg.mr_pbl_page_offset =
+			(po != NULL) ?
+				(size_t)strtoul(po, NULL, 0) :
+				0;
+	}
+
+	/* When UET_LOCAL_SEG=<n> is set, rma operations describe their local
+	 * buffer as n segments naming memory regions, rather than as a
+	 * process address. UET_LOCAL_SEG_MRS=<m> spreads those segments over
+	 * m distinct regions, so one operation crosses several lkeys.
+	 */
+	{
+		const char *ls = getenv("UET_LOCAL_SEG");
+		const char *lm = getenv("UET_LOCAL_SEG_MRS");
+
+		ctx->cfg.local_seg_count =
+			(ls != NULL) ?
+				(size_t)strtoul(ls, NULL, 0) :
+				0;
+
+		ctx->cfg.local_seg_mrs =
+			(lm != NULL) ?
+				(size_t)strtoul(lm, NULL, 0) :
+				1;
+	}
 
 	if (argc == 4) {
 		if (strcmp(argv[2], "tag") != 0) {
@@ -469,13 +635,54 @@ static void uet_init_iov_buf(size_t size, uint8_t *buf)
 }
 
 
+/*
+ * Move the region's contents between the linear shadow buffer and the
+ * scattered pages the page list actually describes.
+ *
+ * When the pages are separately allocated and permuted, mr_buf is no longer
+ * the region - it is only a linear image of it, used to lay down the test
+ * pattern and to verify what came back. Everything the provider touches
+ * goes through the pages.
+ */
+static void uet_pbl_sync(struct uet_context *ctx, bool to_pages)
+{
+	size_t ps = ctx->cfg.mr_pbl_page_size;
+	size_t off = ctx->cfg.mr_pbl_page_offset;
+	size_t done = 0;
+
+	if (ctx->pbl_pages == NULL)
+		return; /* level 0: the region is mr_buf itself */
+
+	while (done < ctx->cfg.msg_size) {
+		size_t abs = (off + done);
+		size_t run = (ps - (abs % ps));
+		uint8_t *p = (ctx->pbl_pages[abs / ps] + (abs % ps));
+
+		if (run > (ctx->cfg.msg_size - done))
+			run = (ctx->cfg.msg_size - done);
+
+		if (to_pages)
+			memcpy(p, (ctx->mr_buf + done), run);
+		else
+			memcpy((ctx->mr_buf + done), p, run);
+
+		done += run;
+	}
+}
+
 /* validate message buffer contents */
 static uet_rc_t uet_validate_msg(struct uet_context *ctx, uint8_t *buf)
 {
 	size_t i;
 
+	/* The rma target is the page list, not this buffer, refresh the
+	 * linear image from the pages before checking it.
+	 */
+	if (buf == ctx->mr_buf)
+		uet_pbl_sync(ctx, false);
+
 	for (i = 0; i < ctx->cfg.msg_size; i++) {
-		if (buf[i] != (uint8_t) i)
+		if (buf[i] != (uint8_t)i)
 			return UET_ERR_RC;
 	}
 
@@ -640,16 +847,217 @@ static uet_rc_t uet_init_transport(struct uet_context *ctx)
 		 * IDEMPOTENT_SAFE. The provider still assigns the key but
 		 * preserves this flag.
 		 */
-		ret = uet_mr_reg(ctx->domain_handle, ctx->mr_buf,
-				 ctx->cfg.msg_size,
-				 FI_WRITE | FI_REMOTE_WRITE |
-				 FI_READ  | FI_REMOTE_READ | FI_ATOMIC,
-				 ctx->cfg.rudi ? UET_MR_KEY_IDEMPOTENT_SAFE :
-						 UET_MR_KEY_NONE,
-				 UET_FLAGS_NONE, context,
-				 &ctx->mr_handle);
+
+		if (ctx->cfg.mr_pbl_page_size > 0) {
+			size_t ps = ctx->cfg.mr_pbl_page_size;
+			size_t po = ctx->cfg.mr_pbl_page_offset;
+			size_t npages = (po + ctx->cfg.msg_size + ps - 1) / ps;
+			size_t per_dir = ps / sizeof(uet_dma_addr_t);
+			uet_dma_addr_t root;
+			uint8_t **raw = NULL;
+			size_t i;
+
+			if (po >= ps) {
+				UET_ERR("UET_MR_PBL_OFFSET must be < page size");
+				goto exit;
+			}
+
+			if (ctx->cfg.mr_pbl_level == UET_PBL_LEVEL_0) {
+				/*
+				 * level 0 is contiguous by definition, so the
+				 * region is one allocation and page_offset is
+				 * simply where it starts inside it
+				 */
+				ctx->pbl_base = calloc(1, po +
+						       ctx->cfg.msg_size);
+				if (ctx->pbl_base == NULL) {
+					UET_ERR("Error allocating PBL region");
+					goto exit;
+				}
+				memcpy(ctx->pbl_base + po, ctx->mr_buf,
+				       ctx->cfg.msg_size);
+				free(ctx->mr_buf);
+				ctx->mr_buf = ctx->pbl_base + po;
+				root = (uet_dma_addr_t) (uintptr_t)
+					ctx->pbl_base;
+			} else {
+				/*
+				 * Allocate every page separately, then map
+				 * region page N to allocation (npages-1-N).
+				 * The permutation is what makes this a real
+				 * test: if the resolver computes the wrong
+				 * page index it returns the wrong bytes
+				 * instead of adjacent - and therefore
+				 * accidentally correct - ones.
+				 */
+				raw = calloc(npages, sizeof(uint8_t *));
+				ctx->pbl_pages = calloc(npages,
+							sizeof(uint8_t *));
+				if ((raw == NULL) || (ctx->pbl_pages == NULL)) {
+					free(raw);
+					UET_ERR("Error allocating PBL pages");
+					goto exit;
+				}
+				ctx->pbl_page_cnt = npages;
+
+				for (i = 0; i < npages; i++) {
+					raw[i] = calloc(1, ps);
+					if (raw[i] == NULL) {
+						free(raw);
+						UET_ERR(
+						"Error allocating PBL page");
+						goto exit;
+					}
+				}
+				for (i = 0; i < npages; i++)
+					ctx->pbl_pages[i] =
+						raw[npages - 1 - i];
+				free(raw);
+
+				/* lay the region's contents into the pages */
+				uet_pbl_sync(ctx, true);
+
+				if (ctx->cfg.mr_pbl_level == UET_PBL_LEVEL_1) {
+					ctx->pbl_root = calloc(npages,
+						sizeof(uet_dma_addr_t));
+					if (ctx->pbl_root == NULL) {
+						UET_ERR(
+						"Error allocating PBL dir");
+						goto exit;
+					}
+					for (i = 0; i < npages; i++)
+						ctx->pbl_root[i] =
+							(uet_dma_addr_t)
+							(uintptr_t)
+							ctx->pbl_pages[i];
+				} else if (ctx->cfg.mr_pbl_level ==
+					   UET_PBL_LEVEL_2) {
+					size_t ndirs = (npages + per_dir - 1) /
+						       per_dir;
+
+					ctx->pbl_root = calloc(ndirs,
+						sizeof(uet_dma_addr_t));
+					ctx->pbl_mid = calloc(ndirs,
+						sizeof(uet_dma_addr_t *));
+					if ((ctx->pbl_root == NULL) ||
+					    (ctx->pbl_mid == NULL)) {
+						UET_ERR(
+						"Error allocating PBL dirs");
+						goto exit;
+					}
+					ctx->pbl_mid_cnt = ndirs;
+					for (i = 0; i < ndirs; i++) {
+						ctx->pbl_mid[i] = calloc(1, ps);
+						if (ctx->pbl_mid[i] == NULL) {
+							UET_ERR(
+							"Error alloc PBL dir");
+							goto exit;
+						}
+						ctx->pbl_root[i] =
+							(uet_dma_addr_t)
+							(uintptr_t)
+							ctx->pbl_mid[i];
+					}
+					for (i = 0; i < npages; i++)
+						ctx->pbl_mid[i / per_dir]
+							   [i % per_dir] =
+							(uet_dma_addr_t)
+							(uintptr_t)
+							ctx->pbl_pages[i];
+				} else {
+					UET_ERR("Invalid UET_MR_PBL_LEVEL");
+					goto exit;
+				}
+
+				root = (uet_dma_addr_t) (uintptr_t)
+					ctx->pbl_root;
+			}
+
+			printf("Registering MR as a level-%d PBL "
+			       "(%zu pages of %zu bytes, page_offset %zu%s)\n",
+			       ctx->cfg.mr_pbl_level, npages, ps, po,
+			       (ctx->pbl_pages != NULL) ?
+					", pages permuted" : "");
+
+			/* base_va 0 makes the region zero-based, so the
+			 * addresses naming it are offsets
+			 */
+			ret = uet_mr_reg_pbl(ctx->domain_handle, root,
+					     (uint32_t) ps,
+					     ctx->cfg.mr_pbl_level,
+					     (uint32_t) po,
+					     0 /* base_va */,
+					     ctx->cfg.msg_size,
+					     FI_WRITE | FI_REMOTE_WRITE |
+					     FI_READ  | FI_REMOTE_READ |
+					     FI_ATOMIC,
+					     ctx->cfg.rudi ?
+						UET_MR_KEY_IDEMPOTENT_SAFE :
+						UET_MR_KEY_NONE,
+					     UET_FLAGS_NONE, context,
+					     &ctx->mr_handle);
+		} else if (ctx->cfg.mr_iov_count > 1) {
+			struct iovec *mr_iov;
+			size_t i, off, chunk;
+			size_t n = ctx->cfg.mr_iov_count;
+
+			/* cannot carve more entries than there are bytes */
+			if (n > ctx->cfg.msg_size)
+				n = ctx->cfg.msg_size;
+
+			mr_iov = calloc(n, sizeof(struct iovec));
+			if (mr_iov == NULL) {
+				UET_PRINT_ERRNO("calloc");
+				UET_ERR("Error allocating MR io vector");
+				goto exit;
+			}
+
+			/*
+			 * carve the same buffer into n adjacent slices - the
+			 * bytes and their order are unchanged, so all existing
+			 * data verification still applies
+			 */
+			chunk = ctx->cfg.msg_size / n;
+			off = 0;
+			for (i = 0; i < n; i++) {
+				mr_iov[i].iov_base = ctx->mr_buf + off;
+				/* last entry absorbs any remainder */
+				mr_iov[i].iov_len = (i == (n - 1)) ?
+					(ctx->cfg.msg_size - off) : chunk;
+				off += mr_iov[i].iov_len;
+			}
+
+			printf("Registering MR as %zu iovec entries (%zu bytes)\n",
+			       n, ctx->cfg.msg_size);
+
+			/* uet_mr_regv() copies the vector, so it need not
+			 * outlive this call
+			 */
+			ret = uet_mr_regv(ctx->domain_handle, mr_iov, n,
+					  FI_WRITE | FI_REMOTE_WRITE |
+					  FI_READ  | FI_REMOTE_READ | FI_ATOMIC,
+					  ctx->cfg.rudi ?
+						UET_MR_KEY_IDEMPOTENT_SAFE :
+						UET_MR_KEY_NONE,
+					  UET_FLAGS_NONE, context,
+					  &ctx->mr_handle);
+			free(mr_iov);
+		} else {
+			ret = uet_mr_reg(ctx->domain_handle, ctx->mr_buf,
+					 ctx->cfg.msg_size,
+					 FI_WRITE | FI_REMOTE_WRITE |
+					 FI_READ  | FI_REMOTE_READ | FI_ATOMIC,
+					 ctx->cfg.rudi ?
+						UET_MR_KEY_IDEMPOTENT_SAFE :
+						UET_MR_KEY_NONE,
+					 UET_FLAGS_NONE, context,
+					 &ctx->mr_handle);
+		}
 		if (ret) {
-			UET_ERR("uet_mr_reg: %s", fi_strerror(-ret));
+			UET_ERR("uet_mr_reg%s: %s",
+				(ctx->cfg.mr_pbl_page_size > 0) ? "_pbl" :
+				((ctx->cfg.mr_iov_count > 1) ? "v" : ""),
+				fi_strerror(-ret));
 			goto exit;
 		}
 
@@ -718,6 +1126,119 @@ static uet_rc_t uet_init_transport(struct uet_context *ctx)
 		if (ret) {
 			UET_ERR("uet_mr_enable: %s", fi_strerror(-ret));
 			goto exit;
+		}
+
+		/*
+		 * Describe the local rma buffer as a segment list instead of
+		 * a process address. The segments carve the same region so
+		 * the bytes and their order are unchanged and every existing
+		 * verification still applies (only the way the buffer is
+		 * named changes. With UET_LOCAL_SEG_MRS the carve is spread
+		 * over several separately registered regions covering the
+		 * same memory, so one operation genuinely crosses several
+		 * lkeys, which is what a multi-SGE work request does.
+		 */
+		if (ctx->cfg.local_seg_count > 0) {
+			size_t nseg = ctx->cfg.local_seg_count;
+			size_t nmr = ctx->cfg.local_seg_mrs;
+			size_t chunk, off, i;
+
+			/*
+			 * sync_rma issues partial writes straight from
+			 * mr_buf, which is only a linear shadow of the region
+			 * when the region is a page list. Segment operations
+			 * land in the pages themselves, so mixing the two
+			 * leaves the shadow stale and the data check fails on
+			 * a harness artifact rather than a real defect.
+			 *
+			 * Each half is fine on its own - segments with a
+			 * contiguous region, or a page list without segments -
+			 * so refuse only the combination, and say why.
+			 */
+			if ((ctx->cfg.mr_pbl_page_size > 0) &&
+			    ctx->cfg.sync_rma) {
+				UET_ERR("UET_LOCAL_SEG with UET_MR_PBL is "
+					"not supported for sync_rma:");
+				UET_ERR("  sync_rma writes partial buffers "
+					"directly from the shadow buffer,");
+				UET_ERR("  which segment operations bypass. "
+					"Use one or the other.");
+				goto exit;
+			}
+
+			if (nseg > ctx->cfg.msg_size)
+				nseg = ctx->cfg.msg_size;
+			if (nmr < 1)
+				nmr = 1;
+			if (nmr > nseg)
+				nmr = nseg;
+
+			ctx->local_seg = calloc(nseg,
+						sizeof(struct uet_mr_seg));
+			if (ctx->local_seg == NULL) {
+				UET_ERR("Error allocating local segments");
+				goto exit;
+			}
+			ctx->local_seg_count = nseg;
+
+			/*
+			 * Extra regions beyond the first each cover the whole
+			 * buffer; a segment then names a slice of whichever
+			 * region it was assigned. Registering the same memory
+			 * more than once is exactly what distinct lkeys over
+			 * overlapping memory look like.
+			 */
+			if (nmr > 1) {
+				ctx->extra_mr = calloc(nmr - 1,
+						sizeof(uet_mr_handle_t));
+				if (ctx->extra_mr == NULL) {
+					UET_ERR("Error allocating extra MRs");
+					goto exit;
+				}
+
+				for (i = 0; i < (nmr - 1); i++) {
+					ret = uet_mr_reg(ctx->domain_handle,
+						ctx->mr_buf, ctx->cfg.msg_size,
+						FI_WRITE | FI_REMOTE_WRITE |
+						FI_READ | FI_REMOTE_READ |
+						FI_ATOMIC,
+						UET_MR_KEY_NONE,
+						UET_FLAGS_NONE, context,
+						&ctx->extra_mr[i]);
+					if (ret == 0)
+						ret = uet_ep_bind_mr(
+							ctx->ep_handle,
+							ctx->extra_mr[i],
+							UET_FLAGS_NONE);
+					if (ret == 0)
+						ret = uet_mr_enable(
+							ctx->extra_mr[i]);
+					if (ret) {
+						UET_ERR("extra MR %zu: %s", i,
+							fi_strerror(-ret));
+						goto exit;
+					}
+					ctx->extra_mr_cnt++;
+				}
+			}
+
+			chunk = ctx->cfg.msg_size / nseg;
+			off = 0;
+			for (i = 0; i < nseg; i++) {
+				size_t which = i % nmr;
+
+				ctx->local_seg[i].mr = (which == 0) ?
+					ctx->mr_handle :
+					ctx->extra_mr[which - 1];
+				ctx->local_seg[i].addr = off;
+				ctx->local_seg[i].len = (i == (nseg - 1)) ?
+					(ctx->cfg.msg_size - off) : chunk;
+				off += ctx->local_seg[i].len;
+			}
+
+			printf("Local rma buffer as %zu segments "
+			       "over %zu region(s)\n",
+			       nseg, nmr);
 		}
 	}
 
@@ -1002,6 +1523,44 @@ static uet_rc_t uet_rma_server_ctrl_exchange(struct uet_context *ctx)
 	return UET_SUCCESS_RC;
 }
 
+/*
+ * rma write / read, using the segment form of the api when the local buffer
+ * has been described as segments. The two forms move identical bytes; only
+ * how the local buffer is named differs.
+ */
+
+static ssize_t uet_test_write(struct uet_context *ctx, uint64_t *imm_data,
+			      size_t len, void *context)
+{
+	if ((ctx->local_seg != NULL) && (len == ctx->cfg.msg_size))
+		return uet_writeseg(ctx->ep_handle, ctx->cfg.job_id,
+				    ctx->local_seg, ctx->local_seg_count,
+				    imm_data, ctx->peer_addr_handle,
+				    ctx->remote_mr.rma_buf_addr,
+				    ctx->remote_mr.key, context);
+
+	return uet_write(ctx->ep_handle, ctx->cfg.job_id, ctx->mr_buf, len,
+			 imm_data, ctx->mr_handle, ctx->peer_addr_handle,
+			 ctx->remote_mr.rma_buf_addr, ctx->remote_mr.key,
+			 context);
+}
+
+static ssize_t uet_test_read(struct uet_context *ctx, size_t len,
+			     void *context)
+{
+	if ((ctx->local_seg != NULL) && (len == ctx->cfg.msg_size))
+		return uet_readseg(ctx->ep_handle, ctx->cfg.job_id,
+				   ctx->local_seg, ctx->local_seg_count,
+				   ctx->peer_addr_handle,
+				   ctx->remote_mr.rma_buf_addr,
+				   ctx->remote_mr.key, context);
+
+	return uet_read(ctx->ep_handle, ctx->cfg.job_id, ctx->mr_buf, len,
+			ctx->mr_handle, ctx->peer_addr_handle,
+			ctx->remote_mr.rma_buf_addr, ctx->remote_mr.key,
+			context);
+}
+
 static uet_rc_t uet_rma_write_data(struct uet_context *ctx, uint64_t *imm_data)
 {
 	struct fi_cq_data_entry cq_entry;
@@ -1014,11 +1573,7 @@ static uet_rc_t uet_rma_write_data(struct uet_context *ctx, uint64_t *imm_data)
 	 */
 	if (ctx->cfg.rudi) {
 		/* bulk data over RUDI (no immediate) */
-		ret = uet_write(ctx->ep_handle, ctx->cfg.job_id, ctx->mr_buf,
-				ctx->cfg.msg_size, NULL, ctx->mr_handle,
-				ctx->peer_addr_handle,
-				ctx->remote_mr.rma_buf_addr,
-				ctx->remote_mr.key, NULL);
+		ret = uet_test_write(ctx, NULL, ctx->cfg.msg_size, NULL);
 		if (ret < 0) {
 			UET_ERR("uet_write (RUDI data): %s", fi_strerror(-ret));
 			return UET_ERR_RC;
@@ -1031,11 +1586,7 @@ static uet_rc_t uet_rma_write_data(struct uet_context *ctx, uint64_t *imm_data)
 		}
 
 		/* signal over RUD (zero-length write-with-immediate) */
-		ret = uet_write(ctx->ep_handle, ctx->cfg.job_id, ctx->mr_buf,
-				0, imm_data, ctx->mr_handle,
-				ctx->peer_addr_handle,
-				ctx->remote_mr.rma_buf_addr,
-				ctx->remote_mr.key, NULL);
+		ret = uet_test_write(ctx, imm_data, 0, NULL);
 		if (ret < 0) {
 			UET_ERR("uet_write (RUD imm): %s", fi_strerror(-ret));
 			return UET_ERR_RC;
@@ -1051,10 +1602,7 @@ static uet_rc_t uet_rma_write_data(struct uet_context *ctx, uint64_t *imm_data)
 	}
 
 	/* single write-with-immediate (data + target completion) */
-	ret = uet_write(ctx->ep_handle, ctx->cfg.job_id, ctx->mr_buf,
-			ctx->cfg.msg_size, imm_data, ctx->mr_handle,
-			ctx->peer_addr_handle, ctx->remote_mr.rma_buf_addr,
-			ctx->remote_mr.key, NULL);
+	ret = uet_test_write(ctx, imm_data, ctx->cfg.msg_size, NULL);
 	if (ret < 0) {
 		UET_ERR("uet_write: %s", fi_strerror(-ret));
 		return UET_ERR_RC;
@@ -1090,10 +1638,7 @@ static uet_rc_t uet_rma_client(struct uet_context *ctx)
 	uint64_t imm_data = UET_WRITE_IMM_DATA;
 	struct fi_cq_data_entry cq_entry;
 
-	ret = uet_read(ctx->ep_handle, ctx->cfg.job_id, ctx->mr_buf,
-			ctx->cfg.msg_size, ctx->mr_handle,
-			ctx->peer_addr_handle, ctx->remote_mr.rma_buf_addr,
-			ctx->remote_mr.key, context);
+	ret = uet_test_read(ctx, ctx->cfg.msg_size, context);
 	if (ret < 0) {
 		UET_ERR("uet_read: %s", fi_strerror(-ret));
 		return UET_ERR_RC;
@@ -1180,10 +1725,7 @@ static uet_rc_t uet_sync_rma_client(struct uet_context *ctx)
 	size_t msg1_sz, msg2_sz, msg3_sz;
 	struct fi_cq_data_entry cq_entry;
 
-	ret = uet_read(ctx->ep_handle, ctx->cfg.job_id, ctx->mr_buf,
-			ctx->cfg.msg_size, ctx->mr_handle,
-			ctx->peer_addr_handle, ctx->remote_mr.rma_buf_addr,
-			ctx->remote_mr.key, context);
+	ret = uet_test_read(ctx, ctx->cfg.msg_size, context);
 	if (ret < 0) {
 		UET_ERR("uet_read: %s", fi_strerror(-ret));
 		return UET_ERR_RC;
@@ -1487,10 +2029,7 @@ static uet_rc_t uet_atomic_client(struct uet_context *ctx)
 		return UET_ERR_RC;
 	}
 
-	ret = uet_write(ctx->ep_handle, ctx->cfg.job_id, ctx->mr_buf,
-			ctx->cfg.msg_size, &imm_data, ctx->mr_handle,
-			ctx->peer_addr_handle, ctx->remote_mr.rma_buf_addr,
-			ctx->remote_mr.key, context);
+	ret = uet_test_write(ctx, &imm_data, ctx->cfg.msg_size, context);
 	if (ret < 0) {
 		UET_ERR("uet_write: %s", fi_strerror(-ret));
 		return UET_ERR_RC;

--- a/uet_api.c
+++ b/uet_api.c
@@ -52,6 +52,30 @@
 #define UET_NO_REMOTE_MEM_ADDR    0
 #define UET_NO_REMOTE_KEY         0
 
+static size_t scatter_flat_to_iov(const struct iovec *iov, size_t iov_count,
+				  const void *payload, size_t payload_len,
+				  size_t payload_offset);
+static size_t gather_iov_to_flat(const struct iovec *iov, size_t iov_count,
+				 void *dst, size_t len, size_t offset);
+static inline bool uet_mr_is_scattered(const struct uet_mr_desc *mr_desc);
+static bool uet_mr_addr_to_offset(const struct uet_mr_desc *mr_desc,
+				  uint64_t addr, size_t len, size_t *offset);
+static size_t uet_seg_total_len(const struct uet_mr_seg *seg, size_t seg_count);
+static bool uet_seg_validate(const struct uet_mr_seg *seg, size_t seg_count);
+static size_t scatter_flat_to_seg(const struct uet_mr_seg *seg,
+				  size_t seg_count, const void *payload,
+				  size_t payload_len, size_t payload_offset);
+static size_t gather_seg_to_flat(const struct uet_mr_seg *seg,
+				 size_t seg_count, void *dst, size_t len,
+				 size_t offset);
+static size_t uet_mr_scatter(const struct uet_mr_desc *mr_desc, size_t offset,
+			     const void *src, size_t len);
+static size_t uet_mr_gather(const struct uet_mr_desc *mr_desc, size_t offset,
+			    void *dst, size_t len);
+static void *uet_mr_atomic_addr(const struct uet_mr_desc *mr_desc,
+				size_t offset, size_t len);
+static void *uet_rx_desc_cq_buf(const struct uet_rx_desc *rx_desc);
+
 /* receive api types */
 typedef enum {
 	UET_RECV_API,
@@ -1278,6 +1302,21 @@ static void uet_rx_desc_recycle(struct uet_rx_desc *rx_desc,
 /* insert entry into list of available tx descriptors for an endpoint */
 static void uet_tx_desc_list_insert(struct uet_tx_desc *tx_desc)
 {
+	/* release a read-response buffer gathered from a scattered memory
+	 * region before the flags that record its ownership are cleared
+	 */
+	if (tx_desc->desc_flags & UET_TX_DESC_FLAG_OWNS_BUF) {
+		free(tx_desc->buf_desc.buf);
+		tx_desc->buf_desc.buf = NULL;
+	}
+
+	/* likewise a segment list this descriptor copied for itself */
+	if (tx_desc->desc_flags & UET_TX_DESC_FLAG_OWNS_SEG) {
+		free(tx_desc->buf_desc.seg.seg);
+		tx_desc->buf_desc.seg.seg = NULL;
+		tx_desc->buf_desc.seg.seg_count = 0;
+	}
+
 	tx_desc->state = UET_TX_DESC_STATE_INACTIVE;
 	tx_desc->desc_flags = UET_TX_DESC_FLAG_NONE;
 	tx_desc->pkt_cnt = 0;
@@ -1385,9 +1424,18 @@ static void uet_desc_free(struct uet_ep *uet_ep)
 	if (uet_ep->rx_desc) {
 		for (i = 0; i < uet_ep->num_rx_desc; i++) {
 			rx_desc = &uet_ep->rx_desc[i];
-			iov = (struct iovec *)rx_desc->buf_desc.iov.iov;
-			if (iov)
-				free(iov);
+			/* Only release a vector this descriptor owns - an rma
+			 * descriptor borrows the vector from the target memory
+			 * region, which frees it with the domain.
+			 */
+			if (rx_desc->desc_flags & UET_RX_DESC_FLAG_OWNS_IOV) {
+				iov = (struct iovec *)rx_desc->buf_desc.iov.iov;
+				if (iov)
+					free(iov);
+			}
+
+			if (rx_desc->desc_flags & UET_RX_DESC_FLAG_OWNS_SEG)
+				free(rx_desc->buf_desc.seg.seg);
 		}
 		free(uet_ep->rx_desc);
 	}
@@ -1395,12 +1443,22 @@ static void uet_desc_free(struct uet_ep *uet_ep)
 	if (uet_ep->tx_desc) {
 		for (i = 0; i < uet_ep->num_tx_desc; i++) {
 			tx_desc = &uet_ep->tx_desc[i];
-			iov = (struct iovec *)(tx_desc->buf_desc.iov.iov);
-			if (iov)
-				free(iov);
+
+			if (tx_desc->buf_desc.type == UET_MSG_BUF_TYPE_IOV) {
+				iov = (struct iovec *)
+					(tx_desc->buf_desc.iov.iov);
+				if (iov)
+					free(iov);
+			} else if (tx_desc->buf_desc.type ==
+				   UET_MSG_BUF_TYPE_SEG) {
+				free(tx_desc->buf_desc.seg.seg);
+			}
+
 			if (tx_desc->desc_flags &
-					UET_TX_DESC_FLAG_MSG_ID_ALLOCATED)
-				uet_dealloc_msg_id(uet_ep->uet_domain->uet, tx_desc->msg_id);
+			    UET_TX_DESC_FLAG_MSG_ID_ALLOCATED)
+				uet_dealloc_msg_id(uet_ep->uet_domain->uet,
+						   tx_desc->msg_id);
+
 			uet_dealloc_tx_rtr_token(tx_desc);
 			uet_tx_desc_buf_rtr_list_remove(tx_desc);
 		}
@@ -1813,7 +1871,7 @@ static void uet_rx_cq_post_entry(struct uet_rx_desc *rx_desc)
 		cq_entry->len = rx_desc->msg_len;
 	}
 	if (cq->format_size >= sizeof(struct fi_cq_msg_entry)) {
-		cq_entry->buf = rx_desc->buf_desc.buf;
+		cq_entry->buf = uet_rx_desc_cq_buf(rx_desc);
 		if (rx_desc->desc_flags & UET_RX_DESC_FLAG_WRITE_IMM) {
 			cq_entry->data = rx_desc->imm_data;
 			cq_entry->flags |= FI_REMOTE_CQ_DATA;
@@ -1895,10 +1953,34 @@ static void uet_rx_cq_post_err(struct uet_rx_desc *rx_desc, int err_code)
 		err_entry->data = rx_desc->imm_data;
 	if (rx_desc->cq_flags & FI_TAGGED)
 		err_entry->tag = ntohll(rx_desc->tag_key.tag);
-	err_entry->buf = rx_desc->buf_desc.buf;
+	err_entry->buf = uet_rx_desc_cq_buf(rx_desc);
 	uet_rx_desc_recycle(rx_desc, false);
 
 	uet_ring_head_advance(ring);
+}
+
+/*
+ * buffer address to report on a completion
+ *
+ * A scattered buffer has no single base address and leaves buf_desc.buf
+ * NULL, so report the first entry of the vector (the start of the region's
+ * flattened address space) rather than a NULL pointer.
+ */
+static void *uet_rx_desc_cq_buf(const struct uet_rx_desc *rx_desc)
+{
+	if ((rx_desc->buf_desc.type == UET_MSG_BUF_TYPE_IOV) &&
+	    (rx_desc->buf_desc.iov.iov != NULL) &&
+	    (rx_desc->buf_desc.iov.iov_count > 0))
+		return rx_desc->buf_desc.iov.iov[0].iov_base;
+
+	if ((rx_desc->buf_desc.type == UET_MSG_BUF_TYPE_MR) &&
+	    (rx_desc->mr_desc != NULL) &&
+	    (rx_desc->mr_desc->buf_desc.type == UET_MR_BUF_TYPE_IOV) &&
+	    (rx_desc->mr_desc->buf_desc.iov.iov != NULL) &&
+	    (rx_desc->mr_desc->buf_desc.iov.iov_count > 0))
+		return rx_desc->mr_desc->buf_desc.iov.iov[0].iov_base;
+
+	return rx_desc->buf_desc.buf;
 }
 
 /* free completion queue resources associated with an endpoint */
@@ -2010,13 +2092,19 @@ static void uet_domain_free(struct uet_domain *uet_dom)
 	if (uet_dom->mr_desc_alloc_cb.state)
 		free(uet_dom->mr_desc_alloc_cb.state);
 	if (uet_dom->mr_desc) {
+		/* Release the vector of every region that owns one. Only
+		 * UET_MR_BUF_TYPE_IOV keeps an allocation here.
+		 */
 		for (i = 0; i < uet_dom->num_mr; i++) {
-			if ((uet_dom->mr_desc[i].state !=
-			     UET_MR_DESC_STATE_INACTIVE) &&
-			    (uet_dom->mr_desc[i].buf_desc.type ==
-			     UET_MR_BUF_TYPE_IOV))
-				free((void *)uet_dom->mr_desc[i].buf_desc.iov.iov);
+			struct uet_mr_desc *mr_desc = &uet_dom->mr_desc[i];
+
+			if (mr_desc->buf_desc.type != UET_MR_BUF_TYPE_IOV)
+				continue;
+
+			free((struct iovec *) mr_desc->buf_desc.iov.iov);
+			mr_desc->buf_desc.iov.iov = NULL;
 		}
+
 		free(uet_dom->mr_desc);
 	}
 	free(uet_dom);
@@ -2288,13 +2376,8 @@ static uet_ses_rc_t uet_get_rx_desc(
 	/* more init of rx descriptor for rma operation */
 	if (mr_desc->buf_desc.type == UET_MR_BUF_TYPE_CONTIG)
 		(*rx_desc)->buf_desc.type = UET_MSG_BUF_TYPE_CONTIG;
-	else {
-		(*rx_desc)->buf_desc.type = UET_MSG_BUF_TYPE_IOV;
-		(*rx_desc)->buf_desc.iov.iov_count =
-			mr_desc->buf_desc.iov.iov_count;
-		(*rx_desc)->buf_desc.iov.iov =
-			mr_desc->buf_desc.iov.iov;;
-	}
+	else
+		(*rx_desc)->buf_desc.type = UET_MSG_BUF_TYPE_MR;
 
 	(*rx_desc)->buf_desc.buf = mr_desc->buf_desc.buf;
 	(*rx_desc)->buf_desc.len = mr_desc->buf_desc.len;
@@ -2382,8 +2465,36 @@ static uet_ses_rc_t uet_get_rd_tx_desc(
 	tx_desc->cq_flags = FI_RMA | FI_REMOTE_READ;
 	tx_desc->desc_flags = UET_TX_DESC_FLAG_READ_RSP;
 	tx_desc->buf_desc.type = UET_MSG_BUF_TYPE_CONTIG;
-	tx_desc->buf_desc.buf = (void *)
-		(((uint8_t *) mr_desc->buf_desc.buf) + buf_off);
+	if (uet_mr_is_scattered(mr_desc)) {
+		/* A scattered region offers no contiguous pointer to hand to
+		 * the transmit path, and this descriptor outlives the call,
+		 * so gather the requested range into a buffer owned by the
+		 * descriptor that is released when it is recycled.
+		 */
+		void *rd_buf = malloc(pp->ses_payload_len);
+		if (rd_buf == NULL) {
+			UET_API_PRINT_ERRNO("malloc");
+			uet_tx_desc_list_insert(tx_desc);
+			*ret_tx_desc = NULL;
+			return UET_RC_UNCOR_TRNSNT;
+		}
+
+		if (uet_mr_gather(mr_desc, buf_off, rd_buf,
+				  pp->ses_payload_len) !=
+		    pp->ses_payload_len) {
+			UET_API_ERR("RX: Read Req: Invalid Buffer Offset");
+			free(rd_buf);
+			uet_tx_desc_list_insert(tx_desc);
+			*ret_tx_desc = NULL;
+			return UET_RC_BAD_ADDR;
+		}
+
+		tx_desc->buf_desc.buf = rd_buf;
+		tx_desc->desc_flags |= UET_TX_DESC_FLAG_OWNS_BUF;
+	} else {
+		tx_desc->buf_desc.buf =
+			(void *)(((uint8_t *)mr_desc->buf_desc.buf) + buf_off);
+	}
 	tx_desc->buf_desc.len = pp->ses_payload_len;
 	tx_desc->remaining_bytes = pp->ses_payload_len;
 	tx_desc->remote_msg_off = msg_off;
@@ -2510,8 +2621,9 @@ static uet_ses_rc_t uet_rx_rd_req_pkt(
 		return UET_RC_OP_VIOLATION;
 	}
 
-	/* validate requested data is within memory region */
-	if ((buf_off + pp->ses_payload_len) > mr_desc->buf_desc.len) {
+	/* resolve the address against the region and validate the range */
+	if (!uet_mr_addr_to_offset(mr_desc, buf_off, pp->ses_payload_len,
+				   &buf_off)) {
 		UET_API_ERR("RX: Read Req: Invalid Buffer Offset");
 		return UET_RC_BAD_ADDR;
 	}
@@ -2524,7 +2636,34 @@ static uet_ses_rc_t uet_rx_rd_req_pkt(
 		ack_d_info->valid = true;
 		ack_d_info->payload_len = pp->ses_payload_len;
 		ack_d_info->msg_off = msg_off;
-		ack_d_info->buf = ((uint8_t *) mr_desc->buf_desc.buf) + buf_off;
+
+		if (uet_mr_is_scattered(mr_desc)) {
+			/* A scattered region offers no contiguous pointer, so
+			 * stage the data in the ack info struct. The staging
+			 * area is sized for a maximum payload. Refuse anything
+			 * larger rather than overrun it.
+			 */
+			if (pp->ses_payload_len >
+			    sizeof(ack_d_info->gather_buf)) {
+				UET_API_ERR("RX: Read Req: ack payload "
+					    "exceeds gather buf");
+				return UET_RC_BAD_ADDR;
+			}
+
+			if (uet_mr_gather(mr_desc, buf_off,
+					  ack_d_info->gather_buf,
+					  pp->ses_payload_len) !=
+			    pp->ses_payload_len) {
+				UET_API_ERR("RX: Read Req: Invalid Buffer "
+					    "Offset");
+				return UET_RC_BAD_ADDR;
+			}
+
+			ack_d_info->buf = ack_d_info->gather_buf;
+		} else {
+			ack_d_info->buf =
+				((uint8_t *)mr_desc->buf_desc.buf + buf_off);
+		}
 	} else {
 		/* get tx descriptor for sending read response */
 		ses_rc = uet_get_rd_tx_desc(uet_ep, pp, req_len, buf_off,
@@ -2717,17 +2856,32 @@ static uet_ses_rc_t uet_rx_atomic_req_pkt(
 		goto err_exit;
 	}
 
-	/* validate requested data is within memory region */
-	if ((start_off + UET_VERBS_ATOMIC_DATA_BYTES) >
-	     mr_desc->buf_desc.len) {
+	/* resolve the address against the region and validate the range */
+	if (!uet_mr_addr_to_offset(mr_desc, start_off,
+				   UET_VERBS_ATOMIC_DATA_BYTES, &start_off)) {
 		UET_API_ERR("RX: Atomic Req: Invalid Buffer Offset");
 		ses_rc = UET_RC_BAD_ADDR;
 		goto err_exit;
 	}
 
+	/* An atomic needs a single naturally aligned location that the
+	 * __atomic builtins can operate on in place. A scattered region has
+	 * no such designation and the operand could straddle two entries.
+	 * Verify that the address offset within the descriptor memory is
+	 * contiguous based on a specific atomic data length.
+	 */
+
 	/* implement atomic operation                                  */
 	/*   - atomic operation may be deferred by sync group protocol */
-	addr = (uint64_t *) (((uint8_t *) mr_desc->buf_desc.buf) + start_off);
+	addr = uet_mr_atomic_addr(mr_desc, start_off,
+				  UET_VERBS_ATOMIC_DATA_BYTES);
+	if (addr == NULL) {
+		UET_API_ERR("RX: Atomic Req: operand misaligned or "
+			    "spans a page boundary");
+		ses_rc = UET_RC_BAD_ADDR;
+		goto err_exit;
+	}
+
 	if (sync)
 		data = ntohll(*((uint64_t *) ses_sync->data));
 	else
@@ -2880,8 +3034,9 @@ static uet_ses_rc_t uet_rx_fetch_atomic_req_pkt(
 		return UET_RC_PERM_VIOLATION;
 	}
 
-	/* validate requested data is within memory region */
-	if ((start_off + UET_VERBS_ATOMIC_DATA_BYTES) > mr_desc->buf_desc.len) {
+	/* resolve the address against the region and validate the range */
+	if (!uet_mr_addr_to_offset(mr_desc, start_off,
+				   UET_VERBS_ATOMIC_DATA_BYTES, &start_off)) {
 		UET_API_ERR("RX: Fetching Atomic Req: Invalid Buffer Offset");
 		return UET_RC_BAD_ADDR;
 	}
@@ -2889,7 +3044,15 @@ static uet_ses_rc_t uet_rx_fetch_atomic_req_pkt(
 	/* implement atomic operation */
 	ack_d_info->payload_len = UET_VERBS_ATOMIC_DATA_BYTES;
 	ack_d_info->msg_off = 0;
-	addr = (uint64_t *) (((uint8_t *) mr_desc->buf_desc.buf) + start_off);
+
+	addr = uet_mr_atomic_addr(mr_desc, start_off,
+				  UET_VERBS_ATOMIC_DATA_BYTES);
+	if (addr == NULL) {
+		UET_API_ERR("RX: Fetching Atomic Req: operand misaligned or "
+			    "spans a page");
+		return UET_RC_BAD_ADDR;
+	}
+
 	if (opcode == UET_AMO_SUM) {
 		data = ntohll(*((uint64_t *) ses_atomic->data));
 		result = __atomic_fetch_add(addr, data, __ATOMIC_SEQ_CST);
@@ -2994,17 +3157,27 @@ static uet_ses_rc_t uet_rx_dsend(struct uet_ep *uet_ep,
 	return UET_RC_DEFER_SEND;
 }
 
-/*Assemble scatter list from buffer*/
-static void scatter_buffer_to_iov(
-	const struct iovec *iov, size_t iov_count, const void *payload,
-	size_t payload_len, size_t payload_offset)
+/*
+ * Assemble scatter list from a flat buffer. Scatters payload_len bytes of
+ * payload into the scatter/gather list, starting payload_offset bytes into
+ * the list's flattened address space.
+ *
+ * returns:
+ *   The number of bytes actually placed. This is less than payload_len only
+ *   when the scatter list is too short to hold the payload at that offset,
+ *   which MUST be treated as an error.
+ */
+static size_t scatter_flat_to_iov(const struct iovec *iov, size_t iov_count,
+				  const void *payload, size_t payload_len,
+				  size_t payload_offset)
 {
 	size_t iov_index = 0;
 	size_t remaining_bytes = payload_len;
 	size_t buf_offset = 0;
 	size_t iov_buf_offset = 0;
 
-	while (payload_offset > 0) {
+	/* walk forward to the entry containing payload_offset */
+	while ((payload_offset > 0) && (iov_index < iov_count)) {
 		if (iov[iov_index].iov_len <= payload_offset) {
 			payload_offset -= iov[iov_index].iov_len;
 			iov_index++;
@@ -3013,24 +3186,495 @@ static void scatter_buffer_to_iov(
 			break;
 		}
 	}
-	while (remaining_bytes > 0) {
-		if (iov[iov_index].iov_len - iov_buf_offset < remaining_bytes) {
 
-			memcpy(iov[iov_index].iov_base + iov_buf_offset,
-				payload + buf_offset,
-				iov[iov_index].iov_len - iov_buf_offset);
+	while ((remaining_bytes > 0) && (iov_index < iov_count)) {
+		size_t avail = (iov[iov_index].iov_len - iov_buf_offset);
 
-			remaining_bytes -= (iov[iov_index].iov_len -
-								iov_buf_offset);
-			buf_offset += (iov[iov_index].iov_len - iov_buf_offset);
+		if (avail < remaining_bytes) {
+			memcpy((iov[iov_index].iov_base + iov_buf_offset),
+			       (payload + buf_offset), avail);
+			remaining_bytes -= avail;
+			buf_offset += avail;
 			iov_index++;
 			iov_buf_offset = 0;
 		} else {
-			memcpy(iov[iov_index].iov_base + iov_buf_offset,
-				payload + buf_offset,
-				remaining_bytes);
-			remaining_bytes -= remaining_bytes;
+			memcpy((iov[iov_index].iov_base + iov_buf_offset),
+			       (payload + buf_offset), remaining_bytes);
+			buf_offset += remaining_bytes;
+			remaining_bytes = 0;
 		}
+	}
+
+	return buf_offset;
+}
+
+/*
+ * Gather from a scatter/gather list into a flat buffer. The mirror of
+ * scatter_flat_to_iov(). Copies len bytes out of the list, starting offset
+ * bytes into the list's flattened address space.
+ *
+ * returns:
+ *   The number of bytes actually gathered. This is less than len only when
+ *   the scatter list is too short to satisfy the request at that offset,
+ *   which MUST be treated as an error.
+ */
+static size_t gather_iov_to_flat(
+	const struct iovec *iov, size_t iov_count, void *dst,
+	size_t len, size_t offset)
+{
+	size_t iov_index = 0;
+	size_t remaining_bytes = len;
+	size_t dst_offset = 0;
+	size_t iov_buf_offset = 0;
+
+	/* walk forward to the entry containing offset */
+	while ((offset > 0) && (iov_index < iov_count)) {
+		if (iov[iov_index].iov_len <= offset) {
+			offset -= iov[iov_index].iov_len;
+			iov_index++;
+		} else {
+			iov_buf_offset = offset;
+			break;
+		}
+	}
+
+	while ((remaining_bytes > 0) && (iov_index < iov_count)) {
+		size_t avail = (iov[iov_index].iov_len - iov_buf_offset);
+		size_t to_copy = (avail < remaining_bytes) ?
+					avail : remaining_bytes;
+
+		memcpy(((uint8_t *)dst + dst_offset),
+		       ((uint8_t *)iov[iov_index].iov_base + iov_buf_offset),
+		       to_copy);
+
+		dst_offset += to_copy;
+		remaining_bytes -= to_copy;
+		iov_index++;
+		iov_buf_offset = 0;
+	}
+
+	return dst_offset;
+}
+
+/*
+ * Translate a dma address to something this process can dereference.
+ *
+ * FIXME: For future use with a device model does not own the memory its page
+ * lists describe and only the device model can resolve them...
+ */
+static void *uet_dma_to_host(const struct uet_instance *uet,
+			     uet_dma_addr_t addr, size_t len)
+{
+	(void)uet;
+	(void)len;
+
+	return (void *)(uintptr_t)addr;
+}
+
+/*
+ * resolve a byte offset within a PBL region to a host address
+ *
+ * Directory and page entries are read in place through the translation
+ * callback rather than being copied/stored in the descriptor.
+ *
+ * parms:
+ *   mr_desc - the region
+ *   offset  - byte offset into the region's flattened address space
+ *   run_len - set to the number of bytes contiguously accessible from the
+ *             returned address, never crossing a page boundary
+ *
+ * returns:
+ *   a dereferenceable pointer, or NULL if the offset cannot be resolved
+ */
+static void *uet_mr_pbl_resolve(const struct uet_mr_desc *mr_desc,
+				size_t offset, size_t *run_len)
+{
+	const struct uet_mr_desc_pbl *pbl = &mr_desc->buf_desc.pbl;
+	const struct uet_instance *uet = mr_desc->uet_dom->uet;
+	size_t abs, page_idx, page_off, per_dir, dir_idx, ent_idx;
+	uet_dma_addr_t page_addr;
+	uet_dma_addr_t *dir;
+
+	abs = ((size_t)pbl->page_offset + offset);
+	page_idx = (abs >> pbl->page_shift);
+	page_off = (abs & ((size_t)pbl->page_size - 1));
+
+	switch (pbl->level) {
+	case UET_PBL_LEVEL_0:
+		*run_len = (mr_desc->buf_desc.len - offset);
+		return uet_dma_to_host(uet, (pbl->root + abs), *run_len);
+
+	case UET_PBL_LEVEL_1:
+		dir = uet_dma_to_host(uet, pbl->root,
+				      ((page_idx + 1) * sizeof(*dir)));
+		if (dir == NULL)
+			return NULL;
+
+		page_addr = dir[page_idx];
+		break;
+
+	case UET_PBL_LEVEL_2:
+		per_dir = (pbl->page_size / sizeof(uet_dma_addr_t));
+		dir_idx = (page_idx / per_dir);
+		ent_idx = (page_idx % per_dir);
+
+		dir = uet_dma_to_host(uet, pbl->root,
+				      ((dir_idx + 1) * sizeof(*dir)));
+		if (dir == NULL)
+			return NULL;
+
+		dir = uet_dma_to_host(uet, dir[dir_idx], pbl->page_size);
+		if (dir == NULL)
+			return NULL;
+
+		page_addr = dir[ent_idx];
+		break;
+
+	default:
+		return NULL;
+	}
+
+	*run_len = ((size_t)pbl->page_size - page_off);
+	return uet_dma_to_host(uet, (page_addr + page_off), *run_len);
+}
+
+/*
+ * copy into or out of a PBL region
+ *
+ * returns the number of bytes moved
+ */
+static size_t uet_mr_pbl_copy(const struct uet_mr_desc *mr_desc, size_t offset,
+			      void *flat, size_t len, bool into_mr)
+{
+	void *p;
+	size_t run;
+	size_t done = 0;
+
+	while (done < len) {
+		p = uet_mr_pbl_resolve(mr_desc, (offset + done), &run);
+		if (p == NULL)
+			break;
+
+		if (run > (len - done))
+			run = (len - done);
+
+		if (run == 0)
+			break;
+
+		if (into_mr)
+			memcpy(p, ((const uint8_t *)flat + done), run);
+		else
+			memcpy(((uint8_t *)flat + done), p, run);
+
+		done += run;
+	}
+
+	return done;
+}
+
+/*
+ * Convert an address naming a memory region into an offset into it.
+ *
+ * A region's base_va selects the convention: 0 means addresses naming it are
+ * offsets from zero, anything else means they are virtual addresses and the
+ * base is subtracted.
+ *
+ * parms:
+ *   mr_desc - the region
+ *   addr    - address naming the region, in its own convention
+ *   len     - number of bytes that must be within the region from there
+ *   offset  - set to the resulting offset on success
+ *
+ * returns:
+ *   true when the range lies wholly within the region
+ */
+static bool uet_mr_addr_to_offset(const struct uet_mr_desc *mr_desc,
+				  uint64_t addr, size_t len, size_t *offset)
+{
+	uint64_t off;
+
+	if (addr < mr_desc->base_va)
+		return false;
+
+	off = (addr - mr_desc->base_va);
+
+	if ((off > mr_desc->buf_desc.len) ||
+	    (len > (mr_desc->buf_desc.len - off)))
+		return false;
+
+	*offset = (size_t)off;
+	return true;
+}
+
+/*
+ * Total length of a segment list.
+ */
+static size_t uet_seg_total_len(const struct uet_mr_seg *seg,
+				size_t seg_count)
+{
+	size_t i, total = 0;
+
+	for (i = 0; i < seg_count; i++)
+		total += seg[i].len;
+
+	return total;
+}
+
+/*
+ * Check that every segment names an enabled region and lies wholly within it.
+ */
+static bool uet_seg_validate(const struct uet_mr_seg *seg, size_t seg_count)
+{
+	size_t i, offset;
+
+	if ((seg == NULL) || (seg_count == 0))
+		return false;
+
+	for (i = 0; i < seg_count; i++) {
+		const struct uet_mr_desc *mr_desc =
+			(const struct uet_mr_desc *)seg[i].mr;
+
+		if (mr_desc == NULL)
+			return false;
+
+		if (mr_desc->state != UET_MR_DESC_STATE_ENABLED)
+			return false;
+
+		if (!uet_mr_addr_to_offset(mr_desc, seg[i].addr, seg[i].len,
+					   &offset))
+			return false;
+	}
+
+	return true;
+}
+
+/*
+ * Move bytes between a flat buffer and a segment list.
+ *
+ * The list's flattened address space are the segments end to end, so an
+ * offset locates a segment and a position within it. Each segment then
+ * resolves through its own region, which is where any knowledge of
+ * contiguous buffers, vectors, and page lists lives.
+ *
+ * returns:
+ *   The number of bytes moved, less than len only when the list cannot
+ *   satisfy the request, which callers MUST treat as an error.
+ */
+static size_t uet_seg_copy(const struct uet_mr_seg *seg, size_t seg_count,
+			   void *flat, size_t len, size_t offset, bool to_seg)
+{
+	size_t i, within = offset, done = 0;
+
+	/* locate the segment holding offset */
+	for (i = 0; i < seg_count; i++) {
+		if (within < seg[i].len)
+			break;
+		within -= seg[i].len;
+	}
+
+	for (; (i < seg_count) && (done < len); i++) {
+		const struct uet_mr_desc *mr_desc =
+			(const struct uet_mr_desc *)seg[i].mr;
+		size_t avail = (seg[i].len - within);
+		size_t run = (avail < (len - done)) ? avail : (len - done);
+		size_t mr_off, moved;
+
+		if (mr_desc == NULL)
+			break;
+
+		/* the segment's address is in its own region's convention */
+		if (!uet_mr_addr_to_offset(mr_desc, (seg[i].addr + within), run,
+					   &mr_off))
+			break;
+
+		if (to_seg)
+			moved = uet_mr_scatter(mr_desc, mr_off,
+					       ((const uint8_t *)flat + done),
+					       run);
+		else
+			moved = uet_mr_gather(mr_desc, mr_off,
+					      ((uint8_t *)flat + done), run);
+
+		if (moved != run)
+			break;
+
+		done += run;
+		within = 0;
+	}
+
+	return done;
+}
+
+/*
+ * Scatter a flat payload into a segment list. The mirror of
+ * scatter_flat_to_iov() one level up.
+ */
+static size_t scatter_flat_to_seg(const struct uet_mr_seg *seg,
+				  size_t seg_count, const void *payload,
+				  size_t payload_len, size_t payload_offset)
+{
+	return uet_seg_copy(seg, seg_count, (void *)payload, payload_len,
+			    payload_offset, true);
+}
+
+/*
+ * Gather from a segment list into a flat buffer. The mirror of
+ * gather_iov_to_flat() one level up.
+ */
+static size_t gather_seg_to_flat(const struct uet_mr_seg *seg,
+				 size_t seg_count, void *dst, size_t len,
+				 size_t offset)
+{
+	return uet_seg_copy(seg, seg_count, dst, len, offset, false);
+}
+
+/*
+ * True when a memory region has no single base address spanning its whole
+ * length, so buf_desc.buf must not be used for address arithmetic. Such a
+ * region can only be reached through uet_mr_scatter()/uet_mr_gather().
+ */
+static inline bool uet_mr_is_scattered(const struct uet_mr_desc *mr_desc)
+{
+	return (mr_desc->buf_desc.type != UET_MR_BUF_TYPE_CONTIG);
+}
+
+/*
+ * resolve an atomic operand to a location that can be updated in place
+ *
+ * An atomic must act on a single naturally aligned location: the __atomic
+ * builtins need a real address, and an operand split across two pages or
+ * two vector entries cannot be made atomic at all.
+ *
+ * Natural alignment is what makes this workable on a scattered region: an
+ * aligned operand can never straddle a power-of-two page boundary, so an
+ * aligned offset resolves to exactly one page.
+ *
+ * parms:
+ *   mr_desc - the region
+ *   offset  - byte offset into the region's flattened address space
+ *   len     - operand size in bytes, which must be a power of 2
+ *
+ * returns:
+ *   The address of the operand, or NULL when it is not addressable that
+ *   way (out of bounds, spanning a boundary, or not naturally aligned)
+ */
+static void *uet_mr_atomic_addr(const struct uet_mr_desc *mr_desc,
+				size_t offset, size_t len)
+{
+	void *p = NULL;
+	size_t run = 0;
+
+	if ((offset > mr_desc->buf_desc.len) ||
+	    (len > (mr_desc->buf_desc.len - offset)))
+		return NULL;
+
+	switch (mr_desc->buf_desc.type) {
+	case UET_MR_BUF_TYPE_CONTIG:
+		p = ((uint8_t *)mr_desc->buf_desc.buf + offset);
+		run = (mr_desc->buf_desc.len - offset);
+		break;
+
+	case UET_MR_BUF_TYPE_IOV: {
+		const struct iovec *iov = mr_desc->buf_desc.iov.iov;
+		size_t count = mr_desc->buf_desc.iov.iov_count;
+		size_t i, rem = offset;
+
+		for (i = 0; i < count; i++) {
+			if (rem < iov[i].iov_len)
+				break;
+
+			rem -= iov[i].iov_len;
+		}
+
+		if (i == count)
+			return NULL;
+
+		p = ((uint8_t *)iov[i].iov_base + rem);
+		run = (iov[i].iov_len - rem);
+		break;
+	}
+
+	case UET_MR_BUF_TYPE_PBL:
+		p = uet_mr_pbl_resolve(mr_desc, offset, &run);
+		break;
+
+	default:
+		return NULL;
+	}
+
+	/* the operand must lie wholly within one addressable run */
+	if ((p == NULL) || (run < len))
+		return NULL;
+
+	/* and be naturally aligned; len is a power of 2 */
+	if (((uintptr_t)p & (len - 1)) != 0)
+		return NULL;
+
+	return p;
+}
+
+/*
+ * Copy into a memory region at a byte offset into its flattened address
+ * space, whatever representation the region uses.
+ *
+ * returns:
+ *   The number of bytes written, which is less than len only when the
+ *   region cannot hold len bytes at that offset. Callers MUST treat a
+ *   short result as an error.
+ */
+static size_t uet_mr_scatter(const struct uet_mr_desc *mr_desc, size_t offset,
+			     const void *src, size_t len)
+{
+	if ((offset > mr_desc->buf_desc.len) ||
+	    (len > (mr_desc->buf_desc.len - offset)))
+		return 0;
+
+	switch (mr_desc->buf_desc.type) {
+	case UET_MR_BUF_TYPE_CONTIG:
+		memcpy(((uint8_t *)mr_desc->buf_desc.buf + offset), src, len);
+		return len;
+
+	case UET_MR_BUF_TYPE_IOV:
+		return scatter_flat_to_iov(mr_desc->buf_desc.iov.iov,
+					   mr_desc->buf_desc.iov.iov_count,
+					   src, len, offset);
+
+	case UET_MR_BUF_TYPE_PBL:
+		return uet_mr_pbl_copy(mr_desc, offset, (void *)src, len,
+				       true);
+
+	default:
+		return 0;
+	}
+}
+
+/*
+ * Copy out of a memory region at a byte offset into its flattened address
+ * space. The mirror of uet_mr_scatter() and the same short-result contract
+ * applies.
+ */
+static size_t uet_mr_gather(const struct uet_mr_desc *mr_desc, size_t offset,
+			    void *dst, size_t len)
+{
+	if ((offset > mr_desc->buf_desc.len) ||
+	    (len > (mr_desc->buf_desc.len - offset)))
+		return 0;
+
+	switch (mr_desc->buf_desc.type) {
+	case UET_MR_BUF_TYPE_CONTIG:
+		memcpy(dst, ((uint8_t *)mr_desc->buf_desc.buf + offset), len);
+		return len;
+
+	case UET_MR_BUF_TYPE_IOV:
+		return gather_iov_to_flat(mr_desc->buf_desc.iov.iov,
+					  mr_desc->buf_desc.iov.iov_count,
+					  dst, len, offset);
+
+	case UET_MR_BUF_TYPE_PBL:
+		return uet_mr_pbl_copy(mr_desc, offset, dst, len, false);
+
+	default:
+		return 0;
 	}
 }
 
@@ -3121,13 +3765,18 @@ static uet_ses_rc_t uet_rx_req_pkt(
 			return UET_RC_OP_VIOLATION;
 		}
 
-		if ((buf_off + pp->ses_payload_len) > mr_desc->buf_desc.len) {
+		if (!uet_mr_addr_to_offset(mr_desc, buf_off,
+					   pp->ses_payload_len, &buf_off)) {
 			UET_API_ERR("RX: RUDI Write: Invalid Buffer Offset");
 			return UET_RC_BAD_ADDR;
 		}
 
-		buf_ptr = (void *)(((size_t) mr_desc->buf_desc.buf) + buf_off);
-		memcpy(buf_ptr, pp->payload, pp->ses_payload_len);
+		if (uet_mr_scatter(mr_desc, buf_off, pp->payload,
+				   pp->ses_payload_len) !=
+		    pp->ses_payload_len) {
+			UET_API_ERR("RX: RUDI Write: Invalid Buffer Offset");
+			return UET_RC_BAD_ADDR;
+		}
 
 		return UET_RC_OK; /* caller will emit one RUDI response */
 	}
@@ -3385,12 +4034,32 @@ static uet_ses_rc_t uet_rx_req_pkt(
 				       UET_RC_INITIATOR_ERR));
 	}
 
-	if (rx_desc->buf_desc.type == UET_MSG_BUF_TYPE_IOV) {
-		scatter_buffer_to_iov(
-				rx_desc->buf_desc.iov.iov,
-				rx_desc->buf_desc.iov.iov_count,
-				pp->payload, pp->pkt_payload_len,
-				buf_off);
+	if (rx_desc->buf_desc.type == UET_MSG_BUF_TYPE_MR) {
+		if (uet_mr_scatter(rx_desc->mr_desc, buf_off, pp->payload,
+				   pp->pkt_payload_len) !=
+		    pp->pkt_payload_len) {
+			UET_API_ERR("RX: Invalid Buffer Offset");
+			return (uet_rx_msg_err(uet_ep, pp, rx_desc,
+					       UET_RC_BAD_ADDR));
+		}
+	} else if (rx_desc->buf_desc.type == UET_MSG_BUF_TYPE_SEG) {
+		if (scatter_flat_to_seg(rx_desc->buf_desc.seg.seg,
+					rx_desc->buf_desc.seg.seg_count,
+					pp->payload, pp->pkt_payload_len,
+					buf_off) != pp->pkt_payload_len) {
+			UET_API_ERR("RX: Payload Exceeds Segment List");
+			return (uet_rx_msg_err(uet_ep, pp, rx_desc,
+					       UET_RC_BAD_ADDR));
+		}
+	} else if (rx_desc->buf_desc.type == UET_MSG_BUF_TYPE_IOV) {
+		if (scatter_flat_to_iov(rx_desc->buf_desc.iov.iov,
+					rx_desc->buf_desc.iov.iov_count,
+					pp->payload, pp->pkt_payload_len,
+					buf_off) != pp->pkt_payload_len) {
+			UET_API_ERR("RX: Payload Exceeds Scatter List");
+			return (uet_rx_msg_err(uet_ep, pp, rx_desc,
+					       UET_RC_BAD_ADDR));
+		}
 	} else {
 		buf_ptr =  (void *) (((size_t) rx_desc->buf_desc.buf) +
 				     buf_off);
@@ -3563,14 +4232,40 @@ static uet_ses_rc_t uet_rx_read_data(
 	/* scatter the read response into the local buffer (which may be a
 	 * multi-segment scatter/gather list)
 	 */
-	if (rx_desc->buf_desc.type == UET_MSG_BUF_TYPE_IOV) {
-		scatter_buffer_to_iov(rx_desc->buf_desc.iov.iov,
-				      rx_desc->buf_desc.iov.iov_count,
-				      ses->payload, pp->ses_payload_len,
-				      msg_off);
-	} else {
+	switch (rx_desc->buf_desc.type) {
+	case UET_MSG_BUF_TYPE_SEG:
+		if (scatter_flat_to_seg(rx_desc->buf_desc.seg.seg,
+					rx_desc->buf_desc.seg.seg_count,
+					ses->payload, pp->ses_payload_len,
+					msg_off) != pp->ses_payload_len) {
+			UET_API_ERR("Read Rsp: Payload Exceeds Segment List");
+			return UET_RC_BAD_ADDR;
+		}
+		break;
+
+	case UET_MSG_BUF_TYPE_IOV:
+		if (scatter_flat_to_iov(rx_desc->buf_desc.iov.iov,
+					rx_desc->buf_desc.iov.iov_count,
+					ses->payload, pp->ses_payload_len,
+					msg_off) != pp->ses_payload_len) {
+			UET_API_ERR("Read Rsp: Payload Exceeds Scatter List");
+			return UET_RC_BAD_ADDR;
+		}
+		break;
+
+	case UET_MSG_BUF_TYPE_CONTIG:
 		buf_ptr = (void *) (((size_t) rx_desc->buf_desc.buf) + msg_off);
 		memcpy(buf_ptr, ses->payload, pp->ses_payload_len);
+		break;
+
+	default:
+		/* A read response lands in the initiator's own buffer. Any
+		 * other description of it is a bug rather than something to
+		 * fall through into a raw pointer dereference.
+		 */
+		UET_API_ERR("Read Rsp: unexpected buffer type %d",
+			    rx_desc->buf_desc.type);
+		return UET_RC_BAD_ADDR;
 	}
 
 	return UET_RC_OK;
@@ -4775,7 +5470,32 @@ static int uet_tx_msg(struct uet_tx_desc *tx_desc)
 				flags |= UET_PDS_FLAG_MAINTAIN_PDC;
 		}
 
-		if (tx_desc->buf_desc.type == UET_MSG_BUF_TYPE_IOV) {
+		if (tx_desc->buf_desc.type == UET_MSG_BUF_TYPE_SEG) {
+			/* The segment walk is positioned by absolute offset
+			 * rather than by a saved offset, so it needs how far
+			 * into the message this packet starts. buf_off is
+			 * that, and is what the iov path uses too - it is
+			 * advanced and reset alongside remaining_bytes.
+			 */
+			pkt_buf = calloc(payload_len, sizeof(char));
+			if (pkt_buf &&
+			    (gather_seg_to_flat(tx_desc->buf_desc.seg.seg,
+						tx_desc->buf_desc.seg.seg_count,
+						pkt_buf, payload_len,
+						tx_desc->buf_desc.buf_off) !=
+			     payload_len)) {
+				free(pkt_buf);
+				pkt_buf = NULL;
+			}
+
+			if (!pkt_buf) {
+				UET_API_ERR("TX: Failed to gather segments");
+				rc = -FI_ENOMEM;
+				uet_tx_desc_set_err(tx_desc, -rc,
+					UET_TX_DESC_STATE_ERR_COMPLETE);
+				goto exit;
+			}
+		} else if (tx_desc->buf_desc.type == UET_MSG_BUF_TYPE_IOV) {
 			pkt_buf = gather_iov_to_buffer(
 					tx_desc->buf_desc.iov.iov,
 					tx_desc->buf_desc.iov.iov_count,
@@ -4804,7 +5524,13 @@ static int uet_tx_msg(struct uet_tx_desc *tx_desc)
 					  flags, pds_info, tx_desc->msg_id,
 					  next_hdr, ses, ses_len,
 					  pkt_buf, pkt_len, false);
-		if (tx_desc->buf_desc.type == UET_MSG_BUF_TYPE_IOV)
+
+		/* The iov and segment paths each build the packet payload in
+		 * a buffer of their own; the contiguous path points straight
+		 * into the caller's buffer and must not be freed.
+		 */
+		if ((tx_desc->buf_desc.type == UET_MSG_BUF_TYPE_IOV) ||
+		    (tx_desc->buf_desc.type == UET_MSG_BUF_TYPE_SEG))
 			free(pkt_buf);
 
 		if (rc == FI_SUCCESS) {
@@ -5085,19 +5811,20 @@ static ssize_t uet_recv_api_common(
 	uet_recv_api_t recv_api, uet_ep_handle_t ep_handle, uint32_t job_id,
 	const struct iovec *iov, size_t iov_count, uet_mr_handle_t mr_handle,
 	uet_addr_handle_t src_addr_handle, uint64_t tag, uint64_t ignore,
-	void *context)
+	void *context, const struct uet_mr_seg *seg, size_t seg_count)
 #else
 static ssize_t uet_recv_api_common(
 	uet_recv_api_t recv_api, uet_ep_handle_t ep_handle, uint32_t job_id,
 	const struct iovec *iov, size_t iov_count, uet_mr_handle_t mr_handle,
 	uet_addr_handle_t src_addr_handle, uint64_t tag, uint64_t ignore,
-	void *context)
+	void *context, const struct uet_mr_seg *seg, size_t seg_count)
 #endif
 {
 	struct uet_ep *uet_ep;
 	struct uet_rx_desc *rx_desc;
 	struct uet_av_entry *av_entry;
 	struct iovec *iov_handle;
+	struct uet_mr_seg *seg_handle = NULL;
 	size_t msg_len = 0;
 	size_t i;
 
@@ -5118,16 +5845,43 @@ static ssize_t uet_recv_api_common(
 		}
 	}
 
-	/* allocate iov and init */
-	iov_handle = calloc(iov_count, sizeof(struct iovec));
-	if (iov_handle == NULL) {
-		UET_API_ERR("Allocation of iov memory failed");
-		return -FI_ENOMEM;
+	/* A segment list describes the buffer with memory regions rather
+	 * than with addresses in this process. Validate it once here so a
+	 * malformed list is rejected at the call rather than partway
+	 * through a transfer, then keep a copy so the caller's array need
+	 * not outlive the operation.
+	 */
+	if (seg != NULL) {
+		if (!uet_seg_validate(seg, seg_count)) {
+			UET_API_ERR("Invalid segment list");
+			return -FI_EINVAL;
+		}
+
+		msg_len = uet_seg_total_len(seg, seg_count);
+
+		seg_handle = calloc(seg_count, sizeof(struct uet_mr_seg));
+		if (seg_handle == NULL) {
+			UET_API_ERR("Allocation of segment list failed");
+			return -FI_ENOMEM;
+		}
+
+		memcpy(seg_handle, seg,
+		       (seg_count * sizeof(struct uet_mr_seg)));
 	}
 
-	for (i = 0; i < iov_count; i++) {
-		msg_len += iov[i].iov_len;
-		iov_handle[i] = iov[i];
+	/* allocate iov and init */
+	iov_handle = NULL;
+	if (seg == NULL) {
+		iov_handle = calloc(iov_count, sizeof(struct iovec));
+		if (iov_handle == NULL) {
+			UET_API_ERR("Allocation of iov memory failed");
+			return -FI_ENOMEM;
+		}
+
+		for (i = 0; i < iov_count; i++) {
+			msg_len += iov[i].iov_len;
+			iov_handle[i] = iov[i];
+		}
 	}
 
 	pthread_mutex_lock(&uet_ep->data_lock);
@@ -5137,19 +5891,26 @@ static ssize_t uet_recv_api_common(
 	if (rx_desc == NULL) {
 		pthread_mutex_unlock(&uet_ep->data_lock);
 		free(iov_handle);
+		free(seg_handle);
 		return -FI_EAGAIN;
 	}
 
 	/* init msg descriptor */
 	memset(rx_desc, 0, sizeof(struct uet_rx_desc));
 	rx_desc->desc_flags = UET_RX_DESC_FLAG_POST_CQ;
-	if (iov_count == 1) {
+	if (seg_handle != NULL) {
+		rx_desc->buf_desc.type = UET_MSG_BUF_TYPE_SEG;
+		rx_desc->buf_desc.seg.seg = seg_handle;
+		rx_desc->buf_desc.seg.seg_count = seg_count;
+		rx_desc->desc_flags |= UET_RX_DESC_FLAG_OWNS_SEG;
+	} else if (iov_count == 1) {
 		rx_desc->buf_desc.type = UET_MSG_BUF_TYPE_CONTIG;
 		rx_desc->buf_desc.buf = iov->iov_base;
 	} else {
 		rx_desc->buf_desc.type = UET_MSG_BUF_TYPE_IOV;
 		rx_desc->buf_desc.iov.iov = iov_handle;
 		rx_desc->buf_desc.iov.iov_count = iov_count;
+		rx_desc->desc_flags |= UET_RX_DESC_FLAG_OWNS_IOV;
 	}
 	rx_desc->buf_desc.len = msg_len;
 	rx_desc->context = context;
@@ -5217,18 +5978,18 @@ static ssize_t uet_recv_api_common(
 static ssize_t uet_send_req_api_common(
 	uet_send_req_api_t send_req_api, uet_ep_handle_t ep_handle,
 	uint32_t job_id, const struct iovec *iov, size_t iov_count,
-	uet_mr_handle_t mr_handle,
-	uet_addr_handle_t dst_addr_handle, uint64_t tag, uint64_t *imm_data,
-	uint64_t remote_mem_addr, uint64_t remote_key,
-	struct uet_atomic_parms *parms, void *context)
+	uet_mr_handle_t mr_handle, uet_addr_handle_t dst_addr_handle,
+	uint64_t tag, uint64_t *imm_data, uint64_t remote_mem_addr,
+	uint64_t remote_key, struct uet_atomic_parms *parms, void *context,
+	const struct uet_mr_seg *seg, size_t seg_count)
 #else
 static ssize_t uet_send_req_api_common(
 	uet_send_req_api_t send_req_api, uet_ep_handle_t ep_handle,
 	uint32_t job_id, const struct iovec *iov, size_t iov_count,
-	uet_mr_handle_t mr_handle,
-	uet_addr_handle_t dst_addr_handle, uint64_t tag, uint64_t *imm_data,
-	uint64_t remote_mem_addr, uint64_t remote_key,
-	struct uet_atomic_parms *parms, void *context, uint16_t resource_index)
+	uet_mr_handle_t mr_handle, uet_addr_handle_t dst_addr_handle,
+	uint64_t tag, uint64_t *imm_data, uint64_t remote_mem_addr,
+	uint64_t remote_key, struct uet_atomic_parms *parms, void *context,
+	uint16_t resource_index, const struct uet_mr_seg *seg, size_t seg_count)
 #endif /* ENABLE_VERBS */
 {
 	int rc;
@@ -5243,6 +6004,7 @@ static ssize_t uet_send_req_api_common(
 	struct uet_av_entry *av_entry;
 	struct uet_sync_grp_av_entry *sync_grp_av_entry;
 	struct iovec *iov_handle;
+	struct uet_mr_seg *seg_handle = NULL;
 
 	uet_ep = (struct uet_ep *) ep_handle;
 	uet = uet_ep->uet_domain->uet;
@@ -5263,22 +6025,56 @@ static ssize_t uet_send_req_api_common(
 		av_entry->flags |= UET_NH_MAC_ADDR_V;
 	}
 
-	/* allocate iov and init */
-	iov_handle = calloc(iov_count, sizeof(struct iovec));
-	if (iov_handle == NULL) {
-		UET_API_ERR("Allocation of iov memory failed");
-		return -FI_ENOMEM;
+	/* A segment list describes the buffer with memory regions rather
+	 * than with addresses in this process. Validate it once here so a
+	 * malformed list is rejected at the call rather than partway
+	 * through a transfer.
+	 */
+	if (seg != NULL) {
+		if (!uet_seg_validate(seg, seg_count)) {
+			UET_API_ERR("Invalid segment list");
+			return -FI_EINVAL;
+		}
+
+		msg_len = uet_seg_total_len(seg, seg_count);
+
+		seg_handle = calloc(seg_count, sizeof(struct uet_mr_seg));
+		if (seg_handle == NULL) {
+			UET_API_ERR("Allocation of segment list failed");
+			return -FI_ENOMEM;
+		}
+
+		memcpy(seg_handle, seg,
+		       (seg_count * sizeof(struct uet_mr_seg)));
 	}
 
-	for (i = 0; i < iov_count; i++) {
-		msg_len += iov[i].iov_len;
-		iov_handle[i] = iov[i];
+	/* Total the length, and keep a private copy of the vector only when
+	 * a descriptor will actually reference it. A single-entry buffer is
+	 * recorded as contiguous and keeps no vector, and a segment list
+	 * keeps no vector at all.
+	 */
+	iov_handle = NULL;
+	if (seg == NULL) {
+		for (i = 0; i < iov_count; i++)
+			msg_len += iov[i].iov_len;
+
+		if (iov_count > 1) {
+			iov_handle = calloc(iov_count, sizeof(struct iovec));
+			if (iov_handle == NULL) {
+				UET_API_ERR("Allocation of iov memory failed");
+				return -FI_ENOMEM;
+			}
+
+			for (i = 0; i < iov_count; i++)
+				iov_handle[i] = iov[i];
+		}
 	}
 
 	/* allocate msg id */
 	rc = uet_alloc_msg_id(uet, &msg_id);
 	if (rc != FI_SUCCESS) {
 		free(iov_handle);
+		free(seg_handle);
 		return rc;
 	}
 
@@ -5291,6 +6087,7 @@ static ssize_t uet_send_req_api_common(
 		if (rc != FI_SUCCESS) {
 			uet_dealloc_msg_id(uet, msg_id);
 			free(iov_handle);
+			free(seg_handle);
 			return rc;
 		}
 		break;
@@ -5306,6 +6103,7 @@ static ssize_t uet_send_req_api_common(
 	if (tx_desc == NULL) {
 		pthread_mutex_unlock(&uet_ep->data_lock);
 		free(iov_handle);
+		free(seg_handle);
 		uet_dealloc_msg_id(uet, msg_id);
 		if (sync_grp_av_entry)
 			uet_sync_grp_free_initiator(uet_ep,
@@ -5338,6 +6136,7 @@ static ssize_t uet_send_req_api_common(
 			uet_tx_desc_list_insert(tx_desc);
 			pthread_mutex_unlock(&uet_ep->data_lock);
 			free(iov_handle);
+			free(seg_handle);
 			uet_dealloc_msg_id(uet, msg_id);
 			if (sync_grp_av_entry)
 				uet_sync_grp_free_initiator(
@@ -5350,7 +6149,30 @@ static ssize_t uet_send_req_api_common(
 		memset(rx_desc, 0, sizeof(struct uet_rx_desc));
 		rx_desc->desc_flags =
 			UET_RX_DESC_FLAG_POST_CQ | UET_RX_DESC_FLAG_READ_RSP;
-		if (iov_count == 1) {
+		if (seg_handle != NULL) {
+			/* The read response lands here while the request's
+			 * transmit descriptor is recycled independently, so
+			 * this descriptor gets its own copy of the list
+			 * rather than sharing one with two owners.
+			 */
+			struct uet_mr_seg *rx_seg =
+				calloc(seg_count, sizeof(struct uet_mr_seg));
+
+			if (rx_seg == NULL) {
+				pthread_mutex_unlock(&uet_ep->data_lock);
+				free(iov_handle);
+				free(seg_handle);
+				return -FI_ENOMEM;
+			}
+
+			memcpy(rx_seg, seg_handle,
+			       (seg_count * sizeof(struct uet_mr_seg)));
+
+			rx_desc->buf_desc.type = UET_MSG_BUF_TYPE_SEG;
+			rx_desc->buf_desc.seg.seg = rx_seg;
+			rx_desc->buf_desc.seg.seg_count = seg_count;
+			rx_desc->desc_flags |= UET_RX_DESC_FLAG_OWNS_SEG;
+		} else if (iov_count == 1) {
 			rx_desc->buf_desc.type = UET_MSG_BUF_TYPE_CONTIG;
 			rx_desc->buf_desc.buf = iov->iov_base;
 		} else {
@@ -5374,7 +6196,12 @@ static ssize_t uet_send_req_api_common(
 	memset(tx_desc, 0, sizeof(struct uet_tx_desc));
 	tx_desc->desc_flags = UET_TX_DESC_FLAG_MSG_ID_ALLOCATED |
 			      UET_TX_DESC_FLAG_POST_CQ;
-	if (iov_count == 1) {
+	if (seg_handle != NULL) {
+		tx_desc->buf_desc.type = UET_MSG_BUF_TYPE_SEG;
+		tx_desc->buf_desc.seg.seg = seg_handle;
+		tx_desc->buf_desc.seg.seg_count = seg_count;
+		tx_desc->desc_flags |= UET_TX_DESC_FLAG_OWNS_SEG;
+	} else if (iov_count == 1) {
 		tx_desc->buf_desc.type = UET_MSG_BUF_TYPE_CONTIG;
 		tx_desc->buf_desc.buf = iov->iov_base;
 	} else {
@@ -6456,22 +7283,22 @@ uint32_t uet_cq_read_src_id(uet_cq_handle_t cq_handle)
 	return cq->last_src_id;
 }
 
-ssize_t uet_cq_read(uet_cq_handle_t cq_handle, void *buf, size_t count)
+/*
+ * run one progress cycle for an endpoint
+ *
+ * Ages idle receive messages and receive sync groups, drives one receive
+ * packet through the PDS, drives pending transmits, and retries deferred
+ * transmit messages.
+ *
+ * NOTE: the caller MUST hold uet_ep->data_lock
+ */
+static void uet_ep_progress_locked(struct uet_ep *uet_ep)
 {
 	int rc;
 	uet_pkt_handle_t err_pkt_handle;
-	struct uet_cq *cq;
-	struct uet_ep *uet_ep;
 	struct uet_pds *pds;
-	struct uet_ring *ring;
-	ssize_t cq_count, rd_count, max_rd_count;
-	char *buffer = buf;
 
-	cq = (struct uet_cq *) cq_handle;
-	uet_ep = cq->uet_ep;
 	pds = &uet_ep->uet_domain->uet->pds;
-
-	pthread_mutex_lock(&uet_ep->data_lock);
 
 	uet_msg_age(uet_ep);
 	uet_rx_sync_grp_age(uet_ep);
@@ -6490,6 +7317,62 @@ ssize_t uet_cq_read(uet_cq_handle_t cq_handle, void *buf, size_t count)
 	}
 
 	uet_tx_msg_try(uet_ep);
+}
+
+int uet_ep_progress(uet_ep_handle_t ep_handle)
+{
+	struct uet_ep *uet_ep = (struct uet_ep *) ep_handle;
+
+	if (uet_ep == NULL)
+		return -FI_EINVAL;
+
+	pthread_mutex_lock(&uet_ep->data_lock);
+	uet_ep_progress_locked(uet_ep);
+	pthread_mutex_unlock(&uet_ep->data_lock);
+
+	return FI_SUCCESS;
+}
+
+int uet_progress(uet_domain_handle_t domain_handle)
+{
+	struct uet_domain *uet_dom = (struct uet_domain *) domain_handle;
+	struct uet_ep *uet_ep;
+	struct dlist_entry *head, *item;
+
+	if (uet_dom == NULL)
+		return -FI_EINVAL;
+
+	head = &uet_dom->ep_list_head;
+
+	uet_rw_lock(&uet_dom->ep_lock, UET_RW_LOCK_RD_ACCESS);
+
+	dlist_foreach(head, item) {
+		uet_ep = container_of(item, struct uet_ep, ep_list_entry);
+
+		pthread_mutex_lock(&uet_ep->data_lock);
+		uet_ep_progress_locked(uet_ep);
+		pthread_mutex_unlock(&uet_ep->data_lock);
+	}
+
+	uet_rw_unlock(&uet_dom->ep_lock, UET_RW_LOCK_RD_ACCESS);
+
+	return FI_SUCCESS;
+}
+
+ssize_t uet_cq_read(uet_cq_handle_t cq_handle, void *buf, size_t count)
+{
+	struct uet_cq *cq;
+	struct uet_ep *uet_ep;
+	struct uet_ring *ring;
+	ssize_t cq_count, rd_count, max_rd_count;
+	char *buffer = buf;
+
+	cq = (struct uet_cq *) cq_handle;
+	uet_ep = cq->uet_ep;
+
+	pthread_mutex_lock(&uet_ep->data_lock);
+
+	uet_ep_progress_locked(uet_ep);
 
 	ring = &cq->ring;
 	cq_count = uet_ring_entry_cnt(ring);
@@ -6638,7 +7521,7 @@ ssize_t uet_recv(uet_ep_handle_t ep_handle, uint32_t job_id,
 
 	return (uet_recv_api_common(UET_RECV_API, ep_handle, job_id, &iov, 1,
 				    mr_handle, src_addr_handle, UET_NO_TAG,
-				    UET_NO_IGNORE_BITS, context));
+				    UET_NO_IGNORE_BITS, context, NULL, 0));
 }
 
 ssize_t uet_recvv(
@@ -6648,7 +7531,7 @@ ssize_t uet_recvv(
 {
 	return (uet_recv_api_common(UET_RECV_API, ep_handle, job_id, iov, count,
 				    mr_handle, src_addr_handle, UET_NO_TAG,
-				    UET_NO_IGNORE_BITS, context));
+				    UET_NO_IGNORE_BITS, context, NULL, 0));
 }
 
 #else
@@ -6665,7 +7548,7 @@ ssize_t uet_recv(uet_ep_handle_t ep_handle, uint32_t job_id,
 
 	return (uet_recv_api_common(UET_RECV_API, ep_handle, job_id, &iov, 1,
 				    mr_handle, src_addr_handle, UET_NO_TAG,
-				    UET_NO_IGNORE_BITS, context));
+				    UET_NO_IGNORE_BITS, context, NULL, 0));
 }
 
 ssize_t uet_recvv(
@@ -6675,7 +7558,8 @@ ssize_t uet_recvv(
 {
 	return (uet_recv_api_common(UET_RECV_API, ep_handle, job_id, iov,
 				    count, mr_handle, src_addr_handle,
-				    UET_NO_TAG, UET_NO_IGNORE_BITS, context));
+				    UET_NO_TAG, UET_NO_IGNORE_BITS, context,
+				    NULL, 0));
 }
 
 #endif /* ENABLE_VERBS */
@@ -6688,7 +7572,7 @@ ssize_t uet_trecvv(uet_ep_handle_t ep_handle, uint32_t job_id,
 {
 	return (uet_recv_api_common(UET_TRECV_API, ep_handle, job_id, iov,
 				    count, mr_handle, src_addr_handle, tag,
-				    ignore, context));
+				    ignore, context, NULL, 0));
 }
 
 #if !ENABLE_VERBS
@@ -6705,7 +7589,7 @@ ssize_t uet_send(uet_ep_handle_t ep_handle, uint32_t job_id,
 			UET_SEND_API, ep_handle, job_id, &iov, 1, mr_handle,
 			dst_addr_handle, UET_NO_TAG, UET_NO_IMM_DATA,
 			UET_NO_REMOTE_MEM_ADDR, UET_NO_REMOTE_KEY,
-			NULL, context));
+			NULL, context, NULL, 0));
 }
 
 ssize_t uet_sendv(
@@ -6717,7 +7601,7 @@ ssize_t uet_sendv(
 			UET_SEND_API, ep_handle, job_id, iov, count, mr_handle,
 			dst_addr_handle, UET_NO_TAG, UET_NO_IMM_DATA,
 			UET_NO_REMOTE_MEM_ADDR, UET_NO_REMOTE_KEY,
-			NULL, context));
+			NULL, context, NULL, 0));
 }
 
 #else
@@ -6735,7 +7619,7 @@ ssize_t uet_send(uet_ep_handle_t ep_handle, uint32_t job_id,
 			UET_SEND_API, ep_handle, job_id, &iov, 1, mr_handle,
 			dst_addr_handle, UET_NO_TAG, UET_NO_IMM_DATA,
 			UET_NO_REMOTE_MEM_ADDR, UET_NO_REMOTE_KEY,
-			NULL, context, resource_index));
+			NULL, context, resource_index, NULL, 0));
 }
 
 ssize_t uet_sendv(
@@ -6748,7 +7632,7 @@ ssize_t uet_sendv(
 			UET_SEND_API, ep_handle, job_id, iov, count, mr_handle,
 			dst_addr_handle, UET_NO_TAG, UET_NO_IMM_DATA,
 			UET_NO_REMOTE_MEM_ADDR, UET_NO_REMOTE_KEY,
-			NULL, context, resource_index));
+			NULL, context, resource_index, NULL, 0));
 }
 
 ssize_t uet_send_imm(uet_ep_handle_t ep_handle, uint32_t job_id,
@@ -6765,7 +7649,7 @@ ssize_t uet_send_imm(uet_ep_handle_t ep_handle, uint32_t job_id,
 			UET_SEND_API, ep_handle, job_id, &iov, 1, mr_handle,
 			dst_addr_handle, UET_NO_TAG, imm_data,
 			UET_NO_REMOTE_MEM_ADDR, UET_NO_REMOTE_KEY,
-			NULL, context, resource_index));
+			NULL, context, resource_index, NULL, 0));
 }
 
 ssize_t uet_sendv_imm(uet_ep_handle_t ep_handle, uint32_t job_id,
@@ -6778,7 +7662,7 @@ ssize_t uet_sendv_imm(uet_ep_handle_t ep_handle, uint32_t job_id,
 			UET_SEND_API, ep_handle, job_id, iov, count, mr_handle,
 			dst_addr_handle, UET_NO_TAG, imm_data,
 			UET_NO_REMOTE_MEM_ADDR, UET_NO_REMOTE_KEY,
-			NULL, context, resource_index));
+			NULL, context, resource_index, NULL, 0));
 }
 #endif /* ENABLE_VERBS */
 
@@ -6792,7 +7676,7 @@ ssize_t uet_tsendv(
 			UET_TSEND_API, ep_handle, job_id, iov, count, mr_handle,
 			dst_addr_handle, tag, UET_NO_IMM_DATA,
 			UET_NO_REMOTE_MEM_ADDR, UET_NO_REMOTE_KEY,
-			NULL, context));
+			NULL, context, NULL, 0));
 }
 #endif
 
@@ -6808,7 +7692,7 @@ ssize_t uet_trecv(uet_ep_handle_t ep_handle, uint32_t job_id,
 
 	return (uet_recv_api_common(UET_TRECV_API, ep_handle, job_id, &iov, 1,
 				    mr_handle, src_addr_handle, tag, ignore,
-				    context));
+				    context, NULL, 0));
 }
 
 #if !ENABLE_VERBS
@@ -6826,7 +7710,7 @@ ssize_t uet_tsend(uet_ep_handle_t ep_handle, uint32_t job_id,
 			UET_TSEND_API, ep_handle, job_id, &iov, 1, mr_handle,
 			dst_addr_handle, tag, UET_NO_IMM_DATA,
 			UET_NO_REMOTE_MEM_ADDR, UET_NO_REMOTE_KEY,
-			NULL, context));
+			NULL, context, NULL, 0));
 }
 #endif
 
@@ -6861,19 +7745,32 @@ int uet_mr_reg(uet_domain_handle_t domain_handle, const void *buf, size_t len,
 			   flags, context, mr_handle);
 }
 
-int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
-		size_t iov_count, uint64_t access, uint64_t requested_key,
-		uint64_t flags, void *context, uet_mr_handle_t *mr_handle)
+/* log2 of a power-of-two page size */
+static unsigned int uet_log2(uint32_t v)
+{
+	unsigned int n = 0;
+
+	while ((v >>= 1) != 0)
+		n++;
+
+	return n;
+}
+
+/*
+ * allocate a memory region key and descriptor index
+ *
+ * Shared by every registration entry point, the key spaces and the
+ * descriptor index are independent of how the region's memory is
+ * described.
+ */
+static int uet_mr_alloc_key(struct uet_domain *uet_dom, uint64_t requested_key,
+			    uint64_t flags, uint64_t *out_key,
+			    uint64_t *out_rkey, size_t *out_mr_index)
 {
 	int rc;
 	uint64_t key, rkey;
 	bool desc_allocated;
-	size_t mr_index, msg_len = 0;
-	struct uet_domain *uet_dom;
-	struct uet_mr_desc *mr_desc;
-	struct iovec *iov_handle;
-
-	uet_dom = (struct uet_domain *) domain_handle;
+	size_t mr_index;
 
 	/*
 	 * The provider maintains two independent memory-region lookup spaces:
@@ -6941,10 +7838,108 @@ int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
 			return rc;
 	}
 
-	/* A contiguous registration stores the buffer directly. Only retain a
-	 * private iovec copy for a real scatter/gather registration.
+	*out_key = key;
+	*out_rkey = rkey;
+	*out_mr_index = mr_index;
+	return FI_SUCCESS;
+}
+
+int uet_mr_reg_pbl(uet_domain_handle_t domain_handle, uet_dma_addr_t pbl_root,
+		   uint32_t page_size, uet_pbl_level_t level,
+		   uint32_t page_offset, uint64_t base_va, size_t len,
+		   uint64_t access, uint64_t requested_key, uint64_t flags,
+		   void *context, uet_mr_handle_t *mr_handle)
+{
+	int rc;
+	uint64_t key, rkey;
+	size_t mr_index;
+	struct uet_domain *uet_dom;
+	struct uet_mr_desc *mr_desc;
+
+	uet_dom = (struct uet_domain *)domain_handle;
+
+	/* a page size must be a non-zero power of two */
+	if ((page_size == 0) || ((page_size & (page_size - 1)) != 0)) {
+		UET_API_ERR("PBL page size must be a power of 2");
+		return -FI_EINVAL;
+	}
+
+	if (page_offset >= page_size) {
+		UET_API_ERR("PBL page offset must be within the first page");
+		return -FI_EINVAL;
+	}
+
+	switch (level) {
+	case UET_PBL_LEVEL_0:
+	case UET_PBL_LEVEL_1:
+	case UET_PBL_LEVEL_2:
+		break;
+	default:
+		UET_API_ERR("Invalid PBL level");
+		return -FI_EINVAL;
+	}
+
+	rc = uet_mr_alloc_key(uet_dom, requested_key, flags, &key, &rkey,
+			      &mr_index);
+	if (rc != FI_SUCCESS)
+		return rc;
+
+	mr_desc = &uet_dom->mr_desc[mr_index];
+	memset(mr_desc, 0, sizeof(struct uet_mr_desc));
+	mr_desc->state = UET_MR_DESC_STATE_DISABLED_REG;
+	mr_desc->uet_dom = uet_dom;
+
+	/*
+	 * buf stays NULL: a page list has no single base address. len is the
+	 * region's length in its flattened address space, which every bounds
+	 * check in the rma paths already tests against.
 	 */
-	iov_handle = NULL;
+	mr_desc->buf_desc.type = UET_MR_BUF_TYPE_PBL;
+	mr_desc->buf_desc.len = len;
+	mr_desc->buf_desc.pbl.root = pbl_root;
+	mr_desc->buf_desc.pbl.page_size = page_size;
+	mr_desc->buf_desc.pbl.page_offset = page_offset;
+	mr_desc->buf_desc.pbl.page_shift = (uint8_t)uet_log2(page_size);
+	mr_desc->buf_desc.pbl.level = level;
+
+	mr_desc->access = access;
+	mr_desc->flags = flags;
+	mr_desc->context = context;
+	mr_desc->full_key = key;
+	mr_desc->hash_key.rkey = rkey;
+	mr_desc->user_key = !!(flags & UET_MR_FLAG_USER_KEY);
+	mr_desc->base_va = base_va;
+
+	*mr_handle = mr_desc;
+
+	return FI_SUCCESS;
+}
+
+int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
+		size_t iov_count, uint64_t access, uint64_t requested_key,
+		uint64_t flags, void *context, uet_mr_handle_t *mr_handle)
+{
+	int rc;
+	uint64_t key, rkey;
+	size_t mr_index, tot_len = 0;
+	struct uet_domain *uet_dom;
+	struct uet_mr_desc *mr_desc;
+	struct iovec *iov_handle = NULL;
+
+	uet_dom = (struct uet_domain *)domain_handle;
+
+	rc = uet_mr_alloc_key(uet_dom, requested_key, flags, &key, &rkey,
+			      &mr_index);
+	if (rc != FI_SUCCESS)
+		return rc;
+
+	for (int i = 0; i < iov_count; i++)
+		tot_len += iov[i].iov_len;
+
+	/* Only a multi-entry region needs a private copy of the vector; a
+	 * single-entry region is recorded as a contiguous buffer and keeps
+	 * no vector at all
+	 */
 	if (iov_count > 1) {
 		iov_handle = calloc(iov_count, sizeof(struct iovec));
 		if (iov_handle == NULL) {
@@ -6952,11 +7947,8 @@ int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
 					    &uet_dom->mr_desc[mr_index]);
 			return -FI_ENOMEM;
 		}
-	}
 
-	for (int i = 0; i < iov_count; i++) {
-		msg_len += iov[i].iov_len;
-		if (iov_handle)
+		for (int i = 0; i < iov_count; i++)
 			iov_handle[i] = iov[i];
 	}
 
@@ -6971,7 +7963,7 @@ int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
 		mr_desc->buf_desc.len = iov->iov_len;
 	} else {
 		mr_desc->buf_desc.type = UET_MR_BUF_TYPE_IOV;
-		mr_desc->buf_desc.len = msg_len;
+		mr_desc->buf_desc.len = tot_len;
 		mr_desc->buf_desc.iov.iov = iov_handle;
 		mr_desc->buf_desc.iov.iov_count = iov_count;
 	}
@@ -6981,6 +7973,9 @@ int uet_mr_regv(uet_domain_handle_t domain_handle, const struct iovec *iov,
 	mr_desc->full_key = key;
 	mr_desc->hash_key.rkey = rkey;
 	mr_desc->user_key = !!(flags & UET_MR_FLAG_USER_KEY);
+
+	/* zero-based: addresses naming this region are offsets */
+	mr_desc->base_va = 0;
 
 	*mr_handle = mr_desc;
 
@@ -7100,12 +8095,26 @@ int uet_mr_enable(uet_mr_handle_t mr_handle)
 		return -FI_EINVAL;
 	}
 
-	if (mr_desc->buf_desc.type != UET_MR_BUF_TYPE_CONTIG) {
-		UET_API_ERR("MR reg only supported for contiguous buf type");
+	switch (mr_desc->buf_desc.type) {
+	case UET_MR_BUF_TYPE_CONTIG:
+		mr_desc->buf_desc.contig.dma_addr =
+			(uet_dma_addr_t)mr_desc->buf_desc.buf;
+		break;
+
+	case UET_MR_BUF_TYPE_IOV:
+	case UET_MR_BUF_TYPE_PBL:
+		/* A scattered region has no single base address, so
+		 * buf_desc.buf stays NULL and every consumer must branch on
+		 * buf_desc.type rather than dereference it. Per-entry
+		 * addresses live in buf_desc.iov or buf_desc.pbl.
+		 */
+		break;
+
+	default:
+		UET_API_ERR("MR reg only supported for contiguous and iov "
+			    "buf types");
 		return -FI_EINVAL;
 	}
-
-	mr_desc->buf_desc.contig.dma_addr = (uet_dma_addr_t) mr_desc->buf_desc.buf;
 
 	/*
 	 * Insert into the lookup space that matches the key's origin: user
@@ -7172,7 +8181,7 @@ ssize_t uet_write(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
 	return (uet_send_req_api_common(
 			UET_WRITE_API, ep_handle, job_id, &iov, 1, mr_handle,
 			dst_addr_handle, UET_NO_TAG, data, remote_mem_addr,
-			remote_key, NULL, context));
+			remote_key, NULL, context, NULL, 0));
 }
 
 ssize_t uet_write_sync(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
@@ -7189,7 +8198,7 @@ ssize_t uet_write_sync(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
 	return (uet_send_req_api_common(
 			UET_WRITE_SYNC_API, ep_handle, job_id, &iov, 1,
 			mr_handle, dst_addr_handle, UET_NO_TAG, data,
-			remote_mem_addr, remote_key, NULL, context));
+			remote_mem_addr, remote_key, NULL, context, NULL, 0));
 }
 
 ssize_t uet_read(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
@@ -7205,7 +8214,7 @@ ssize_t uet_read(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
 	return (uet_send_req_api_common(
 			UET_READ_API, ep_handle, job_id, &iov, 1, mr_handle,
 			uet_addr_handle, UET_NO_TAG, UET_NO_IMM_DATA,
-			remote_mem_addr, remote_key, NULL, context));
+			remote_mem_addr, remote_key, NULL, context, NULL, 0));
 }
 
 #else
@@ -7223,7 +8232,7 @@ ssize_t uet_write(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
 	return (uet_send_req_api_common(
 			UET_WRITE_API, ep_handle, job_id, &iov, 1, mr_handle,
 			dst_addr_handle, UET_NO_TAG, data, remote_mem_addr,
-			remote_key, NULL, context, resource_index));
+			remote_key, NULL, context, resource_index, NULL, 0));
 }
 
 ssize_t uet_write_sync(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
@@ -7241,7 +8250,7 @@ ssize_t uet_write_sync(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
 			UET_WRITE_SYNC_API, ep_handle, job_id, &iov, 1,
 			mr_handle, dst_addr_handle, UET_NO_TAG, data,
 			remote_mem_addr, remote_key, NULL, context,
-			resource_index));
+			resource_index, NULL, 0));
 }
 
 ssize_t uet_read(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
@@ -7259,7 +8268,7 @@ ssize_t uet_read(uet_ep_handle_t ep_handle, uint32_t job_id, void *buf,
 			UET_READ_API, ep_handle, job_id, &iov, 1, mr_handle,
 			uet_addr_handle, UET_NO_TAG, UET_NO_IMM_DATA,
 			remote_mem_addr, remote_key, NULL, context,
-			resource_index));
+			resource_index, NULL, 0));
 }
 
 ssize_t uet_writev(uet_ep_handle_t ep_handle, uint32_t job_id,
@@ -7271,7 +8280,7 @@ ssize_t uet_writev(uet_ep_handle_t ep_handle, uint32_t job_id,
 	return (uet_send_req_api_common(
 			UET_WRITE_API, ep_handle, job_id, iov, count, mr_handle,
 			dst_addr_handle, UET_NO_TAG, data, remote_mem_addr,
-			remote_key, NULL, context, resource_index));
+			remote_key, NULL, context, resource_index, NULL, 0));
 }
 
 ssize_t uet_readv(uet_ep_handle_t ep_handle, uint32_t job_id,
@@ -7284,9 +8293,124 @@ ssize_t uet_readv(uet_ep_handle_t ep_handle, uint32_t job_id,
 			UET_READ_API, ep_handle, job_id, iov, count, mr_handle,
 			uet_addr_handle, UET_NO_TAG, UET_NO_IMM_DATA,
 			remote_mem_addr, remote_key, NULL, context,
-			resource_index));
+			resource_index, NULL, 0));
 }
 #endif /* ENABLE_VERBS */
+
+/*
+ * Segment-list variants. The local buffer is described by memory regions
+ * rather than by addresses in this process, everything else matches the
+ * corresponding iov form.
+ */
+#if !ENABLE_VERBS
+ssize_t uet_sendseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		    const struct uet_mr_seg *seg, size_t seg_count,
+		    uet_addr_handle_t dst_addr_handle, void *context)
+{
+	return (uet_send_req_api_common(
+			UET_SEND_API, ep_handle, job_id, NULL, 0, NULL,
+			dst_addr_handle, UET_NO_TAG, UET_NO_IMM_DATA,
+			UET_NO_REMOTE_MEM_ADDR, UET_NO_REMOTE_KEY,
+			NULL, context, seg, seg_count));
+}
+
+ssize_t uet_sendseg_imm(uet_ep_handle_t ep_handle, uint32_t job_id,
+			const struct uet_mr_seg *seg, size_t seg_count,
+			uint64_t *data, uet_addr_handle_t dst_addr_handle,
+			void *context)
+{
+	return (uet_send_req_api_common(
+			UET_SEND_API, ep_handle, job_id, NULL, 0, NULL,
+			dst_addr_handle, UET_NO_TAG, data,
+			UET_NO_REMOTE_MEM_ADDR, UET_NO_REMOTE_KEY,
+			NULL, context, seg, seg_count));
+}
+
+ssize_t uet_writeseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		     const struct uet_mr_seg *seg, size_t seg_count,
+		     uint64_t *data, uet_addr_handle_t dst_addr_handle,
+		     uint64_t remote_mem_addr, uint64_t remote_key,
+		     void *context)
+{
+	return (uet_send_req_api_common(
+			UET_WRITE_API, ep_handle, job_id, NULL, 0, NULL,
+			dst_addr_handle, UET_NO_TAG, data, remote_mem_addr,
+			remote_key, NULL, context, seg, seg_count));
+}
+
+ssize_t uet_readseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		    const struct uet_mr_seg *seg, size_t seg_count,
+		    uet_addr_handle_t uet_addr_handle,
+		    uint64_t remote_mem_addr, uint64_t remote_key,
+		    void *context)
+{
+	return (uet_send_req_api_common(
+			UET_READ_API, ep_handle, job_id, NULL, 0, NULL,
+			uet_addr_handle, UET_NO_TAG, UET_NO_IMM_DATA,
+			remote_mem_addr, remote_key, NULL, context,
+			seg, seg_count));
+}
+#else
+ssize_t uet_sendseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		    const struct uet_mr_seg *seg, size_t seg_count,
+		    uet_addr_handle_t dst_addr_handle, void *context,
+		    uint16_t resource_index)
+{
+	return (uet_send_req_api_common(
+			UET_SEND_API, ep_handle, job_id, NULL, 0, NULL,
+			dst_addr_handle, UET_NO_TAG, UET_NO_IMM_DATA,
+			UET_NO_REMOTE_MEM_ADDR, UET_NO_REMOTE_KEY,
+			NULL, context, resource_index, seg, seg_count));
+}
+
+ssize_t uet_sendseg_imm(uet_ep_handle_t ep_handle, uint32_t job_id,
+			const struct uet_mr_seg *seg, size_t seg_count,
+			uint64_t *data, uet_addr_handle_t dst_addr_handle,
+			void *context, uint16_t resource_index)
+{
+	return (uet_send_req_api_common(
+			UET_SEND_API, ep_handle, job_id, NULL, 0, NULL,
+			dst_addr_handle, UET_NO_TAG, data,
+			UET_NO_REMOTE_MEM_ADDR, UET_NO_REMOTE_KEY,
+			NULL, context, resource_index, seg, seg_count));
+}
+
+ssize_t uet_writeseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		     const struct uet_mr_seg *seg, size_t seg_count,
+		     uint64_t *data, uet_addr_handle_t dst_addr_handle,
+		     uint64_t remote_mem_addr, uint64_t remote_key,
+		     void *context, uint16_t resource_index)
+{
+	return (uet_send_req_api_common(
+			UET_WRITE_API, ep_handle, job_id, NULL, 0, NULL,
+			dst_addr_handle, UET_NO_TAG, data, remote_mem_addr,
+			remote_key, NULL, context, resource_index,
+			seg, seg_count));
+}
+
+ssize_t uet_readseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		    const struct uet_mr_seg *seg, size_t seg_count,
+		    uet_addr_handle_t uet_addr_handle,
+		    uint64_t remote_mem_addr, uint64_t remote_key,
+		    void *context, uint16_t resource_index)
+{
+	return (uet_send_req_api_common(
+			UET_READ_API, ep_handle, job_id, NULL, 0, NULL,
+			uet_addr_handle, UET_NO_TAG, UET_NO_IMM_DATA,
+			remote_mem_addr, remote_key, NULL, context,
+			resource_index, seg, seg_count));
+}
+#endif /* ENABLE_VERBS */
+
+ssize_t uet_recvseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		    const struct uet_mr_seg *seg, size_t seg_count,
+		    uet_addr_handle_t src_addr_handle, void *context)
+{
+	return (uet_recv_api_common(UET_RECV_API, ep_handle, job_id, NULL, 0,
+				    NULL, src_addr_handle, UET_NO_TAG,
+				    UET_NO_IGNORE_BITS, context,
+				    seg, seg_count));
+}
 
 int uet_query_atomic(uet_domain_handle_t domain_handle,
 		     enum fi_datatype datatype, enum fi_op op,
@@ -7394,7 +8518,7 @@ ssize_t uet_atomic(uet_ep_handle_t ep_handle, uint32_t job_id,
                         UET_ATOMIC_API, ep_handle, job_id, &iov, 1,
                         mr_handle, dst_addr_handle, UET_NO_TAG,
                         UET_NO_IMM_DATA, remote_mem_addr, remote_key,
-                        &parms, context));
+                        &parms, context, NULL, 0));
 }
 #else
 ssize_t uet_atomic(uet_ep_handle_t ep_handle, uint32_t job_id,
@@ -7421,7 +8545,7 @@ ssize_t uet_atomic(uet_ep_handle_t ep_handle, uint32_t job_id,
                         UET_ATOMIC_API, ep_handle, job_id, &iov, 1,
                         mr_handle, dst_addr_handle, UET_NO_TAG,
                         UET_NO_IMM_DATA, remote_mem_addr, remote_key,
-                        &parms, context, resource_index));
+                        &parms, context, resource_index, NULL, 0));
 }
 #endif
 
@@ -7450,7 +8574,7 @@ ssize_t uet_atomic_sync(uet_ep_handle_t ep_handle, uint32_t job_id,
 			UET_ATOMIC_SYNC_API, ep_handle, job_id, &iov, 1,
 			mr_handle, dst_addr_handle, UET_NO_TAG,
 			UET_NO_IMM_DATA, remote_mem_addr, remote_key,
-			&parms, context));
+			&parms, context, NULL, 0));
 }
 #else
 ssize_t uet_atomic_sync(uet_ep_handle_t ep_handle, uint32_t job_id,
@@ -7477,7 +8601,7 @@ ssize_t uet_atomic_sync(uet_ep_handle_t ep_handle, uint32_t job_id,
 			UET_ATOMIC_SYNC_API, ep_handle, job_id, &iov, 1,
 			mr_handle, dst_addr_handle, UET_NO_TAG,
 			UET_NO_IMM_DATA, remote_mem_addr, remote_key,
-			&parms, context, resource_index));
+			&parms, context, resource_index, NULL, 0));
 }
 #endif
 
@@ -7509,7 +8633,7 @@ ssize_t uet_fetch_atomic(uet_ep_handle_t ep_handle, uint32_t job_id,
 			UET_FETCH_ATOMIC_API, ep_handle, job_id, &iov, 1,
 			op_mr_handle, dst_addr_handle, UET_NO_TAG,
 			UET_NO_IMM_DATA, remote_mem_addr, remote_key,
-			&parms, context));
+			&parms, context, NULL, 0));
 }
 #else
 ssize_t uet_fetch_atomic(uet_ep_handle_t ep_handle, uint32_t job_id,
@@ -7540,7 +8664,7 @@ ssize_t uet_fetch_atomic(uet_ep_handle_t ep_handle, uint32_t job_id,
 			UET_FETCH_ATOMIC_API, ep_handle, job_id, &iov, 1,
 			op_mr_handle, dst_addr_handle, UET_NO_TAG,
 			UET_NO_IMM_DATA, remote_mem_addr, remote_key,
-			&parms, context, resource_index));
+			&parms, context, resource_index, NULL, 0));
 }
 #endif /* ENABLE_VERBS */
 
@@ -7573,7 +8697,7 @@ ssize_t uet_compare_atomic(uet_ep_handle_t ep_handle, uint32_t job_id,
 			UET_COMPARE_ATOMIC_API, ep_handle, job_id, &iov, 1,
 			op_mr_handle, dst_addr_handle, UET_NO_TAG,
 			UET_NO_IMM_DATA, remote_mem_addr, remote_key,
-			&parms, context));
+			&parms, context, NULL, 0));
 }
 #else
 ssize_t uet_compare_atomic(uet_ep_handle_t ep_handle, uint32_t job_id,
@@ -7605,7 +8729,7 @@ ssize_t uet_compare_atomic(uet_ep_handle_t ep_handle, uint32_t job_id,
 			UET_COMPARE_ATOMIC_API, ep_handle, job_id, &iov, 1,
 			op_mr_handle, dst_addr_handle, UET_NO_TAG,
 			UET_NO_IMM_DATA, remote_mem_addr, remote_key,
-			&parms, context, resource_index));
+			&parms, context, resource_index, NULL, 0));
 }
 #endif /* ENABLE_VERBS */
 

--- a/uet_api.h
+++ b/uet_api.h
@@ -75,6 +75,45 @@ typedef void *uet_cntr_handle_t;    /* handle for counter instance */
 typedef void *uet_addr_handle_t;    /* handle for uet address */
 typedef void *uet_mr_handle_t;      /* handle for memory region */
 
+/*
+ * An address as a device would see it on the bus. When the implementation
+ * runs in the address space that owns the memory, the standalone app and
+ * the libfabric provider, this is simply a process address. When it runs
+ * as a device model on behalf of another address space, it is whatever the
+ * driver programmed, and only that device model can resolve it.
+ */
+typedef uint64_t uet_dma_addr_t;
+
+/*
+ * One segment of a local buffer, naming a range within a memory region.
+ *
+ * A local buffer is an array of these. Each element carries its own region,
+ * so a single operation can span several regions (the same thing an
+ * ibv_sge[] expresses) where every entry has its own lkey.
+ *
+ * The region a segment names may be contiguous, a scatter/gather list, or a
+ * page list. The segment does not care and neither does anything that walks
+ * one.
+ */
+struct uet_mr_seg {
+	uet_mr_handle_t mr;                   /* region this segment lives in */
+	        /* Address within the region in whichever convention the      */
+	        /* region was registered with. An offset from zero when its   */
+	        /* base_va is 0, otherwise a virtual address.                 */
+	uint64_t addr;
+	size_t len;                                  /* bytes in this segment */
+};
+
+/*
+ * Page buffer list levels, as a device driver builds them after pinning
+ * the pages behind a user VA range.
+ */
+typedef enum {
+	UET_PBL_LEVEL_0 = 0, /* the region's data pages are contiguous */
+	UET_PBL_LEVEL_1,     /* root is a directory of data page addresses */
+	UET_PBL_LEVEL_2,     /* root is a directory of directories */
+} uet_pbl_level_t;
+
 /* event callback functions */
 typedef void (*uet_eq_callback_t)(uet_handle_t handle,
 				  struct fi_eq_entry *eq_entry);
@@ -338,6 +377,46 @@ int uet_mr_reg_job(uet_domain_handle_t domain_handle, const void *buf,
 		   size_t len, uint64_t access, uint64_t requested_key,
 		   uint64_t flags, uint32_t job_id, void *context,
 		   uet_mr_handle_t *mr_handle);
+
+/*
+ * register a memory region described by a page buffer list
+ *
+ * This is the registration a device driver performs: the pages behind a
+ * user VA range have been pinned and enumerated into a page list, and the
+ * region is named by that list rather than by an address in this process.
+ *
+ * Resolving an offset is arithmetic, not a walk, because every page is the
+ * same size. The list is read in place rather than copied, so registration
+ * cost does not grow with the size of the region.
+ *
+ * parms:
+ *   domain_handle - handle identifying uet domain instance
+ *   pbl_root      - level 0: the region's contiguous data pages
+ *                   level 1: a directory of data page addresses
+ *                   level 2: a directory of directories of data page addresses
+ *   page_size     - bytes per page, a power of 2
+ *   level         - page list level, see uet_pbl_level_t
+ *   page_offset   - offset of the region within its first page, which is
+ *                   how an unaligned base VA is expressed. Must be less
+ *                   than page_size.
+ *   base_va       - virtual address the region starts at, which also
+ *                   selects how addresses naming it are interpreted
+ *   len           - length of the region in bytes
+ *   access        - memory access permissions, see fi_mr
+ *   requested_key - requested key for the region
+ *   flags         - properties of the region
+ *   context       - for completion
+ *   mr_handle     - location where the region handle is returned
+ *
+ * returns:
+ *   0 on success,
+ *   negative value corresponding to fabric errno on error
+ */
+int uet_mr_reg_pbl(uet_domain_handle_t domain_handle, uet_dma_addr_t pbl_root,
+		   uint32_t page_size, uet_pbl_level_t level,
+		   uint32_t page_offset, uint64_t base_va, size_t len,
+		   uint64_t access, uint64_t requested_key, uint64_t flags,
+		   void *context, uet_mr_handle_t *mr_handle);
 
 /*
  * get memory region protection key
@@ -783,6 +862,51 @@ int uet_ep_setopt(uet_ep_handle_t ep_handle, int level, int optname,
  *   negative value corresponding to fabric errno on error
  */
 int uet_ep_close(uet_ep_handle_t ep_handle);
+
+/*******************************************************************
+ * uet_progress API family
+ *******************************************************************/
+
+/*
+ * run one progress cycle for every endpoint on a domain
+ *
+ * Ages idle receive messages and receive sync groups, drives receive
+ * packets through the PDS, drives pending transmits, and retries deferred
+ * transmit messages.
+ *
+ * uet_cq_read() performs the same work for the endpoint it is reading, so
+ * an application that polls its completion queues does not need to call
+ * this. It exists for callers that must make progress independently of
+ * completion queue polling. Retransmission timeouts, PDC establishment, and
+ * packet reception all require progress even when no completions are being
+ * read.
+ *
+ * One receive packet is processed per endpoint per call, so a caller acting
+ * as a progress engine should call this repeatedly rather than once.
+ *
+ * parms:
+ *   domain_handle - handle identifying uet domain instance
+ *
+ * returns:
+ *   0 on success,
+ *   negative value corresponding to fabric errno on error
+ */
+int uet_progress(uet_domain_handle_t domain_handle);
+
+/*
+ * run one progress cycle for a single endpoint
+ *
+ * Performs exactly the progress work that uet_cq_read() performs before
+ * reading completions, without reading any.
+ *
+ * parms:
+ *   ep_handle - handle identifying uet endpoint instance
+ *
+ * returns:
+ *   0 on success,
+ *   negative value corresponding to fabric errno on error
+ */
+int uet_ep_progress(uet_ep_handle_t ep_handle);
 
 /*******************************************************************
  * uet_cq API family
@@ -1557,6 +1681,90 @@ ssize_t uet_readv(uet_ep_handle_t ep_handle, uint32_t job_id,
 		  uet_mr_handle_t mr_handle, uet_addr_handle_t uet_addr_handle,
 		  uint64_t remote_mem_addr, uint64_t remote_key,
 		  void *context, uint16_t resource_index);
+#endif
+
+/*******************************************************************
+ * uet_*seg API family
+ *******************************************************************/
+
+/*
+ * Segment-list variants of the send, receive, write and read operations.
+ *
+ * Where the iov forms describe a local buffer with addresses in this
+ * process, these describe it with memory regions: an array of uet_mr_seg
+ * strutures, each naming a range within its own region. That is what an
+ * ibv_sge[] expresses (where every entry carries its own lkey) and it lets
+ * one operation span several regions.
+ *
+ * The regions may be contiguous, scatter/gather lists, or page lists; the
+ * operation does not care.
+ *
+ * parms:
+ *   ep_handle       - handle identifying uet endpoint instance
+ *   job_id          - id of the job
+ *   seg             - array of segments describing the local buffer
+ *   seg_count       - number of segments
+ *   data            - immediate data, or NULL
+ *   dst_addr_handle - handle identifying the peer
+ *   remote_mem_addr - address within the remote region (rma only)
+ *   remote_key      - key of the remote region (rma only)
+ *   context         - for completion
+ *
+ * returns:
+ *   0 on success,
+ *   negative value corresponding to fabric errno on error
+ */
+#if !ENABLE_VERBS
+ssize_t uet_sendseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		    const struct uet_mr_seg *seg, size_t seg_count,
+		    uet_addr_handle_t dst_addr_handle, void *context);
+
+ssize_t uet_sendseg_imm(uet_ep_handle_t ep_handle, uint32_t job_id,
+			const struct uet_mr_seg *seg, size_t seg_count,
+			uint64_t *data, uet_addr_handle_t dst_addr_handle,
+			void *context);
+
+ssize_t uet_recvseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		    const struct uet_mr_seg *seg, size_t seg_count,
+		    uet_addr_handle_t src_addr_handle, void *context);
+
+ssize_t uet_writeseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		     const struct uet_mr_seg *seg, size_t seg_count,
+		     uint64_t *data, uet_addr_handle_t dst_addr_handle,
+		     uint64_t remote_mem_addr, uint64_t remote_key,
+		     void *context);
+
+ssize_t uet_readseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		    const struct uet_mr_seg *seg, size_t seg_count,
+		    uet_addr_handle_t uet_addr_handle,
+		    uint64_t remote_mem_addr, uint64_t remote_key,
+		    void *context);
+#else
+ssize_t uet_sendseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		    const struct uet_mr_seg *seg, size_t seg_count,
+		    uet_addr_handle_t dst_addr_handle, void *context,
+		    uint16_t resource_index);
+
+ssize_t uet_sendseg_imm(uet_ep_handle_t ep_handle, uint32_t job_id,
+			const struct uet_mr_seg *seg, size_t seg_count,
+			uint64_t *data, uet_addr_handle_t dst_addr_handle,
+			void *context, uint16_t resource_index);
+
+ssize_t uet_recvseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		    const struct uet_mr_seg *seg, size_t seg_count,
+		    uet_addr_handle_t src_addr_handle, void *context);
+
+ssize_t uet_writeseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		     const struct uet_mr_seg *seg, size_t seg_count,
+		     uint64_t *data, uet_addr_handle_t dst_addr_handle,
+		     uint64_t remote_mem_addr, uint64_t remote_key,
+		     void *context, uint16_t resource_index);
+
+ssize_t uet_readseg(uet_ep_handle_t ep_handle, uint32_t job_id,
+		    const struct uet_mr_seg *seg, size_t seg_count,
+		    uet_addr_handle_t uet_addr_handle,
+		    uint64_t remote_mem_addr, uint64_t remote_key,
+		    void *context, uint16_t resource_index);
 #endif
 
 /*

--- a/uet_api_private.h
+++ b/uet_api_private.h
@@ -21,8 +21,13 @@
 #ifndef _UET_API_PRIVATE_H_
 #define _UET_API_PRIVATE_H_
 
-#define UET_IOV_LIMIT     8
-#define UET_RMA_IOV_LIMIT 8
+/*
+ * Scatter/gather limits advertised to applications. These bound what an
+ * application may pass to the vector send/recv/rma calls; they do not bound
+ * how a memory region describes itself, which is an attribute of a page list.
+ */
+#define UET_IOV_LIMIT     64
+#define UET_RMA_IOV_LIMIT 64
 #if UET_IOV_LIMIT > UET_RMA_IOV_LIMIT
 	#define UET_IOV_LIMIT_MAX UET_IOV_LIMIT
 #else
@@ -98,8 +103,6 @@
 	fprintf(stdout, "UET_API: %s(): %s:%-4d, ret = %d (%s)\n",    \
 		(CALL), __FILE__, __LINE__, errno, strerror(errno))
 
-typedef uint64_t uet_dma_addr_t;
-
 /* endpoint states */
 typedef enum {
 	UET_EP_DISABLED = 0,
@@ -132,6 +135,9 @@ typedef enum {
 	UET_MR_BUF_TYPE_IOV,
 	UET_MR_BUF_TYPE_REGATTR_IOV,
 	UET_MR_BUF_TYPE_REGATTR_DMABUF,
+	        /* region described by a page buffer list, as a device driver */
+	        /* builds it after pinning the pages behind a user VA range   */
+	UET_MR_BUF_TYPE_PBL,
 } uet_mr_buf_type_t;
 
 /* descriptor for contiguous mr */
@@ -143,15 +149,36 @@ struct uet_mr_desc_contig {
 struct uet_mr_desc_iov {
 	size_t iov_count;                         /* number of entries in iov */
 	const struct iovec *iov;                  /* vector for memory region */
-			     /* array of base dma addresses for memory region */
-	uet_dma_addr_t dma_addr[UET_IOV_LIMIT_MAX];
+};
+
+/*
+ * Page buffer list (PBL) descriptor. The region is a run of uniform pages.
+ * Every page must be the same size so resolving an offset is arithmetic
+ * rather than a walk:
+ *
+ *   abs      = (page_offset + offset)
+ *   page_idx = (abs >> page_shift)
+ *   page_off = (abs & (page_size - 1))
+ *
+ * This is followed by zero, one, or two indirections depending on the level
+ * attribute. The page directories and data pages are named by dma addresses
+ * and are read in place on demand.
+ *
+ * level 0: the region's data pages themselves
+ * level 1: a directory of data page addresses
+ * level 2: a directory of a directory of data page addresses
+ */
+struct uet_mr_desc_pbl {
+	uet_dma_addr_t root;
+	uint32_t page_size;                     /* bytes per page, power of 2 */
+	uint32_t page_offset;       /* offset of the region in its first page */
+	uint8_t page_shift;                   /* log2(page_size), precomputed */
+	uet_pbl_level_t level;
 };
 
 /* descriptor for mr registered with uet_mr_regattr API */
 struct uet_mr_desc_regattr {
 	const struct fi_mr_attr *attr;
-			     /* array of base dma addresses for memory region */
-	uet_dma_addr_t dma_addr[UET_IOV_LIMIT_MAX];
 };
 
 /* memory region buffer descriptor */
@@ -163,6 +190,7 @@ struct uet_mr_buf_desc {
 		struct uet_mr_desc_contig contig;
 		struct uet_mr_desc_iov iov;
 		struct uet_mr_desc_regattr regattr;
+		struct uet_mr_desc_pbl pbl;
 	};
 };
 
@@ -175,6 +203,11 @@ struct uet_mr_desc {
 	uint64_t full_key;                      /* full key for memory region */
 	uint64_t access;            /* operations supported for memory region */
 	uint64_t flags;                        /* properties of memory region */
+	     /* Virtual address the region starts at, which is also what      */
+	     /* selects the addressing convention: 0 means addresses naming   */
+	     /* this region are offsets from zero, anything else means they   */
+	     /* are virtual addresses and this is subtracted from them.       */
+	uint64_t base_va;
 	uint32_t job_id;                 /* JobID the region is restricted to */
 	bool job_restricted;               /* region is restricted to a JobID */
 	bool user_key;            /* key is user-assigned (hash space) vs the */
@@ -205,6 +238,18 @@ struct uet_tag_initiator_key {
 typedef enum {
 	UET_MSG_BUF_TYPE_CONTIG = 0,
 	UET_MSG_BUF_TYPE_IOV,
+	       /* The data lives in the memory region referenced by the       */
+	       /* descriptor's mr_desc, and is reached through uet_mr_scatter */
+	       /* and uet_mr_gather. Used for rma at the target, where the    */
+	       /* region owns its own representation. Contiguous,             */
+	       /* scatter/gather list, or a page list.                        */
+	UET_MSG_BUF_TYPE_MR,
+	       /* The data lives in a list of segments, each naming a range   */
+	       /* within its own memory region (MR), and is reached through   */
+	       /* scatter_flat_to_seg and gather_seg_to_flat. This is how a   */
+	       /* local buffer is described when it is backed by regions      */
+	       /* rather than by addresses.                                   */
+	UET_MSG_BUF_TYPE_SEG,
 } uet_msg_buf_type_t;
 
 /* descriptor for contiguous message buffer */
@@ -216,8 +261,12 @@ struct uet_msg_desc_contig {
 struct uet_msg_desc_iov {
 	size_t iov_count;                         /* number of entries in iov */
 	const struct iovec *iov;                         /* vector for buffer */
-					    /* array of dma addr's for buffer */
-	uet_dma_addr_t dma_addr[UET_IOV_LIMIT_MAX];
+};
+
+/* descriptor for a segment-list message buffer */
+struct uet_msg_desc_seg {
+	size_t seg_count;                               /* number of segments */
+	struct uet_mr_seg *seg;            /* owned copy of the caller's list */
 };
 
 /* message buffer descriptor */
@@ -229,6 +278,7 @@ struct uet_msg_buf_desc {
 	union {
 		struct uet_msg_desc_contig contig;
 		struct uet_msg_desc_iov iov;
+		struct uet_msg_desc_seg seg;
 	};
 };
 
@@ -247,6 +297,13 @@ struct uet_rx_desc {
 #define UET_RX_DESC_FLAG_DSEND		(1 << 6)       /* deferred descriptor */
 #define UET_RX_DESC_FLAG_CANCELLED	(1 << 7)
 #define UET_RX_DESC_FLAG_ERR_TRACK	(1 << 8)
+	   /* buf_desc.iov.iov was allocated for this descriptor and must be  */
+	   /* freed with it. When clear, the vector is borrowed from a memory */
+	   /* region descriptor, which owns it (prevents double free).        */
+#define UET_RX_DESC_FLAG_OWNS_IOV	(1 << 9)
+	   /* buf_desc.seg.seg was allocated for this descriptor and must be  */
+	   /* freed with it                                                   */
+#define UET_RX_DESC_FLAG_OWNS_SEG	(1 << 10)
 	int desc_flags;                          /* flags for this descriptor */
 	uet_ses_rc_t ses_rc;    /* ses return code, for marking errored msg's */
 	struct uet_msg_buf_desc buf_desc;                /* buffer descriptor */
@@ -350,6 +407,13 @@ struct uet_tx_desc {
 #define UET_TX_DESC_FLAG_ATOMIC_FETCH_REQ	(1 << 11)
 #define UET_TX_DESC_FLAG_ATOMIC_COMPARE_REQ	(1 << 12)
 #define UET_TX_DESC_FLAG_SYNC_REQ		(1 << 13)
+	   /* buf_desc.buf was allocated for this descriptor (a read response */
+	   /* gathered out of a scattered memory region) and must be freed    */
+	   /* when the descriptor is recycled.                                */
+#define UET_TX_DESC_FLAG_OWNS_BUF		(1 << 14)
+	   /* buf_desc.seg.seg was allocated for this descriptor and must be  */
+	   /* freed with it                                                   */
+#define UET_TX_DESC_FLAG_OWNS_SEG		(1 << 15)
 	int desc_flags;                          /* flags for this descriptor */
 	struct uet_msg_buf_desc buf_desc;                /* buffer descriptor */
 	uint64_t pkt_cnt;                /* number of pkt tx for this message */
@@ -651,6 +715,10 @@ struct uet_ack_d_info {
 	uint32_t payload_len;                        /* size of data in bytes */
 	uint32_t msg_off;                               /* msg offset of data */
 	void *buf;                                             /* ptr to data */
+	     /* Staging area used when the source memory region is described  */
+	     /* by a scatter/gather list, where no contiguous pointer into    */
+	     /* the region exists. buf points here once the data is gathered. */
+	uint8_t gather_buf[UET_DEFAULT_MAX_PAYLOAD_LEN];
 };
 
 #endif /* _UET_API_PRIVATE_H_ */


### PR DESCRIPTION
- Add uet_mr_reg_pbl(): memory regions described by a page buffer list (levels 0-2), resolved arithmetically and read in place. base_va selects zero-based vs VA addressing (0 = zero-based).
- Enable multi-entry iov regions, previously registerable but rejected by uet_mr_enable().
- Add segment-list operations (uet_sendseg/sendseg_imm/recvseg/ writeseg/readseg) so a local buffer can span multiple regions, one per segment, as an ibv_sge[] does.
- Route all region access through uet_mr_scatter()/uet_mr_gather(), which dispatch on representation (contig/iov/pbl).
- Support atomics on scattered regions via uet_mr_atomic_addr(), enforcing natural alignment, misaligned operands return BAD_ADDR.
- Raise advertised iov limits 8 -> 64 and drop the unused dma_addr[] arrays that pinned them.
- Fix leaks and double-frees: per-op iov_handle leak in the send path, iov leak in uet_mr_regv(), rx-descriptor iov aliasing, type-blind frees in domain/descriptor teardown.
- Test env vars in uet.c: UET_MR_IOV, UET_MR_PBL, UET_MR_PBL_LEVEL, UET_MR_PBL_OFFSET, UET_LOCAL_SEG, UET_LOCAL_SEG_MRS
- Export uet_progress()/uet_ep_progress() so a calling thread can drive the instance without polling completion queues.