### PR TITLE
api: avoid leaking single-buffer receive vectors

### DIFF
--- a/uet_api.c
+++ b/uet_api.c
@@ -5872,15 +5872,21 @@ static ssize_t uet_recv_api_common(
 	/* allocate iov and init */
 	iov_handle = NULL;
 	if (seg == NULL) {
-		iov_handle = calloc(iov_count, sizeof(struct iovec));
-		if (iov_handle == NULL) {
-			UET_API_ERR("Allocation of iov memory failed");
-			return -FI_ENOMEM;
+		/* A single contiguous buffer is recorded directly below.  Only a
+		 * vector needs a private copy that outlives this call.
+		 */
+		if (iov_count > 1) {
+			iov_handle = calloc(iov_count, sizeof(struct iovec));
+			if (iov_handle == NULL) {
+				UET_API_ERR("Allocation of iov memory failed");
+				return -FI_ENOMEM;
+			}
 		}
 
 		for (i = 0; i < iov_count; i++) {
 			msg_len += iov[i].iov_len;
-			iov_handle[i] = iov[i];
+			if (iov_handle != NULL)
+				iov_handle[i] = iov[i];
 		}
 	}
 


### PR DESCRIPTION
## Summary

- allocate a private `iovec` copy only for multi-vector receive requests
- keep the existing direct-buffer representation for a single-element receive
- avoid leaking one allocation for every posted single-buffer receive

## Validation

- `make strict-core`
- `make all`
- ASAN-enabled `ibv_ru_pingpong`, 100 iterations through UPROT and the VPP AF_PACKET datapath on Linux 6.18.39; the previous 500-allocation/8,000-byte report is gone